### PR TITLE
Added a note in the README about adding Gini's custom podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,17 @@ $ gem install cocoapods
 
 > CocoaPods 1.1.0+ is required to build Gini Vision Library.
 
+
 To integrate Gini Vision Library into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
+source 'https://github.com/gini/gini-podspecs.git'
+source 'https://github.com/CocoaPods/Specs.git'
+
 pod "GiniVision"
 ```
+
+**Note:** You need to add Gini's podspec repository as a source.
 
 Then run the following command:
 


### PR DESCRIPTION
# Introduction

Our installation guide in `README.md` wasn't mentioning  that we use a custom podspec repository. 

# How to test

Open the README, scroll to the Cocoapods section and verify that the text acknowledges that we host our podspec ourselves.

# Merge information

Automatic