### PR TITLE
Community requests to make some properties publicly accessible

### DIFF
--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		0A4C62AC1D4F535A00A15FFA /* invoice.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 0A4C62AA1D4F535500A15FFA /* invoice.jpg */; };
 		0A5A7D661D2CFA3E0007C98D /* ComponentAPIOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7D651D2CFA3E0007C98D /* ComponentAPIOnboardingViewController.swift */; };
 		0A5DDCA61D9E6A5300EBDDCD /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A5DDCA51D9E6A5300EBDDCD /* Settings.bundle */; };
+		0A6A78A61E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A78A51E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift */; };
+		0A6A78A81E1412E000AEB328 /* GINICameraViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A78A71E1412E000AEB328 /* GINICameraViewControllerTests.swift */; };
 		0A735C371D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A735C361D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift */; };
 		0A82FAD21D59D78300D84632 /* GINIAnalysisUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A82FAD11D59D78300D84632 /* GINIAnalysisUITests.swift */; };
 		0AAE6D481D6B473900EE9EDD /* CancelationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAE6D471D6B473900EE9EDD /* CancelationToken.swift */; };
@@ -67,6 +69,8 @@
 		0A4C62AA1D4F535500A15FFA /* invoice.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = invoice.jpg; sourceTree = "<group>"; };
 		0A5A7D651D2CFA3E0007C98D /* ComponentAPIOnboardingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentAPIOnboardingViewController.swift; sourceTree = "<group>"; };
 		0A5DDCA51D9E6A5300EBDDCD /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		0A6A78A51E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GINIOnboardingViewControllerTests.swift; sourceTree = "<group>"; };
+		0A6A78A71E1412E000AEB328 /* GINICameraViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GINICameraViewControllerTests.swift; sourceTree = "<group>"; };
 		0A735C361D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentAPIAnalysisViewController.swift; sourceTree = "<group>"; };
 		0A82FAD11D59D78300D84632 /* GINIAnalysisUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GINIAnalysisUITests.swift; path = UITests/GINIAnalysisUITests.swift; sourceTree = SOURCE_ROOT; };
 		0AAE6D471D6B473900EE9EDD /* CancelationToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancelationToken.swift; sourceTree = "<group>"; };
@@ -231,6 +235,8 @@
 			isa = PBXGroup;
 			children = (
 				607FACEB1AFB9204008FA782 /* GINIMetaInformationManagerTests.swift */,
+				0A6A78A51E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift */,
+				0A6A78A71E1412E000AEB328 /* GINICameraViewControllerTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -587,6 +593,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A6A78A61E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift in Sources */,
+				0A6A78A81E1412E000AEB328 /* GINICameraViewControllerTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* GINIMetaInformationManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/GiniVision/Base.lproj/Main.storyboard
+++ b/Example/GiniVision/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Q18-fR-y4t">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Q18-fR-y4t">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/Example/Tests/GINICameraViewControllerTests.swift
+++ b/Example/Tests/GINICameraViewControllerTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import GiniVision
+
+class GINICameraViewControllerTests: XCTestCase {
+    
+    var vc = GINICameraViewController(success: { _ in }, failure: { _ in })
+    
+    func testInitialization() {
+        XCTAssertNotNil(vc, "view controller should not be nil")
+    }
+    
+    func testCameraOverlayAccessibility() {
+        XCTAssertNotNil(vc.cameraOverlay, "camera overlay should be accessible and not nil")
+    }
+    
+}
+

--- a/Example/Tests/GINIOnboardingViewControllerTests.swift
+++ b/Example/Tests/GINIOnboardingViewControllerTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import GiniVision
+
+class GINIOnboardingViewControllerTests: XCTestCase {
+    
+    var vc = GINIOnboardingViewController(scrollViewDelegate: nil)
+    
+    func testConvenientInitialization() {
+        XCTAssertNotNil(vc, "view controller should not be nil")
+        XCTAssert(vc.pages == GINIConfiguration.sharedConfiguration.onboardingPages, "default pages should be set")
+    }
+    
+    func testScrollViewAccessibility() {
+        XCTAssertNotNil(vc.scrollView, "scroll view should be accessible and not nil")
+    }
+
+}

--- a/GiniVision/Classes/GINICameraViewController.swift
+++ b/GiniVision/Classes/GINICameraViewController.swift
@@ -52,6 +52,12 @@ public typealias GINICameraErrorBlock = (error: GINICameraError) -> ()
  */
 @objc public final class GINICameraViewController: UIViewController {
     
+    /**
+     Image view used to display a camera overlay like corners or a frame. 
+     Use public methods `showCameraOverlay` and `hideCameraOverlay` to control visibility of overlay.
+     */
+    public var cameraOverlay = UIImageView()
+
     private enum CameraState {
         case Valid, NotValid
     }
@@ -59,7 +65,6 @@ public typealias GINICameraErrorBlock = (error: GINICameraError) -> ()
     // User interface
     private var controlsView  = UIView()
     private var previewView   = GINICameraPreviewView()
-    private var cameraOverlay = UIImageView()
     private var captureButton = UIButton()
     private var focusIndicatorImageView: UIImageView?
     private var defaultImageView: UIImageView?

--- a/GiniVision/Classes/GINIOnboardingViewController.swift
+++ b/GiniVision/Classes/GINIOnboardingViewController.swift
@@ -44,10 +44,19 @@ import UIKit
  */
 @objc public final class GINIOnboardingViewController: UIViewController {
     
+    
+    /**
+     Scroll view used to display different onboarding pages.
+     */
+    public var scrollView = UIScrollView()
+    
+    /**
+     Array of views displayed as pages inside the scroll view.
+     */
+    public var pages = [UIView]()
+
     // User interface
-    private var scrollView  = UIScrollView()
     private var contentView = UIView()
-    private var pages       = [UIView]()
 
     /**
      Designated intitializer for the `GINIOnboardingViewController` which allows to pass a custom set of views which will be displayed in horizontal scroll view.


### PR DESCRIPTION
## Information

To allow a more specific customization of the Gini Vision Library it was requested to make some properties publicly accessible. In this PR `cameraOverlay` (in GINICameraViewController) and `scrollView` (in GINIOnboardingViewController) were made public.

## How to test

Use Unit Tests and/or try to access the properties in the example projects Component API implementation.

## Merge information

Features needs to be merged into `swift-2.3` and `swift3` branch.

## YouTrack Tickets

MOBILE-678, MOBILE-679
Github Issues: #19, #22