### PR TITLE
Adding UUID and rotation to EXIF

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - Bolts/Tasks (1.1.5)
   - Gini-iOS-SDK (0.3.0):
     - Bolts (~> 1.1.0)
-  - GiniVision (3.0.3-beta)
+  - GiniVision (3.0.3)
 
 DEPENDENCIES:
   - Gini-iOS-SDK
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
   Gini-iOS-SDK: a10593870472fb94fc82f6173cd35171d07ca0e3
-  GiniVision: 5f2908290c7bb6622972cf8c8b284c56966d36ef
+  GiniVision: 1edf9dc7c3fe0f6c1fd70ddd68717b77299f9f18
 
 PODFILE CHECKSUM: a87c082243c89b1f7c8c2bdf8399a28021b79b71
 

--- a/GiniVision/Classes/ImageMetaInformationManager.swift
+++ b/GiniVision/Classes/ImageMetaInformationManager.swift
@@ -273,7 +273,7 @@ internal struct ImageMetaInformationManager {
         var comment = "Platform=\(platform),OSVer=\(osVersion),GiniVisionVer=\(giniVisionVersion),\(userCommentUUID)=\(uuid)"
         if let rotationDegrees = rotationDegrees {
             // normalize the rotation to 0-360
-            let rotation = imageRotation() + rotationDegrees
+            let rotation = imageRotationDeltaDegrees() + rotationDegrees
             let rotationNorm = normalizedDegrees(imageRotation: rotation)
             comment += ",\(userCommentRotation)=\(rotationNorm)"
         }
@@ -287,15 +287,15 @@ internal struct ImageMetaInformationManager {
         return existingUUID ?? NSUUID().uuidString
     }
     
-    fileprivate func imageRotation() -> Int {
-        return rotationFromImage() ?? 0
+    fileprivate func imageRotationDeltaDegrees() -> Int {
+        return rotationDeltaFromImage() ?? 0
     }
     
     fileprivate func uuidFromImage() -> String? {
         return self.valueFor(userCommentField: userCommentUUID)
     }
     
-    fileprivate func rotationFromImage() -> Int? {
+    fileprivate func rotationDeltaFromImage() -> Int? {
         return Int(self.valueFor(userCommentField: userCommentRotation) ?? "0")
     }
     

--- a/GiniVision/Classes/ImageMetaInformationManager.swift
+++ b/GiniVision/Classes/ImageMetaInformationManager.swift
@@ -162,6 +162,10 @@ internal struct ImageMetaInformationManager {
     var image: UIImage?
     var metaInformation: MetaInformation?
     
+    // user comment fields
+    let userCommentRotation = "RotDeltaDeg"
+    let userCommentUUID = "UUID"
+    
     init(imageData data: Data) {
         image = UIImage(data: data)
         metaInformation = metaInformation(fromImageData: data)
@@ -176,6 +180,12 @@ internal struct ImageMetaInformationManager {
         information = addDefaultValues(toMetaInformation: information)
         guard let filteredInformation = filterDefaultValues(fromMetaInformation: information) else { return }
         metaInformation = filteredInformation
+    }
+    
+    mutating func rotate(degrees:Int, imageOrientation: UIImageOrientation) {
+        update(imageOrientation: imageOrientation)
+        let information = metaInformation as? NSMutableDictionary
+        information?.set(metaInformation: userComment(rotationDegrees: degrees) as AnyObject?, forKey: kCGImagePropertyExifUserComment as String)
     }
     
     mutating func update(imageOrientation orientation: UIImageOrientation) {
@@ -255,11 +265,49 @@ internal struct ImageMetaInformationManager {
         return nil
     }
     
-    fileprivate func userComment() -> String {
+    fileprivate func userComment(rotationDegrees:Int? = nil) -> String {
         let platform = "iOS"
         let osVersion = UIDevice.current.systemVersion
         let giniVisionVersion = GiniVision.versionString
-        return "Platform=\(platform),OSVer=\(osVersion),GiniVisionVer=\(giniVisionVersion)"
+        let uuid = imageUUID()
+        var comment = "Platform=\(platform),OSVer=\(osVersion),GiniVisionVer=\(giniVisionVersion),\(userCommentUUID)=\(uuid)"
+        if let rotationDegrees = rotationDegrees {
+            // normalize the rotation to 0-360
+            let rotation = imageRotation() + rotationDegrees
+            let rotationNorm = normalizedDegrees(imageRotation: rotation)
+            comment += ",\(userCommentRotation)=\(rotationNorm)"
+        }
+        return comment
+    }
+    
+    fileprivate func imageUUID() -> String {
+        // if it already has one, reuse it - it shouldn't change
+        // if not, generate it
+        let existingUUID = uuidFromImage()
+        return existingUUID ?? NSUUID().uuidString
+    }
+    
+    fileprivate func imageRotation() -> Int {
+        return rotationFromImage() ?? 0
+    }
+    
+    fileprivate func uuidFromImage() -> String? {
+        return self.valueFor(userCommentField: userCommentUUID)
+    }
+    
+    fileprivate func rotationFromImage() -> Int? {
+        return Int(self.valueFor(userCommentField: userCommentRotation) ?? "0")
+    }
+    
+    fileprivate func valueFor(userCommentField:String) -> String? {
+        let exifDict = metaInformation as? NSMutableDictionary
+        let existingUserComment = exifDict?.getMetaInformation(forKey:kCGImagePropertyExifUserComment as String)
+        let components = existingUserComment?.components(separatedBy: ",")
+        let userCommentComponent = components?.filter({ (component) -> Bool in
+            return component.contains(userCommentField)
+        })
+        let equasionComponents = userCommentComponent?.last?.components(separatedBy: "=")
+        return equasionComponents?.last
     }
     
     fileprivate func deviceName() -> String? {
@@ -292,6 +340,14 @@ internal struct ImageMetaInformationManager {
             number = 5
         }
         return number
+    }
+    
+    fileprivate func normalizedDegrees(imageRotation:Int) -> Int {
+        var normalized = imageRotation % 360
+        if imageRotation < 0 {
+            normalized += 360
+        }
+        return normalized
     }
     
 }

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -167,7 +167,7 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
         guard let rotatedImage = rotateImage(imageView.image) else { return }
         imageView.image = rotatedImage
         guard var metaInformationManager = metaInformationManager else { return }
-        metaInformationManager.update(imageOrientation: rotatedImage.imageOrientation)
+        metaInformationManager.rotate(degrees: 90, imageOrientation: rotatedImage.imageOrientation)
         guard let data = metaInformationManager.imageData() else { return }
         successBlock?(data as Data)
     }


### PR DESCRIPTION
# Introduction

In order to better identified identical (only rotated) images in the backend, we are now adding a UUID to the image's EXIF user comment. Also, the rotation angle in degrees should be included. For example:

`UUID=F26AE2F5-4E12-4CD8-A079-0114A11F3C12,RotDeltaDeg=90`

# How to test

Currently, there are no unit tests, unfortunately. You have to either save the image before uploading and view its EXIF data, or get the uploaded image from the backend

# Merge information

Automatic