### PR TITLE
Example app saves images

### DIFF
--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		0AE3571C1D196CEB006785EE /* ComponentAPIReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE3571B1D196CEB006785EE /* ComponentAPIReviewViewController.swift */; };
 		0AEACE0A1D6385F700052120 /* AnalysisManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEACE091D6385F700052120 /* AnalysisManager.swift */; };
 		0AFE00C41D130C7E00E4425C /* ComponentAPICameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFE00C31D130C7E00E4425C /* ComponentAPICameraViewController.swift */; };
+		23FB66AD1E8188D70030D227 /* FileUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FB66AC1E8188D70030D227 /* FileUtil.swift */; };
 		2C6F599D8B27A6A37706D1EA /* Pods_GiniVision_UITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C02ECA63474B5ED5FCF96CEA /* Pods_GiniVision_UITests.framework */; };
 		37975173A4FFCC2734442225 /* Pods_GiniVision_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E30FF133638A1E33E023726 /* Pods_GiniVision_Example.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -85,6 +86,7 @@
 		0E30FF133638A1E33E023726 /* Pods_GiniVision_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GiniVision_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		156A507DBF7F781FDA55A5E2 /* Pods-GiniVision_UITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiniVision_UITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GiniVision_UITests/Pods-GiniVision_UITests.debug.xcconfig"; sourceTree = "<group>"; };
 		20C11219DD668F0EB599E7EC /* Pods-GiniVision_Example.in house.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiniVision_Example.in house.xcconfig"; path = "Pods/Target Support Files/Pods-GiniVision_Example/Pods-GiniVision_Example.in house.xcconfig"; sourceTree = "<group>"; };
+		23FB66AC1E8188D70030D227 /* FileUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileUtil.swift; sourceTree = "<group>"; };
 		28FA9DC48A643D78D00DB131 /* Pods-GiniVision_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiniVision_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GiniVision_Tests/Pods-GiniVision_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		3AFCE27BDC0098A311CCFB18 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* GiniVision_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiniVision_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -211,6 +213,7 @@
 				0AE3571B1D196CEB006785EE /* ComponentAPIReviewViewController.swift */,
 				0A735C361D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift */,
 				0A5A7D651D2CFA3E0007C98D /* ComponentAPIOnboardingViewController.swift */,
+				23FB66AC1E8188D70030D227 /* FileUtil.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -582,6 +585,7 @@
 				0AE3571C1D196CEB006785EE /* ComponentAPIReviewViewController.swift in Sources */,
 				0A735C371D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift in Sources */,
 				0AEACE0A1D6385F700052120 /* AnalysisManager.swift in Sources */,
+				23FB66AD1E8188D70030D227 /* FileUtil.swift in Sources */,
 				0AB97AFF1D646BA40024C266 /* Constants.m in Sources */,
 				607FACD81AFB9204008FA782 /* ScreenAPIViewController.swift in Sources */,
 				0AAE6D481D6B473900EE9EDD /* CancelationToken.swift in Sources */,

--- a/Example/GiniVision/ComponentAPIAnalysisViewController.swift
+++ b/Example/GiniVision/ComponentAPIAnalysisViewController.swift
@@ -32,6 +32,8 @@ class ComponentAPIAnalysisViewController: UIViewController {
         
         errorButton.alpha = 0.0
         
+        FileUtil.saveJpegImage(data: imageData, withSuffix: "for_analysis")
+        
         /***************************************************************************
          * ANALYSIS SCREEN OF THE COMPONENT API OF THE GINI VISION LIBRARY FOR IOS *
          ***************************************************************************/

--- a/Example/GiniVision/ComponentAPIReviewViewController.swift
+++ b/Example/GiniVision/ComponentAPIReviewViewController.swift
@@ -32,6 +32,8 @@ class ComponentAPIReviewViewController: UIViewController {
         
         originalData = imageData
         
+        FileUtil.saveJpegImage(data: imageData, withSuffix: "for_review")
+        
         // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
         // to have results in as early as possible.
         AnalysisManager.sharedManager.analyzeDocument(withImageData: imageData, cancelationToken: CancelationToken(), completion: nil)

--- a/Example/GiniVision/FileUtil.swift
+++ b/Example/GiniVision/FileUtil.swift
@@ -1,0 +1,49 @@
+//
+//  FileUtil.swift
+//  GiniVision
+//
+//  Created by Alpár Szotyori on 21/03/2017.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+class FileUtil {
+    
+    static func saveJpegImage(data imageData: Data, withSuffix suffix: String) {
+        let documentDir = documentDirURL()
+        guard let _ = documentDir else { return }
+        
+        let filePath = uniqueFile(withSuffix: suffix, relativeTo: documentDir!)
+        guard let _ = filePath else { return }
+        
+        write(data: imageData, to: filePath!)
+    }
+    
+    private static func documentDirURL() -> URL? {
+        let fileManager = FileManager.default
+        let documentsDir: URL?
+        do {
+            documentsDir = try fileManager.url(for: FileManager.SearchPathDirectory.documentDirectory, in: FileManager.SearchPathDomainMask.userDomainMask, appropriateFor: nil, create: true)
+        } catch let error as NSError {
+            print("Error getting document dir path: \(error.description)")
+            documentsDir = nil
+        }
+        return documentsDir
+    }
+    
+    private static func uniqueFile(withSuffix suffix: String, relativeTo:URL) -> URL? {
+        let fileName = "\(Date().timeIntervalSince1970)_\(suffix).jpeg"
+        return URL(string: fileName, relativeTo: relativeTo)
+    }
+
+    private static func write(data:Data, to path: URL) {
+        do {
+            try data.write(to: path)
+            print("Image written to \(path.absoluteString)");
+        } catch let error as NSError {
+            print("Error writing image: \(error.description)")
+        }
+    }
+    
+}

--- a/Example/GiniVision/FileUtil.swift
+++ b/Example/GiniVision/FileUtil.swift
@@ -11,16 +11,16 @@ import Foundation
 class FileUtil {
     
     static func saveJpegImage(data imageData: Data, withSuffix suffix: String) {
-        let documentDir = documentDirURL()
-        guard let _ = documentDir else { return }
+        let documentsDir = documentsDirURL()
+        guard let _ = documentsDir else { return }
         
-        let filePath = uniqueFile(withSuffix: suffix, relativeTo: documentDir!)
+        let filePath = uniqueFile(withSuffix: suffix, relativeTo: documentsDir!)
         guard let _ = filePath else { return }
         
         write(data: imageData, to: filePath!)
     }
     
-    private static func documentDirURL() -> URL? {
+    private static func documentsDirURL() -> URL? {
         let fileManager = FileManager.default
         let documentsDir: URL?
         do {

--- a/Example/GiniVision/Info.plist
+++ b/Example/GiniVision/Info.plist
@@ -40,6 +40,9 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>Um Dokumente mit deinem Gerät zu scannen, erlaube den Zugriff auf deine Kamera.  📸 -&gt; 📄 -&gt; 🎉</string>
+	<string>Um Dokumente mit deinem Gerät zu scannen, erlaube den Zugriff auf deine Kamera.
+📸 -&gt; 📄 -&gt; 🎉</string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>

--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -172,12 +172,16 @@ extension ScreenAPIViewController: GiniVisionDelegate {
     func didCapture(_ imageData: Data) {
         print("Screen API received image data")
         
+        FileUtil.saveJpegImage(data: imageData, withSuffix: "for_review")
+        
         // Analyze image data right away with the Gini SDK for iOS to have results in as early as possible.
         analyzeDocument(withImageData: imageData)
     }
     
     func didReview(_ imageData: Data, withChanges changes: Bool) {
         print("Screen API received updated image data with \(changes ? "changes" : "no changes")")
+        
+        FileUtil.saveJpegImage(data: imageData, withSuffix: "for_analysis")
         
         // Analyze reviewed data because changes were made by the user during review.
         if changes {


### PR DESCRIPTION
Sometimes it is useful to get the images that are taken and manipulated by the library (for checking EXIF tags for ex.).

Created a `FileUtil` class which saves `Data` types to a unique file suffixed by a provided string and with the `jpeg` extension. Timestamp is used for uniqueness. It also logs the file path. File name ex.:  `1490114874.42508_for_review.jpeg`

Both Screen API and Component API examples save the original image shown in the Review Screen with the `for_review` suffix and the image shown in the Analysis Screen with the `for_analysis` suffix.

### How to test
Run the example app and take pictures and analyse them with Screen API and Component API. Watch the log to see that the images are saved.

Using iTunes download the images from the device.

### Merge
Automatic