### PR TITLE
Not being able to set custom titles on buttons

### DIFF
--- a/GiniVision/Classes/AnalysisContainerViewController.swift
+++ b/GiniVision/Classes/AnalysisContainerViewController.swift
@@ -15,7 +15,7 @@ internal class AnalysisContainerViewController: UIViewController, ContainerViewC
     internal var contentController = UIViewController()
     
     // Resources
-    fileprivate let backButtonResources = PreferredResource(image: "navigationAnalysisBack", title: "ginivision.navigationbar.analysis.back", comment: "Button title in the navigation bar for the back button on the analysis screen")
+    fileprivate let backButtonResources = PreferredButtonResource(image: "navigationAnalysisBack", title: "ginivision.navigationbar.analysis.back", comment: "Button title in the navigation bar for the back button on the analysis screen", configEntry: GiniConfiguration.sharedConfiguration.navigationBarAnalysisTitleBackButton)
     
     // Properties
     fileprivate var noticeView: NoticeView?

--- a/GiniVision/Classes/AnalysisContainerViewController.swift
+++ b/GiniVision/Classes/AnalysisContainerViewController.swift
@@ -14,9 +14,6 @@ internal class AnalysisContainerViewController: UIViewController, ContainerViewC
     internal var containerView     = UIView()
     internal var contentController = UIViewController()
     
-    // User interface
-    fileprivate var backButton = UIBarButtonItem()
-    
     // Resources
     fileprivate let backButtonResources = PreferredResource(image: "navigationAnalysisBack", title: "ginivision.navigationbar.analysis.back", comment: "Button title in the navigation bar for the back button on the analysis screen")
     
@@ -36,17 +33,10 @@ internal class AnalysisContainerViewController: UIViewController, ContainerViewC
         view.backgroundColor = GiniConfiguration.sharedConfiguration.backgroundColor
         
         // Configure close button
-        backButton = GiniBarButtonItem(
-            image: backButtonResources.preferredImage,
-            title: backButtonResources.preferredText,
-            style: .plain,
-            target: self,
-            action: #selector(back)
-        )
+        setupLeftNavigationItem(usingResources: backButtonResources, selector: #selector(back))
         
         // Configure view hierachy
         view.addSubview(containerView)
-        navigationItem.setLeftBarButton(backButton, animated: false)
         
         // Add constraints
         addConstraints()

--- a/GiniVision/Classes/AnalysisContainerViewController.swift
+++ b/GiniVision/Classes/AnalysisContainerViewController.swift
@@ -17,10 +17,8 @@ internal class AnalysisContainerViewController: UIViewController, ContainerViewC
     // User interface
     fileprivate var backButton = UIBarButtonItem()
     
-    // Images
-    fileprivate var backButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "navigationAnalysisBack")
-    }
+    // Resources
+    fileprivate let backButtonResources = PreferredResource(image: "navigationAnalysisBack", title: "ginivision.navigationbar.analysis.back", comment: "Button title in the navigation bar for the back button on the analysis screen")
     
     // Properties
     fileprivate var noticeView: NoticeView?
@@ -39,8 +37,8 @@ internal class AnalysisContainerViewController: UIViewController, ContainerViewC
         
         // Configure close button
         backButton = GiniBarButtonItem(
-            image: backButtonImage,
-            title: GiniConfiguration.sharedConfiguration.navigationBarAnalysisTitleBackButton,
+            image: backButtonResources.preferredImage,
+            title: backButtonResources.preferredText,
             style: .plain,
             target: self,
             action: #selector(back)

--- a/GiniVision/Classes/AnalysisViewController.swift
+++ b/GiniVision/Classes/AnalysisViewController.swift
@@ -32,6 +32,8 @@ import UIKit
  
  * `ginivision.navigationbar.analysis.back` (Screen API only.)
  
+  - note: Setting `ginivision.navigationbar.analysis.back` explicitly to the empty string in your localized strings will make `AnalysisViewController` revert to the default iOS back button.
+ 
  **Image resources for this screen**
  
  * `navigationAnalysisBack` (Screen API only.)

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -22,8 +22,8 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
     fileprivate var showHelp: (() -> ())?
     
     // Resources
-    fileprivate let closeButtonResources = PreferredResource(image: "navigationCameraClose", title: "ginivision.navigationbar.camera.close", comment: "Button title in the navigation bar for the close button on the camera screen")
-    fileprivate let helpButtonResources = PreferredResource(image: "navigationCameraHelp", title: "ginivision.navigationbar.camera.help", comment: "Button title in the navigation bar for the help button on the camera screen")
+    fileprivate let closeButtonResources = PreferredButtonResource(image: "navigationCameraClose", title: "ginivision.navigationbar.camera.close", comment: "Button title in the navigation bar for the close button on the camera screen", configEntry: GiniConfiguration.sharedConfiguration.navigationBarCameraTitleCloseButton)
+    fileprivate let helpButtonResources = PreferredButtonResource(image: "navigationCameraHelp", title: "ginivision.navigationbar.camera.help", comment: "Button title in the navigation bar for the help button on the camera screen", configEntry: GiniConfiguration.sharedConfiguration.navigationBarCameraTitleHelpButton)
     
     init() {
         super.init(nibName: nil, bundle: nil)

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -21,13 +21,9 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
     // Properties
     fileprivate var showHelp: (() -> ())?
     
-    // Images
-    fileprivate var closeButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "navigationCameraClose")
-    }
-    fileprivate var helpButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "navigationCameraHelp")
-    }
+    // Resources
+    fileprivate let closeButtonResources = PreferredResource(image: "navigationCameraClose", title: "ginivision.navigationbar.camera.close", comment: "Button title in the navigation bar for the close button on the camera screen")
+    fileprivate let helpButtonResources = PreferredResource(image: "navigationCameraHelp", title: "ginivision.navigationbar.camera.help", comment: "Button title in the navigation bar for the help button on the camera screen")
     
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -59,8 +55,8 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
         
         // Configure close button
         closeButton = GiniBarButtonItem(
-            image: closeButtonImage,
-            title: GiniConfiguration.sharedConfiguration.navigationBarCameraTitleCloseButton,
+            image: closeButtonResources.preferredImage,
+            title: closeButtonResources.preferredText,
             style: .plain,
             target: self,
             action: #selector(close)
@@ -68,8 +64,8 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
         
         // Configure help button
         helpButton = GiniBarButtonItem(
-            image: helpButtonImage,
-            title: GiniConfiguration.sharedConfiguration.navigationBarCameraTitleHelpButton,
+            image: helpButtonResources.preferredImage,
+            title: helpButtonResources.preferredText,
             style: .plain,
             target: self,
             action: #selector(help)

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -121,14 +121,14 @@ import UIKit
      
      - note: Screen API only.
      */
-    public var navigationBarCameraTitleCloseButton = NSLocalizedStringPreferred("ginivision.navigationbar.camera.close", comment: "Button title in the navigation bar for the close button on the camera screen")
+    public var navigationBarCameraTitleCloseButton = ""
     
     /**
      Sets the help button text in the navigation bar on the camera screen.
      
      - note: Screen API only.
      */
-    public var navigationBarCameraTitleHelpButton = NSLocalizedStringPreferred("ginivision.navigationbar.camera.help", comment: "Button title in the navigation bar for the help button on the camera screen")
+    public var navigationBarCameraTitleHelpButton = ""
     
     /**
      Sets the text for the accessibility label of the capture button which allows the user to capture an image of a document.
@@ -182,7 +182,7 @@ import UIKit
      
      - note: Screen API only.
      */
-    public var navigationBarOnboardingTitleContinueButton = NSLocalizedStringPreferred("ginivision.navigationbar.onboarding.continue", comment: "Button title in the navigation bar for the continue button on the onboarding screen")
+    public var navigationBarOnboardingTitleContinueButton = ""
     
     /**
      Sets the color of the page controller's page indicator items.
@@ -274,14 +274,14 @@ import UIKit
      
      - note: Screen API only.
      */
-    public var navigationBarReviewTitleBackButton = NSLocalizedStringPreferred("ginivision.navigationbar.review.back", comment: "Button title in the navigation bar for the back button on the review screen")
+    public var navigationBarReviewTitleBackButton = ""
     
     /**
      Sets the continue button text in the navigation bar on the review screen.
      
      - note: Screen API only.
      */
-    public var navigationBarReviewTitleContinueButton = NSLocalizedStringPreferred("ginivision.navigationbar.review.continue", comment: "Button title in the navigation bar for the continue button on the review screen")
+    public var navigationBarReviewTitleContinueButton = ""
     
     /**
      Sets the text appearing at the top of the review screen which should ask the user if the whole document is in focus and has correct orientation.
@@ -348,7 +348,7 @@ import UIKit
     /** 
      Sets the back button text in the navigation bar on the analysis screen.
      */
-    public var navigationBarAnalysisTitleBackButton = NSLocalizedStringPreferred("ginivision.navigationbar.analysis.back", comment: "Button title in the navigation bar for the back button on the analysis screen")
+    public var navigationBarAnalysisTitleBackButton = ""
     
     /**
      Sets the color of the loading indicator on the analysis screen to the specified color.

--- a/GiniVision/Classes/OnboardingContainerViewController.swift
+++ b/GiniVision/Classes/OnboardingContainerViewController.swift
@@ -31,7 +31,7 @@ internal class OnboardingContainerViewController: UIViewController, ContainerVie
     fileprivate let backgroundAlpha: CGFloat = 0.85
     
     // Resources
-    fileprivate let continueButtonResources = PreferredResource(image: "navigationOnboardingContinue", title: "ginivision.navigationbar.onboarding.continue", comment: "Button title in the navigation bar for the continue button on the onboarding screen")
+    fileprivate let continueButtonResources = PreferredButtonResource(image: "navigationOnboardingContinue", title: "ginivision.navigationbar.onboarding.continue", comment: "Button title in the navigation bar for the continue button on the onboarding screen", configEntry: GiniConfiguration.sharedConfiguration.navigationBarOnboardingTitleContinueButton)
 
     // Output
     fileprivate var completionBlock: OnboardingContainerCompletionBlock?

--- a/GiniVision/Classes/OnboardingContainerViewController.swift
+++ b/GiniVision/Classes/OnboardingContainerViewController.swift
@@ -30,11 +30,9 @@ internal class OnboardingContainerViewController: UIViewController, ContainerVie
     fileprivate var continueButton           = UIBarButtonItem()
     fileprivate let backgroundAlpha: CGFloat = 0.85
     
-    // Images
-    fileprivate var continueButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "navigationOnboardingContinue")
-    }
-    
+    // Resources
+    fileprivate let continueButtonResources = PreferredResource(image: "navigationOnboardingContinue", title: "ginivision.navigationbar.onboarding.continue", comment: "Button title in the navigation bar for the continue button on the onboarding screen")
+
     // Output
     fileprivate var completionBlock: OnboardingContainerCompletionBlock?
     
@@ -64,8 +62,8 @@ internal class OnboardingContainerViewController: UIViewController, ContainerVie
         
         // Configure continue button
         continueButton = GiniBarButtonItem(
-            image: continueButtonImage,
-            title: GiniConfiguration.sharedConfiguration.navigationBarOnboardingTitleContinueButton,
+            image: continueButtonResources.preferredImage,
+            title: continueButtonResources.preferredText,
             style: .plain,
             target: self,
             action: #selector(nextPage)

--- a/GiniVision/Classes/PreferredResource.swift
+++ b/GiniVision/Classes/PreferredResource.swift
@@ -84,3 +84,25 @@ struct PreferredResource {
         return (textSource == .custom && imageSource != .custom)
     }
 }
+
+// MARK Navigation items
+internal extension UIViewController {
+    
+    // Setup the leftNavigationItem property of a UIViewController. It will create an UIBarButtonItem
+    // for it and add it to the navigation bar.
+    // Note that if the preferred title of the resource is the empty string, the leftNavigationItem
+    // will not be set so the default back button is shown
+    func setupLeftNavigationItem(usingResources preferredResources:PreferredResource, selector:Selector) {
+        let buttonText = preferredResources.preferredText
+        if buttonText != nil && !buttonText!.isEmpty {
+            let navButton = GiniBarButtonItem(
+                image: preferredResources.preferredImage,
+                title: buttonText,
+                style: .plain,
+                target: self,
+                action: selector
+            )
+            self.navigationItem.setLeftBarButton(navButton, animated: false)
+        }
+    }
+}

--- a/GiniVision/Classes/PreferredResource.swift
+++ b/GiniVision/Classes/PreferredResource.swift
@@ -1,0 +1,86 @@
+//
+//  PreferredResource.swift
+//  Pods
+//
+//  Created by Nikola Sobadjiev on 16/03/2017.
+//
+//
+
+import UIKit
+
+enum ResourceSource {
+    case unknown
+    case library
+    case custom
+}
+
+/*
+ * PreferredResource typically controls what artwork (image and text) would be used in a UI element
+ * such as a button or a bar button item. Resources in the Gini Vision Library are usually brandable
+ * via UIAppearance, Asset catalogs and localizable strings. For instance, many buttons have a default
+ * image in the library's Asset catalog, but clients are free to add an image with the same image in
+ * their catalog. In this case, the customized image will be used.
+ */
+
+struct PreferredResource {
+    
+    let imageName:String?
+    let text:String?
+    let textComment:String?
+    let appBundle = Bundle.main
+    let libBundle = Bundle(for: GiniVision.self)
+    var imageSource:ResourceSource {
+        if let name = imageName {
+            if UIImage(named: name, in: appBundle, compatibleWith: nil) != nil {
+                return .custom
+            }
+            else if UIImage(named: name, in: libBundle, compatibleWith: nil) != nil {
+                return .library
+            }
+        }
+        return.unknown
+    }
+    
+    var textSource:ResourceSource {
+        if let text = text,
+            let comment = textComment {
+            let textFromMainBundle = NSLocalizedString(text, bundle: appBundle, comment: comment)
+            if textFromMainBundle != text {
+                // text was in the bundle - the resource is custom
+                return .custom
+            }
+            let textFromLibBundle = NSLocalizedString(text, bundle: libBundle, comment: comment)
+            if textFromLibBundle != text {
+                return .library
+            }
+        }
+        return .unknown
+    }
+
+    init(image:String?, title:String?, comment:String?) {
+        imageName = image
+        text = title
+        textComment = comment
+    }
+
+    var preferredImage:UIImage? {
+        if !shouldIgnoreImage && imageName != nil {
+            return UIImageNamedPreferred(named: imageName!)
+        }
+        return nil
+    }
+    
+    var preferredText:String? {
+        if let text = text,
+            let comment = textComment {
+            return NSLocalizedStringPreferred(text, comment: comment)
+        }
+        return ""
+    }
+    
+    // if a custom text is supplied to the control, but the image is left to the default one
+    // (or not set at all), the image property needs to be ignored so that the text is shown instead
+    private var shouldIgnoreImage:Bool {
+        return (textSource == .custom && imageSource != .custom)
+    }
+}

--- a/GiniVision/Classes/ReviewContainerViewController.swift
+++ b/GiniVision/Classes/ReviewContainerViewController.swift
@@ -15,7 +15,6 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
     internal var contentController = UIViewController()
     
     // User interface
-    fileprivate var backButton     = UIBarButtonItem()
     fileprivate var continueButton = UIBarButtonItem()
 
     // Resources
@@ -48,13 +47,7 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
         view.backgroundColor = GiniConfiguration.sharedConfiguration.backgroundColor
         
         // Configure back button
-        backButton = GiniBarButtonItem(
-            image: backButtonResources.preferredImage,
-            title: backButtonResources.preferredText,
-            style: .plain,
-            target: self,
-            action: #selector(back)
-        )
+        setupLeftNavigationItem(usingResources: backButtonResources, selector:#selector(back))
         
         // Configure continue button
         continueButton = GiniBarButtonItem(
@@ -67,7 +60,7 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
         
         // Configure view hierachy
         view.addSubview(containerView)
-        navigationItem.setLeftBarButton(backButton, animated: false)
+        
         navigationItem.setRightBarButton(continueButton, animated: false)
         
         // Add constraints

--- a/GiniVision/Classes/ReviewContainerViewController.swift
+++ b/GiniVision/Classes/ReviewContainerViewController.swift
@@ -18,13 +18,10 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
     fileprivate var backButton     = UIBarButtonItem()
     fileprivate var continueButton = UIBarButtonItem()
 
-    // Images
-    fileprivate var backButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "navigationReviewBack")
-    }
-    fileprivate var continueButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "navigationReviewContinue")
-    }
+    // Resources
+    fileprivate let continueButtonResources = PreferredResource(image: "navigationReviewContinue", title: "ginivision.navigationbar.review.continue", comment: "Button title in the navigation bar for the continue button on the review screen")
+    
+    fileprivate let backButtonResources = PreferredResource(image: "navigationReviewBack", title: "ginivision.navigationbar.review.back", comment: "Button title in the navigation bar for the back button on the review screen")
     
     // Output
     fileprivate var imageData: Data?
@@ -52,8 +49,8 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
         
         // Configure back button
         backButton = GiniBarButtonItem(
-            image: backButtonImage,
-            title: GiniConfiguration.sharedConfiguration.navigationBarReviewTitleBackButton,
+            image: backButtonResources.preferredImage,
+            title: backButtonResources.preferredText,
             style: .plain,
             target: self,
             action: #selector(back)
@@ -61,8 +58,8 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
         
         // Configure continue button
         continueButton = GiniBarButtonItem(
-            image: continueButtonImage,
-            title: GiniConfiguration.sharedConfiguration.navigationBarReviewTitleContinueButton,
+            image: continueButtonResources.preferredImage,
+            title: continueButtonResources.preferredText,
             style: .plain,
             target: self,
             action: #selector(analyse)

--- a/GiniVision/Classes/ReviewContainerViewController.swift
+++ b/GiniVision/Classes/ReviewContainerViewController.swift
@@ -18,9 +18,9 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
     fileprivate var continueButton = UIBarButtonItem()
 
     // Resources
-    fileprivate let continueButtonResources = PreferredResource(image: "navigationReviewContinue", title: "ginivision.navigationbar.review.continue", comment: "Button title in the navigation bar for the continue button on the review screen")
+    fileprivate let continueButtonResources = PreferredButtonResource(image: "navigationReviewContinue", title: "ginivision.navigationbar.review.continue", comment: "Button title in the navigation bar for the continue button on the review screen", configEntry: GiniConfiguration.sharedConfiguration.navigationBarReviewTitleContinueButton)
     
-    fileprivate let backButtonResources = PreferredResource(image: "navigationReviewBack", title: "ginivision.navigationbar.review.back", comment: "Button title in the navigation bar for the back button on the review screen")
+    fileprivate let backButtonResources = PreferredButtonResource(image: "navigationReviewBack", title: "ginivision.navigationbar.review.back", comment: "Button title in the navigation bar for the back button on the review screen", configEntry: GiniConfiguration.sharedConfiguration.navigationBarReviewTitleBackButton)
     
     // Output
     fileprivate var imageData: Data?

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -63,8 +63,10 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
     fileprivate var imageViewTrailingConstraint: NSLayoutConstraint!
     fileprivate var metaInformationManager: ImageMetaInformationManager?
     
-    // Resources
-    fileprivate let rotateButtonResources = PreferredResource(image: "reviewRotateButton", title: "ginivision.review.rotateButton", comment: "Title for rotate button in review screen will be used exclusively for accessibility label")
+    // Images
+    fileprivate var rotateButtonImage: UIImage? {
+        return UIImageNamedPreferred(named: "reviewRotateButton")
+    }
     
     // Output
     fileprivate var successBlock: ReviewSuccessBlock?
@@ -108,9 +110,9 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
         bottomView.backgroundColor = GiniConfiguration.sharedConfiguration.reviewBottomViewBackgroundColor.withAlphaComponent(0.8)
         
         // Configure rotate button
-        rotateButton.setImage(rotateButtonResources.preferredImage, for: .normal)
+        rotateButton.setImage(rotateButtonImage, for: .normal)
         rotateButton.addTarget(self, action: #selector(rotate), for: .touchUpInside)
-        rotateButton.accessibilityLabel = rotateButtonResources.preferredText
+        rotateButton.accessibilityLabel = GiniConfiguration.sharedConfiguration.reviewRotateButtonTitle
         
         // Configure bottom label
         bottomLabel.text = GiniConfiguration.sharedConfiguration.reviewTextBottom

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -61,10 +61,8 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
     fileprivate var imageViewTrailingConstraint: NSLayoutConstraint!
     fileprivate var metaInformationManager: ImageMetaInformationManager?
     
-    // Images
-    fileprivate var rotateButtonImage: UIImage? {
-        return UIImageNamedPreferred(named: "reviewRotateButton")
-    }
+    // Resources
+    fileprivate let rotateButtonResources = PreferredResource(image: "reviewRotateButton", title: "ginivision.review.rotateButton", comment: "Title for rotate button in review screen will be used exclusively for accessibility label")
     
     // Output
     fileprivate var successBlock: ReviewSuccessBlock?
@@ -108,9 +106,9 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
         bottomView.backgroundColor = GiniConfiguration.sharedConfiguration.reviewBottomViewBackgroundColor.withAlphaComponent(0.8)
         
         // Configure rotate button
-        rotateButton.setImage(rotateButtonImage, for: .normal)
+        rotateButton.setImage(rotateButtonResources.preferredImage, for: .normal)
         rotateButton.addTarget(self, action: #selector(rotate), for: .touchUpInside)
-        rotateButton.accessibilityLabel = GiniConfiguration.sharedConfiguration.reviewRotateButtonTitle
+        rotateButton.accessibilityLabel = rotateButtonResources.preferredText
         
         // Configure bottom label
         bottomLabel.text = GiniConfiguration.sharedConfiguration.reviewTextBottom

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -34,6 +34,8 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
  * `ginivision.review.rotateButton`
  * `ginivision.review.bottom`
  
+ - note: Setting `ginivision.navigationbar.review.back` explicitly to the empty string in your localized strings will make `ReviewViewController` revert to the default iOS back button.
+ 
  **Image resources for this screen**
  
  * `reviewRotateButton`


### PR DESCRIPTION
# Introduction

This pull request tackles two problems:
* On customisable buttons, it is impossible to override the default image with a custom text
* On customisable navigation buttons, it is impossible to revert to the default iOS back button (an arrow to the left and a title "Back" or the title of the previous screen).

The problem was that client could override images and titles by providing resources with the same name in their project's asset catalog and `Localizable.strings`, respectively. However, if they supplied a custom text, it would still be overridden by setting the default image, since images take precedence to titles in UIKit. 

# How to test

Pick a button from the documentation that is subject to customisation (for instance the back button in the review screen). Add an entry to the `Localizable.strings` or your client or example project with the key used for that button. Run the app and verify that the new text is shown and not the default image.

To test the second part of the fix, set the key to the empty string. Run the app and verify that the default iOS back button is shown (in the review screen example, it you just say "Back", or "Zurück" with german localisation).

# Merge information

Automatic
