### PR TITLE
Bugfix image compression

### DIFF
--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -99,6 +99,7 @@ class ScreenAPIViewController: UIViewController {
         
         cancelAnalsyis()
         imageData = data
+        print("Analysing document with size \(Double(data.count) / 1024.0)")
         AnalysisManager.sharedManager.analyzeDocument(withImageData: data, cancelationToken: CancelationToken(), completion: { inner in
             do {
                 guard let response = try inner?(),

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - Bolts/Tasks (1.1.5)
   - Gini-iOS-SDK (0.3.2):
     - Bolts (~> 1.1.0)
-  - GiniVision (3.0.3)
+  - GiniVision (3.0.4)
 
 DEPENDENCIES:
   - Gini-iOS-SDK
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
   Gini-iOS-SDK: eb35141d81af9f4fcb1a8937ba42c626e5b378c9
-  GiniVision: 1edf9dc7c3fe0f6c1fd70ddd68717b77299f9f18
+  GiniVision: ce978fd3047e3f557f1b0ec1e30a0d6e078282bc
 
 PODFILE CHECKSUM: a87c082243c89b1f7c8c2bdf8399a28021b79b71
 

--- a/Example/Tests/GINIMetaInformationManagerTests.swift
+++ b/Example/Tests/GINIMetaInformationManagerTests.swift
@@ -13,7 +13,7 @@ class ImageMetaInformationManagerTests: XCTestCase {
     }
     
     func testInitialization() {
-        XCTAssertNotNil(manager.image, "image should not be nil")
+        XCTAssertNotNil(manager.imageData, "image should not be nil")
         XCTAssertNotNil(manager.metaInformation, "meta information should not be nil")
     }
     
@@ -39,14 +39,14 @@ class ImageMetaInformationManagerTests: XCTestCase {
     }
     
     func testFilteringAndSettingRequiredFields() {
-        var mutableManager = manager
+        let mutableManager = manager
         mutableManager.filterMetaInformation()
         guard let filteredData = mutableManager.imageData() else {
             return XCTFail("filtered image data should not be nil")
         }
         
         let filteredManager = ImageMetaInformationManager(imageData: filteredData)
-        XCTAssertNotNil(filteredManager.image, "image should not be nil")
+        XCTAssertNotNil(filteredManager.imageData, "image should not be nil")
         XCTAssertNotNil(filteredManager.metaInformation, "meta information should not be nil")
         guard let mutableInformation = filteredManager.metaInformation?.mutableCopy() as? NSMutableDictionary else {
             return XCTFail("failed to retrieve mutable meta information from filtered image data")

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -241,7 +241,7 @@ public typealias CameraErrorBlock = (_ error: CameraError) -> ()
             if GiniConfiguration.DEBUG {
                 // Retrieve image from default image view to make sure image was set and therefor the correct states were checked before.
                 if let image = self.defaultImageView?.image,
-                   let imageData = UIImageJPEGRepresentation(image, 1) {
+                   let imageData = UIImageJPEGRepresentation(image, 0.2) {
                     self.successBlock?(imageData)
                 }
             }
@@ -252,9 +252,9 @@ public typealias CameraErrorBlock = (_ error: CameraError) -> ()
                 var imageData = try inner()
                 
                 // Set meta information in image
-                var manager = ImageMetaInformationManager(imageData: imageData)
+                let manager = ImageMetaInformationManager(imageData: imageData)
                 manager.filterMetaInformation()
-                if let richImageData = manager.imageData(withCompression: 0.2) {
+                if let richImageData = manager.imageData() {
                     imageData = richImageData
                 }
                 

--- a/GiniVision/Classes/ImageMetaInformationManager.swift
+++ b/GiniVision/Classes/ImageMetaInformationManager.swift
@@ -237,10 +237,7 @@ internal class ImageMetaInformationManager {
         let source = CGImageSourceCreateWithData(image as CFData, nil)
         information.setValue(compression, forKey: kCGImageDestinationLossyCompressionQuality as String)
         
-        let count = CGImageSourceGetCount(source!)
-        for _ in 0...count - 1 {
-            CGImageDestinationAddImageFromSource(destination, source!, 0, information as CFDictionary)
-        }
+        CGImageDestinationAddImageFromSource(destination, source!, 0, information as CFDictionary)
         CGImageDestinationFinalize(destination)
         return targetData as Data
     }

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -168,7 +168,7 @@ public typealias ReviewErrorBlock = (_ error: ReviewError) -> ()
     @objc fileprivate func rotate(_ sender: AnyObject) {
         guard let rotatedImage = rotateImage(imageView.image) else { return }
         imageView.image = rotatedImage
-        guard var metaInformationManager = metaInformationManager else { return }
+        guard let metaInformationManager = metaInformationManager else { return }
         metaInformationManager.rotate(degrees: 90, imageOrientation: rotatedImage.imageOrientation)
         guard let data = metaInformationManager.imageData() else { return }
         successBlock?(data as Data)


### PR DESCRIPTION
# Information

We saw that there was not much change in the uploaded image's quality and size even after changing the JPEG compression level. We debugged that to the `ImageMetainformationManager`. When it was generating compressed images and injecting the EXIF data, there were two conversions between `UIImage` and `NSData`. After the first one, the compression level was lost. This resulted in images with the wrong compression level and it was also wasting processing time.

The fix was to switch to Core Image and compress and annotate the image with EXIF data all in one pass.

# How to test

Start debugging the example app and look at the console logs while uploading the images. The total size in KB should be printed just before the upload starts. To try different compression levels, change the `JPEGDefaultCompression` variable in `ImageMetainformationManager `

# Merge information

Automatic