### PR TITLE
Changed the default JPEG compression level to 0.2

### DIFF
--- a/GiniVision/Classes/GINIMetaInformationManager.swift
+++ b/GiniVision/Classes/GINIMetaInformationManager.swift
@@ -136,7 +136,7 @@ typealias MetaInformation = NSDictionary
 
 /// The JPEG compression level that will be used if nothing else
 /// is specified in imageData(withCompression:)
-let jpegDefaultCompression:CGFloat = 0.2
+let JPEGDefaultCompression:CGFloat = 0.2
 
 internal struct GINIMetaInformationManager {
     
@@ -167,7 +167,7 @@ internal struct GINIMetaInformationManager {
         metaInformation = metaInformation(fromImageData: data)
     }
     
-    func imageData(withCompression compression: CGFloat = jpegDefaultCompression) -> Data? {
+    func imageData(withCompression compression: CGFloat = JPEGDefaultCompression) -> Data? {
         return merge(image, withMetaInformation: metaInformation, andCompression: compression)
     }
     

--- a/GiniVision/Classes/GINIMetaInformationManager.swift
+++ b/GiniVision/Classes/GINIMetaInformationManager.swift
@@ -134,6 +134,10 @@ internal extension NSMutableDictionary {
 
 typealias MetaInformation = NSDictionary
 
+/// The JPEG compression level that will be used if nothing else
+/// is specified in imageData(withCompression:)
+let jpegDefaultCompression:CGFloat = 0.2
+
 internal struct GINIMetaInformationManager {
     
     fileprivate let cfRequiredExifKeys = [
@@ -163,7 +167,7 @@ internal struct GINIMetaInformationManager {
         metaInformation = metaInformation(fromImageData: data)
     }
     
-    func imageData(withCompression compression: CGFloat = 1.0) -> Data? {
+    func imageData(withCompression compression: CGFloat = jpegDefaultCompression) -> Data? {
         return merge(image, withMetaInformation: metaInformation, andCompression: compression)
     }
     


### PR DESCRIPTION
# Information

A bug has been reported that rotated pictures are a lot bigger in file size than the unrotated original.
I've tracked this down to using 1.0 as JPEG compression level (best precision). This is too much and we usually use 0.2. So now the default is 0.2.

# How to test

It's easier to test on the simulator. Use a hardcoded image as input. Note it's file size. Go to the review step and rotate the image. Tap "Next" to start analysing. At this point its useful to save the image before it's sent to the file system. This can be done in `GINIReviewContainerViewController->analyse`:

```swift
try! imageData?.write(to: URL(fileURLWithPath:"/Users/<user>/Documents/libTestimage.jpg"), options: .atomic)
```

Check the saved file's size - it shouldn't be bigger than expected (it highly depends on the compression level of the original, though).

# Merge information

Should be automatic. However, once this pull request is approved, we need to cherry-pick it into master, develop and swift-2.3.