### PR TITLE
Uncouple image meta information manager from views

### DIFF
--- a/Example/Tests/GINIMetaInformationManagerTests.swift
+++ b/Example/Tests/GINIMetaInformationManagerTests.swift
@@ -40,8 +40,7 @@ class ImageMetaInformationManagerTests: XCTestCase {
     
     func testFilteringAndSettingRequiredFields() {
         let mutableManager = manager
-        mutableManager.filterMetaInformation()
-        guard let filteredData = mutableManager.addMetaInformationToImage() else {
+        guard let filteredData = mutableManager.imageByAddingMetadata()else {
             return XCTFail("filtered image data should not be nil")
         }
         

--- a/Example/Tests/GINIMetaInformationManagerTests.swift
+++ b/Example/Tests/GINIMetaInformationManagerTests.swift
@@ -41,7 +41,7 @@ class ImageMetaInformationManagerTests: XCTestCase {
     func testFilteringAndSettingRequiredFields() {
         let mutableManager = manager
         mutableManager.filterMetaInformation()
-        guard let filteredData = mutableManager.imageData() else {
+        guard let filteredData = mutableManager.addMetaInformationToImage() else {
             return XCTFail("filtered image data should not be nil")
         }
         

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -322,15 +322,8 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
         }
         camera.captureStillImage { inner in
             do {
-                var imageData = try inner()
-                
-                // Set meta information in image
-                let manager = ImageMetaInformationManager(imageData: imageData, deviceOrientation: UIApplication.shared.statusBarOrientation)
-                manager.filterMetaInformation()
-                if let richImageData = manager.imageData() {
-                    imageData = richImageData
-                }
-                let imageDocument = GiniImageDocument(data: imageData)
+                let imageData = try inner()
+                let imageDocument = GiniImageDocument(data: imageData, deviceOrientation: UIApplication.shared.statusBarOrientation)
                 
                 // Call success block
                 self.successBlock?(imageDocument, false)

--- a/GiniVision/Classes/GiniImageDocument.swift
+++ b/GiniVision/Classes/GiniImageDocument.swift
@@ -17,16 +17,23 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     public var data:Data
     public var previewImage: UIImage?
     
+    fileprivate let metaInformationManager:ImageMetaInformationManager
+    
     /**
      Initializes a GiniImageDocument.
      
      - Parameter data: PDF data
+     - Parameter deviceOrientation: Device orientation when a picture was taken from the camera. In other cases it should be `nil`
      
      */
     
-    public init(data: Data) {
-        self.data = data
+    public init(data: Data, deviceOrientation:UIInterfaceOrientation? = nil) {
         self.previewImage = UIImage(data: data)
+        self.metaInformationManager = ImageMetaInformationManager(imageData: data, deviceOrientation:deviceOrientation)
+        self.metaInformationManager.filterMetaInformation()
+        
+        // Add meta information to image document data
+        self.data = metaInformationManager.imageData() ?? data
     }
     
     /**
@@ -44,6 +51,12 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
         } else {
             throw DocumentValidationError.fileFormatNotValid
         }
+    }
+    
+    func rotateImage(degrees:Int, imageOrientation:UIImageOrientation) {
+        metaInformationManager.rotate(degrees: 90, imageOrientation: imageOrientation)
+        guard let data = metaInformationManager.imageData() else { return }
+        self.data = data
     }
 }
 

--- a/GiniVision/Classes/GiniImageDocument.swift
+++ b/GiniVision/Classes/GiniImageDocument.swift
@@ -33,7 +33,7 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
         self.metaInformationManager.filterMetaInformation()
         
         // Add meta information to image document data
-        self.data = metaInformationManager.imageData() ?? data
+        self.data = metaInformationManager.addMetaInformationToImage() ?? data
     }
     
     /**
@@ -55,7 +55,7 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     
     func rotateImage(degrees:Int, imageOrientation:UIImageOrientation) {
         metaInformationManager.rotate(degrees: 90, imageOrientation: imageOrientation)
-        guard let data = metaInformationManager.imageData() else { return }
+        guard let data = metaInformationManager.addMetaInformationToImage() else { return }
         self.data = data
     }
 }

--- a/GiniVision/Classes/GiniImageDocument.swift
+++ b/GiniVision/Classes/GiniImageDocument.swift
@@ -30,10 +30,13 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     public init(data: Data, deviceOrientation:UIInterfaceOrientation? = nil) {
         self.previewImage = UIImage(data: data)
         self.metaInformationManager = ImageMetaInformationManager(imageData: data, deviceOrientation:deviceOrientation)
-        self.metaInformationManager.filterMetaInformation()
         
-        // Add meta information to image document data
-        self.data = metaInformationManager.addMetaInformationToImage() ?? data
+        if let dataWithMetadata = metaInformationManager.imageByAddingMetadata() {
+            self.data = dataWithMetadata
+        } else {
+            self.data = data
+            assertionFailure("It wasn't possible to add metadata to the image")
+        }
     }
     
     /**
@@ -55,7 +58,10 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     
     func rotateImage(degrees:Int, imageOrientation:UIImageOrientation) {
         metaInformationManager.rotate(degrees: 90, imageOrientation: imageOrientation)
-        guard let data = metaInformationManager.addMetaInformationToImage() else { return }
+        guard let data = metaInformationManager.imageByAddingMetadata() else {
+            assertionFailure("It wasn't possible to add metadata to the image")
+            return
+        }
         self.data = data
         self.previewImage = UIImage(data: data)
     }

--- a/GiniVision/Classes/GiniImageDocument.swift
+++ b/GiniVision/Classes/GiniImageDocument.swift
@@ -57,6 +57,7 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
         metaInformationManager.rotate(degrees: 90, imageOrientation: imageOrientation)
         guard let data = metaInformationManager.addMetaInformationToImage() else { return }
         self.data = data
+        self.previewImage = UIImage(data: data)
     }
 }
 

--- a/GiniVision/Classes/GiniVisionDocument.swift
+++ b/GiniVision/Classes/GiniVisionDocument.swift
@@ -28,6 +28,7 @@ import Foundation
 public class GiniVisionDocumentBuilder {
     
     let data:Data?
+    var deviceOrientation:UIInterfaceOrientation?
     
     /**
      Initializes a `GiniVisionDocumentBuilder` with a Data object
@@ -51,7 +52,7 @@ public class GiniVisionDocumentBuilder {
             if data.isPDF {
                 return GiniPDFDocument(data: data)
             } else if data.isImage {
-                return GiniImageDocument(data: data)
+                return GiniImageDocument(data: data, deviceOrientation: deviceOrientation)
             }
         }
         return nil

--- a/GiniVision/Classes/GiniVisionDocument.swift
+++ b/GiniVision/Classes/GiniVisionDocument.swift
@@ -13,7 +13,6 @@ import Foundation
     var data:Data { get }
     var previewImage:UIImage? { get }
     
-    init(data:Data)
     func checkType() throws
 }
 

--- a/GiniVision/Classes/ImageMetaInformationManager.swift
+++ b/GiniVision/Classes/ImageMetaInformationManager.swift
@@ -57,41 +57,36 @@ internal class ImageMetaInformationManager {
     init(imageData data: Data, deviceOrientation:UIInterfaceOrientation? = nil) {
         imageData = data
         metaInformation = metaInformation(fromImageData: data)
-        
+
         // If the image has the DeviceOrientation, it should not be added again
         // because current device orientation could be different.
         // deviceOrientation must be always nil except when the picture has just been taken.
         deviceOrientationOnCapture = value(forUserCommentField: userCommentDeviceOrientation)
         
-        guard let _ = deviceOrientationOnCapture else {
-            if let deviceOrientation = deviceOrientation {
-                deviceOrientationOnCapture = deviceOrientation.isLandscape ? "landscape" : "portrait"
-            }
-            return
+        if let deviceOrientation = deviceOrientation, deviceOrientationOnCapture == nil {
+            deviceOrientationOnCapture = deviceOrientation.isLandscape ? "landscape" : "portrait"
         }
+        
+        filterMetaInformation()
     }
     
     // Returns the current image but with all meta information added
-    func addMetaInformationToImage(withCompression compression: CGFloat = JPEGDefaultCompression) -> Data? {
-        guard let image = imageData else { return nil }
-        guard let information = metaInformation else { return nil }
+    func imageByAddingMetadata(withCompression compression: CGFloat = JPEGDefaultCompression) -> Data? {
+        guard let image = imageData, let information = metaInformation else { return nil }
         
         let targetData = NSMutableData()
-        
-        let destination = CGImageDestinationCreateWithData(targetData, kUTTypeJPEG, 1, nil)!
+        let destination = CGImageDestinationCreateWithData(targetData, kUTTypeJPEG, 1, nil)
         let source = CGImageSourceCreateWithData(image as CFData, nil)
         information.setValue(compression, forKey: kCGImageDestinationLossyCompressionQuality as String)
         
-        CGImageDestinationAddImageFromSource(destination, source!, 0, information as CFDictionary)
-        CGImageDestinationFinalize(destination)
-        return targetData as Data
-    }
-    
-    func filterMetaInformation() {
-        var information = metaInformation ?? MetaInformation()
-        information = addDefaultValues(toMetaInformation: information)
-        guard let filteredInformation = filterDefaultValues(fromMetaInformation: information) else { return }
-        metaInformation = filteredInformation
+        if let destination = destination, let source = source {
+            CGImageDestinationAddImageFromSource(destination, source, 0, information as CFDictionary)
+            CGImageDestinationFinalize(destination)
+            
+            return targetData as Data
+        }
+        
+        return nil
     }
     
     func rotate(degrees:Int, imageOrientation: UIImageOrientation) {
@@ -104,6 +99,13 @@ internal class ImageMetaInformationManager {
         var information = metaInformation ?? MetaInformation()
         information = update(getExifOrientationFromUIImageOrientation(orientation), onMetaInformation: information)
         metaInformation = information
+    }
+    
+    fileprivate func filterMetaInformation() {
+        var information = metaInformation ?? MetaInformation()
+        information = addDefaultValues(toMetaInformation: information)
+        guard let filteredInformation = filterDefaultValues(fromMetaInformation: information) else { return }
+        metaInformation = filteredInformation
     }
     
     fileprivate func update(_ orientation: Int, onMetaInformation information: MetaInformation) -> MetaInformation {

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -76,7 +76,6 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> ()
     fileprivate var imageViewLeadingConstraint: NSLayoutConstraint!
     fileprivate var imageViewTopConstraint: NSLayoutConstraint!
     fileprivate var imageViewTrailingConstraint: NSLayoutConstraint!
-    fileprivate var metaInformationManager: ImageMetaInformationManager?
     fileprivate var currentDocument:GiniVisionDocument?
     
     // Images
@@ -107,11 +106,6 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> ()
         
         // Initialize currentDocument
         currentDocument = document
-        
-        // Set meta information manager
-        if document.type == .Image {
-            metaInformationManager = ImageMetaInformationManager(imageData: document.data)
-        }
         
         // Configure scroll view
         scrollView.delegate = self
@@ -228,11 +222,12 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> ()
     // MARK: Rotation handling
     @objc fileprivate func rotate(_ sender: AnyObject) {
         guard let rotatedImage = rotateImage(imageView.image) else { return }
+        guard let imageDocument = currentDocument as? GiniImageDocument else { return }
+        
         imageView.image = rotatedImage
-        guard let metaInformationManager = metaInformationManager else { return }
-        metaInformationManager.rotate(degrees: 90, imageOrientation: rotatedImage.imageOrientation)
-        guard let data = metaInformationManager.imageData() else { return }
-        successBlock?(GiniImageDocument(data: data), false)
+        imageDocument.rotateImage(degrees: 90, imageOrientation: rotatedImage.imageOrientation)
+        
+        successBlock?(imageDocument, false)
     }
     
     fileprivate func rotateImage(_ image: UIImage?) -> UIImage? {


### PR DESCRIPTION
`ImageMetaInformationManager` is coupled to the views and they should not know anything about the manager.

### How to test
Take a picture or import an image an see that all meta information is added to it. Also rotate the picture and check that `RotDeltaDeg` has changed.

### Merging
Automatic.

### Ticket 
Issue #58  
