### PR TITLE
Remove document validation on review screen

### DIFF
--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		1F5F53321F5DB2E300D4BF06 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		1F8547641F56E44700B1CAC6 /* GiniVisionDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8547631F56E44700B1CAC6 /* GiniVisionDocumentTests.swift */; };
 		1FD55CBE1F66BF9000A1F9C7 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */; };
+		1FE3AC851F729205004D75E0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE3AC841F729205004D75E0 /* Extensions.swift */; };
 		1FEED28D1F6ABEA40068E8AB /* testPDF-rotated90.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED2891F6ABEA40068E8AB /* testPDF-rotated90.pdf */; };
 		1FEED28E1F6ABEA40068E8AB /* testPDF-rotated270.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED28A1F6ABEA40068E8AB /* testPDF-rotated270.pdf */; };
 		1FEED28F1F6ABEA40068E8AB /* testPDF-rotated180.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED28B1F6ABEA40068E8AB /* testPDF-rotated180.pdf */; };
@@ -96,6 +97,7 @@
 		1F2A7D331F6F9F910028C127 /* testPDF2Pages.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = testPDF2Pages.pdf; sourceTree = "<group>"; };
 		1F8547631F56E44700B1CAC6 /* GiniVisionDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiniVisionDocumentTests.swift; sourceTree = "<group>"; };
 		1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		1FE3AC841F729205004D75E0 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		1FEED2891F6ABEA40068E8AB /* testPDF-rotated90.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated90.pdf"; sourceTree = "<group>"; };
 		1FEED28A1F6ABEA40068E8AB /* testPDF-rotated270.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated270.pdf"; sourceTree = "<group>"; };
 		1FEED28B1F6ABEA40068E8AB /* testPDF-rotated180.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated180.pdf"; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				0AB97AFE1D646BA40024C266 /* Constants.m */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				0AAE6D471D6B473900EE9EDD /* CancelationToken.swift */,
+				1FE3AC841F729205004D75E0 /* Extensions.swift */,
 				0AEACE091D6385F700052120 /* AnalysisManager.swift */,
 				0AAE6D491D6B6BC500EE9EDD /* NoResultViewController.swift */,
 				0AAE6D4B1D6B6C0B00EE9EDD /* ResultTableViewController.swift */,
@@ -637,6 +640,7 @@
 				607FACD81AFB9204008FA782 /* ScreenAPIViewController.swift in Sources */,
 				0AAE6D481D6B473900EE9EDD /* CancelationToken.swift in Sources */,
 				0A5A7D661D2CFA3E0007C98D /* ComponentAPIOnboardingViewController.swift in Sources */,
+				1FE3AC851F729205004D75E0 /* Extensions.swift in Sources */,
 				0AFE00C41D130C7E00E4425C /* ComponentAPICameraViewController.swift in Sources */,
 				0AAE6D4A1D6B6BC500EE9EDD /* NoResultViewController.swift in Sources */,
 				0AAE6D4C1D6B6C0B00EE9EDD /* ResultTableViewController.swift in Sources */,

--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		2C6F599D8B27A6A37706D1EA /* Pods_GiniVision_UITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C02ECA63474B5ED5FCF96CEA /* Pods_GiniVision_UITests.framework */; };
 		37975173A4FFCC2734442225 /* Pods_GiniVision_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E30FF133638A1E33E023726 /* Pods_GiniVision_Example.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
-		607FACD81AFB9204008FA782 /* ScreenAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ScreenAPIViewController.swift */; };
+		607FACD81AFB9204008FA782 /* SelectAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* SelectAPIViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
@@ -109,7 +109,7 @@
 		607FACD01AFB9204008FA782 /* GiniVision_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiniVision_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		607FACD71AFB9204008FA782 /* ScreenAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenAPIViewController.swift; sourceTree = "<group>"; };
+		607FACD71AFB9204008FA782 /* SelectAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAPIViewController.swift; sourceTree = "<group>"; };
 		607FACDA1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
@@ -226,7 +226,7 @@
 				0AEACE091D6385F700052120 /* AnalysisManager.swift */,
 				0AAE6D491D6B6BC500EE9EDD /* NoResultViewController.swift */,
 				0AAE6D4B1D6B6C0B00EE9EDD /* ResultTableViewController.swift */,
-				607FACD71AFB9204008FA782 /* ScreenAPIViewController.swift */,
+				607FACD71AFB9204008FA782 /* SelectAPIViewController.swift */,
 				0AFE00C31D130C7E00E4425C /* ComponentAPICameraViewController.swift */,
 				0AE3571B1D196CEB006785EE /* ComponentAPIReviewViewController.swift */,
 				0A735C361D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift */,
@@ -637,7 +637,7 @@
 				0A735C371D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift in Sources */,
 				0AEACE0A1D6385F700052120 /* AnalysisManager.swift in Sources */,
 				0AB97AFF1D646BA40024C266 /* Constants.m in Sources */,
-				607FACD81AFB9204008FA782 /* ScreenAPIViewController.swift in Sources */,
+				607FACD81AFB9204008FA782 /* SelectAPIViewController.swift in Sources */,
 				0AAE6D481D6B473900EE9EDD /* CancelationToken.swift in Sources */,
 				0A5A7D661D2CFA3E0007C98D /* ComponentAPIOnboardingViewController.swift in Sources */,
 				1FE3AC851F729205004D75E0 /* Extensions.swift in Sources */,

--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1F8547641F56E44700B1CAC6 /* GiniVisionDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8547631F56E44700B1CAC6 /* GiniVisionDocumentTests.swift */; };
 		1FD55CBE1F66BF9000A1F9C7 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */; };
 		1FE3AC851F729205004D75E0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE3AC841F729205004D75E0 /* Extensions.swift */; };
+		1FEEADA91F793F84005BA159 /* ComponentAPICoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEEADA81F793F84005BA159 /* ComponentAPICoordinator.swift */; };
 		1FEED28D1F6ABEA40068E8AB /* testPDF-rotated90.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED2891F6ABEA40068E8AB /* testPDF-rotated90.pdf */; };
 		1FEED28E1F6ABEA40068E8AB /* testPDF-rotated270.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED28A1F6ABEA40068E8AB /* testPDF-rotated270.pdf */; };
 		1FEED28F1F6ABEA40068E8AB /* testPDF-rotated180.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED28B1F6ABEA40068E8AB /* testPDF-rotated180.pdf */; };
@@ -98,6 +99,7 @@
 		1F8547631F56E44700B1CAC6 /* GiniVisionDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiniVisionDocumentTests.swift; sourceTree = "<group>"; };
 		1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		1FE3AC841F729205004D75E0 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		1FEEADA81F793F84005BA159 /* ComponentAPICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentAPICoordinator.swift; sourceTree = "<group>"; };
 		1FEED2891F6ABEA40068E8AB /* testPDF-rotated90.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated90.pdf"; sourceTree = "<group>"; };
 		1FEED28A1F6ABEA40068E8AB /* testPDF-rotated270.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated270.pdf"; sourceTree = "<group>"; };
 		1FEED28B1F6ABEA40068E8AB /* testPDF-rotated180.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated180.pdf"; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				0AAE6D491D6B6BC500EE9EDD /* NoResultViewController.swift */,
 				0AAE6D4B1D6B6C0B00EE9EDD /* ResultTableViewController.swift */,
 				607FACD71AFB9204008FA782 /* SelectAPIViewController.swift */,
+				1FEEADA81F793F84005BA159 /* ComponentAPICoordinator.swift */,
 				0AFE00C31D130C7E00E4425C /* ComponentAPICameraViewController.swift */,
 				0AE3571B1D196CEB006785EE /* ComponentAPIReviewViewController.swift */,
 				0A735C361D3948E7000444A7 /* ComponentAPIAnalysisViewController.swift */,
@@ -644,6 +647,7 @@
 				0AFE00C41D130C7E00E4425C /* ComponentAPICameraViewController.swift in Sources */,
 				0AAE6D4A1D6B6BC500EE9EDD /* NoResultViewController.swift in Sources */,
 				0AAE6D4C1D6B6C0B00EE9EDD /* ResultTableViewController.swift in Sources */,
+				1FEEADA91F793F84005BA159 /* ComponentAPICoordinator.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/GiniVision/AppDelegate.swift
+++ b/Example/GiniVision/AppDelegate.swift
@@ -41,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         // This is only a shortcut for demo purposes since if the current root view controller is not
         // the ScreenAPIViewController (a GiniVisionDelegate), it won't do anything.
-        guard let navVC = window?.rootViewController as? UINavigationController, let screenAPIVC = navVC.viewControllers.first as? ScreenAPIViewController else {
+        guard let navVC = window?.rootViewController as? UINavigationController, let selectAPIVC = navVC.viewControllers.first as? SelectAPIViewController else {
             return false
         }
         
@@ -58,16 +58,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         do {
             try document?.validate()
             
-            // 4. Create alert which allows user to open imported file either with ScreenAPI or ComponentAPI
+            // 4. Create an alert which allow users to open imported file either with the ScreenAPI or the ComponentAPI
             alertViewController = UIAlertController(title: "Importierte Datei", message: "Möchten Sie die importierte Datei mit dem ScreenAPI oder ComponentAPI verwenden?", preferredStyle: .alert)
             
             alertViewController.addAction(UIAlertAction(title: "Screen API", style: .default) { _ in
-                screenAPIVC.present(screenAPIVC.giniScreenAPI(withImportedDocument: document), animated: true, completion: nil)
+                selectAPIVC.present(selectAPIVC.giniScreenAPI(withImportedDocument: document), animated: true, completion: nil)
             })
             
             alertViewController.addAction(UIAlertAction(title: "Component API", style: .default) { _ in
-                if let componentAPI = screenAPIVC.giniComponentAPI(withImportedDocument: document) {
-                    screenAPIVC.present(componentAPI, animated: true, completion: nil)
+                if let componentAPI = selectAPIVC.giniComponentAPI(withImportedDocument: document) {
+                    selectAPIVC.present(componentAPI, animated: true, completion: nil)
                 }
             })
         } catch {
@@ -79,7 +79,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         // 5. Present alert
-        screenAPIVC.present(alertViewController, animated: true, completion: nil)
+        selectAPIVC.present(alertViewController, animated: true, completion: nil)
         
         return true
     }

--- a/Example/GiniVision/AppDelegate.swift
+++ b/Example/GiniVision/AppDelegate.swift
@@ -66,9 +66,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             })
             
             alertViewController.addAction(UIAlertAction(title: "Component API", style: .default) { _ in
-                if let componentAPI = selectAPIVC.giniComponentAPI(withImportedDocument: document) {
-                    selectAPIVC.present(componentAPI, animated: true, completion: nil)
-                }
+//                if let componentAPI = selectAPIVC.giniComponentAPI(withImportedDocument: document) {
+//                    selectAPIVC.present(componentAPI, animated: true, completion: nil)
+//                }
+                let componentAPICoordinator = ComponentAPICoordinator(document: document)
+                componentAPICoordinator.start(from: selectAPIVC)
             })
         } catch {
             // 4.1. Create alert which shows an error pointing out that it is not a valid document

--- a/Example/GiniVision/AppDelegate.swift
+++ b/Example/GiniVision/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         self.giniSDK = builder?.build()
         
         print("Gini Vision Library for iOS (\(GiniVision.versionString)) / Client id: \(clientId)")
-        
+
         return true
     }
     

--- a/Example/GiniVision/AppDelegate.swift
+++ b/Example/GiniVision/AppDelegate.swift
@@ -66,9 +66,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             })
             
             alertViewController.addAction(UIAlertAction(title: "Component API", style: .default) { _ in
-//                if let componentAPI = selectAPIVC.giniComponentAPI(withImportedDocument: document) {
-//                    selectAPIVC.present(componentAPI, animated: true, completion: nil)
-//                }
                 let componentAPICoordinator = ComponentAPICoordinator(document: document)
                 componentAPICoordinator.start(from: selectAPIVC)
             })

--- a/Example/GiniVision/Base.lproj/Main.storyboard
+++ b/Example/GiniVision/Base.lproj/Main.storyboard
@@ -178,7 +178,7 @@
         <!--API Selection-->
         <scene sceneID="Cmn-ER-b8i">
             <objects>
-                <viewController id="Ggv-ZP-h5h" userLabel="API Selection" customClass="ScreenAPIViewController" customModule="GiniVision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Ggv-ZP-h5h" userLabel="API Selection" customClass="SelectAPIViewController" customModule="GiniVision_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="a3q-Yk-YSo"/>
                         <viewControllerLayoutGuide type="bottom" id="Z9y-Oh-GoV"/>

--- a/Example/GiniVision/Base.lproj/Main.storyboard
+++ b/Example/GiniVision/Base.lproj/Main.storyboard
@@ -120,6 +120,7 @@
                     <connections>
                         <outlet property="containerView" destination="NO8-lz-gzK" id="ekj-pK-WL7"/>
                         <segue destination="bpn-9B-40f" kind="show" identifier="showReview" id="Idu-Pb-0ha"/>
+                        <segue destination="ej4-eT-XJQ" kind="show" identifier="showAnalysisFromCamera" id="0G8-Vw-j63"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ewg-dP-sNc" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -172,7 +173,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w4V-do-qjJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="5447" y="-255"/>
+            <point key="canvasLocation" x="5471" y="83"/>
         </scene>
         <!--API Selection-->
         <scene sceneID="Cmn-ER-b8i">
@@ -277,6 +278,7 @@
                 <tabBarController storyboardIdentifier="ComponentAPI" automaticallyAdjustsScrollViewInsets="NO" id="e8r-Qt-I6L" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" translucent="NO" id="yHo-i0-MdR">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -387,7 +389,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nY8-xm-izW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6148" y="-255"/>
+            <point key="canvasLocation" x="6174" y="-454"/>
         </scene>
         <!--Result Table View Controller-->
         <scene sceneID="dA0-59-wBc">
@@ -584,4 +586,7 @@
         <image name="tabBarIconHelp" width="12" height="25"/>
         <image name="tabBarIconNewDocument" width="29" height="25"/>
     </resources>
+    <inferredMetricsTieBreakers>
+        <segue reference="0G8-Vw-j63"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/Example/GiniVision/Base.lproj/Main.storyboard
+++ b/Example/GiniVision/Base.lproj/Main.storyboard
@@ -326,7 +326,7 @@
         <!--ComponentAPI Analysis View Controller-->
         <scene sceneID="Jdr-6S-YsN">
             <objects>
-                <viewController automaticallyAdjustsScrollViewInsets="NO" id="ej4-eT-XJQ" customClass="ComponentAPIAnalysisViewController" customModule="GiniVision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ComponentAPIAnalysis" automaticallyAdjustsScrollViewInsets="NO" id="ej4-eT-XJQ" customClass="ComponentAPIAnalysisViewController" customModule="GiniVision_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Mvi-1p-ikx"/>
                         <viewControllerLayoutGuide type="bottom" id="b2S-iE-aI1"/>
@@ -587,6 +587,6 @@
         <image name="tabBarIconNewDocument" width="29" height="25"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="0G8-Vw-j63"/>
+        <segue reference="b8t-LI-ByW"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Example/GiniVision/Base.lproj/Main.storyboard
+++ b/Example/GiniVision/Base.lproj/Main.storyboard
@@ -70,17 +70,17 @@
         <!--Component API-->
         <scene sceneID="ZuU-uX-Wsc">
             <objects>
-                <viewController id="pYU-Ln-Vjq" customClass="ComponentAPICameraViewController" customModule="GiniVision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ComponentAPICamera" id="pYU-Ln-Vjq" customClass="ComponentAPICameraViewController" customModule="GiniVision_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="hDk-Fp-Wsr"/>
                         <viewControllerLayoutGuide type="bottom" id="4f2-WH-Mos"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ph2-oy-6hw">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xiy-Qn-t95">
-                                <rect key="frame" x="0.0" y="578" width="375" height="40"/>
+                                <rect key="frame" x="0.0" y="627" width="375" height="40"/>
                                 <color key="backgroundColor" red="0.4549019608" green="0.81960784310000001" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="GLv-47-mFs"/>
@@ -119,8 +119,6 @@
                     <navigationItem key="navigationItem" title="Component API" id="u33-fr-0bj"/>
                     <connections>
                         <outlet property="containerView" destination="NO8-lz-gzK" id="ekj-pK-WL7"/>
-                        <segue destination="bpn-9B-40f" kind="show" identifier="showReview" id="Idu-Pb-0ha"/>
-                        <segue destination="ej4-eT-XJQ" kind="show" identifier="showAnalysisFromCamera" id="0G8-Vw-j63"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ewg-dP-sNc" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -136,11 +134,11 @@
                         <viewControllerLayoutGuide type="bottom" id="jlx-L6-fKV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="q0u-mJ-1aS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uvg-cz-X1a">
-                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                             </containerView>
                         </subviews>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -168,12 +166,11 @@
                     </navigationItem>
                     <connections>
                         <outlet property="containerView" destination="Uvg-cz-X1a" id="Jr1-sh-Ssh"/>
-                        <segue destination="ej4-eT-XJQ" kind="show" identifier="showAnalysis" id="b8t-LI-ByW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="w4V-do-qjJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="5471" y="83"/>
+            <point key="canvasLocation" x="5414" y="-255"/>
         </scene>
         <!--API Selection-->
         <scene sceneID="Cmn-ER-b8i">
@@ -222,7 +219,7 @@
                                     </mask>
                                 </variation>
                                 <connections>
-                                    <segue destination="e8r-Qt-I6L" kind="presentation" id="So6-UQ-l96"/>
+                                    <action selector="launchComponentAPI:" destination="Ggv-ZP-h5h" eventType="touchUpInside" id="iSn-RY-c6E"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version and Client Id" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDA-QI-3LG">
@@ -301,7 +298,7 @@
         <!--New Document-->
         <scene sceneID="eFr-UT-TEA">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="g5Q-Tk-dmU" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="componenAPINavController" automaticallyAdjustsScrollViewInsets="NO" id="g5Q-Tk-dmU" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="New Document" image="tabBarIconNewDocument" id="y5X-0r-qWR"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="wmk-h1-aiy">
@@ -315,9 +312,6 @@
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="pYU-Ln-Vjq" kind="relationship" relationship="rootViewController" id="sa6-GC-q44"/>
-                    </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7G5-7Q-zn4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -332,11 +326,11 @@
                         <viewControllerLayoutGuide type="bottom" id="b2S-iE-aI1"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Qo1-xJ-5g4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tZD-YC-RgH">
-                                <rect key="frame" x="0.0" y="578" width="375" height="40"/>
+                                <rect key="frame" x="0.0" y="627" width="375" height="40"/>
                                 <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="F5p-c6-3LU"/>
@@ -357,7 +351,7 @@
                                 </connections>
                             </button>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dnB-Gz-I2J">
-                                <rect key="frame" x="0.0" y="64" width="375" height="514"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="607"/>
                             </containerView>
                         </subviews>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -389,7 +383,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nY8-xm-izW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6174" y="-454"/>
+            <point key="canvasLocation" x="6218" y="-255"/>
         </scene>
         <!--Result Table View Controller-->
         <scene sceneID="dA0-59-wBc">
@@ -586,7 +580,4 @@
         <image name="tabBarIconHelp" width="12" height="25"/>
         <image name="tabBarIconNewDocument" width="29" height="25"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="b8t-LI-ByW"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/Example/GiniVision/Base.lproj/Main.storyboard
+++ b/Example/GiniVision/Base.lproj/Main.storyboard
@@ -261,8 +261,6 @@
                     <navigationItem key="navigationItem" id="SQK-hk-Ah4"/>
                     <connections>
                         <outlet property="metaInformationLabel" destination="hDA-QI-3LG" id="0eX-ll-pGK"/>
-                        <segue destination="QXp-IJ-1GQ" kind="show" identifier="presentResult" id="25E-8G-1O3"/>
-                        <segue destination="pIn-fG-Rai" kind="show" identifier="presentNoResult" id="xBe-GO-GLS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VQd-cL-q81" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -427,7 +425,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZdL-Oq-NkM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3160" y="-988"/>
+            <point key="canvasLocation" x="6998" y="-255"/>
         </scene>
         <!--Ihre Überweisung-->
         <scene sceneID="hVm-Cc-8N0">
@@ -442,7 +440,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Es konnten keine Daten ausgelesen werden." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dq1-1G-cuV">
-                                <rect key="frame" x="16" y="109" width="343" height="21"/>
+                                <rect key="frame" x="16" y="65" width="343" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="FkV-Ri-EwD"/>
                                 </constraints>
@@ -451,7 +449,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bitte beachten Sie:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dWP-XX-MgH">
-                                <rect key="frame" x="16" y="170" width="343" height="21"/>
+                                <rect key="frame" x="16" y="126" width="343" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="FVY-pT-7qZ"/>
                                 </constraints>
@@ -496,7 +494,7 @@
                                 </variation>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reviewRotateButton" translatesAutoresizingMaskIntoConstraints="NO" id="g01-Yw-KKa">
-                                <rect key="frame" x="175.5" y="284" width="24" height="24"/>
+                                <rect key="frame" x="175.5" y="240" width="24" height="24"/>
                                 <color key="tintColor" red="0.0" green="0.61960784310000006" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="FjC-iT-BH0"/>
@@ -504,7 +502,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WR-c9-tM1">
-                                <rect key="frame" x="37" y="200" width="301" height="84"/>
+                                <rect key="frame" x="37" y="156" width="301" height="84"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="84" id="skS-lc-WKb"/>
                                 </constraints>
@@ -548,7 +546,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0zT-Jd-RrB" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3160" y="-1713"/>
+            <point key="canvasLocation" x="7766" y="-255"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="3be-GW-981">

--- a/Example/GiniVision/ComponentAPIAnalysisViewController.swift
+++ b/Example/GiniVision/ComponentAPIAnalysisViewController.swift
@@ -10,6 +10,13 @@ import UIKit
 import GiniVision
 import Gini_iOS_SDK
 
+protocol ComponentAPIAnalysisScreenDelegate:class {
+    func didCancelAnalysis()
+    func didTapErrorButton()
+    func didAppear()
+    func didDisappear()
+}
+
 /**
  View controller showing how to implement the analysis screen using the Component API of the Gini Vision Library for iOS and
  how to process the previously reviewed image using the Gini SDK for iOS
@@ -20,6 +27,7 @@ class ComponentAPIAnalysisViewController: UIViewController {
      The image data of the captured document to be reviewed.
      */
     var document: GiniVisionDocument?
+    var delegate: ComponentAPIAnalysisScreenDelegate?
     
     @IBOutlet var containerView: UIView!
     var contentController = UIViewController()
@@ -42,60 +50,27 @@ class ComponentAPIAnalysisViewController: UIViewController {
         // 2. Create the analysis view controller
         guard let document = document else { return }
         
-        // In case that the view is loaded but is not analysing (i.e: user imported a PDF with the Open With feature), it should start.
-        if !AnalysisManager.sharedManager.isAnalyzing {
-            AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
-        }
-        
         contentController = AnalysisViewController(document)
         
         // 3. Display the analysis view controller
         displayContent(contentController)
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        guard let navController = navigationController else { return }
-        if isFirstViewController(inNavController: navController) {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Abbrechen", style: .plain, target: self, action: #selector(closeAction))
-        }
-    }
-    
-    func closeAction() {
-        dismiss(animated: true, completion: nil)
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        delegate?.didAppear()
         
-        // Subscribe to analysis events which will be fired when the analysis process ends.
-        // Either with a valid result or an error.
-        NotificationCenter.default.addObserver(self, selector: #selector(handleAnalysis(errorNotification:)), name: NSNotification.Name(rawValue: GINIAnalysisManagerDidReceiveErrorNotification), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(handleAnalysis(resultNotification:)), name: NSNotification.Name(rawValue: GINIAnalysisManagerDidReceiveResultNotification), object: nil)
-        
-        // Because results may come in during view controller transition,
-        // check for already existent results in shared analysis manager.
-        handleExistinResults()
-        
-        // Start loading animation.
         (contentController as? AnalysisViewController)?.showAnimation()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         
-        // Never forget to remove observers when you support iOS versions prior to 9.0.
-        NotificationCenter.default.removeObserver(self)
-    }
-    
-    override func didMove(toParentViewController parent: UIViewController?) {
-        super.didMove(toParentViewController: parent)
-        
-        // Cancel analysis process to avoid unnecessary network calls.
-        if parent == nil {
-            AnalysisManager.sharedManager.cancelAnalysis()
+        if isMovingFromParentViewController || isBeingDismissed {
+            delegate?.didCancelAnalysis()
         }
+        
+        delegate?.didDisappear()
     }
     
     // Displays the content controller inside the container view
@@ -110,80 +85,20 @@ class ComponentAPIAnalysisViewController: UIViewController {
     @IBAction func errorButtonTapped(_ sender: AnyObject) {
         (contentController as? AnalysisViewController)?.showAnimation()
         hideErrorButton()
-        
-        // Retry analysis of the document.
-        guard let document = document else { return }
-        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
+        delegate?.didTapErrorButton()
     }
     
-    // MARK: Handle results from analysis process
-    func handleExistinResults() {
-        if let result = AnalysisManager.sharedManager.result,
-           let document = AnalysisManager.sharedManager.document {
-            handleAnalysis(result, fromDocument: document)
-        } else if let error = AnalysisManager.sharedManager.error {
-            handleAnalysis(error)
-        }
-    }
-    
-    func handleAnalysis(errorNotification notification: Notification) {
-        let error = notification.userInfo?[GINIAnalysisManagerErrorUserInfoKey] as? NSError
-        handleAnalysis(error)
-    }
-    
-    func handleAnalysis(resultNotification notification: Notification) {
-        if let result = notification.userInfo?[GINIAnalysisManagerResultDictionaryUserInfoKey] as? GINIResult,
-           let document = notification.userInfo?[GINIAnalysisManagerDocumentUserInfoKey] as? GINIDocument {
-            handleAnalysis(result, fromDocument: document)
-        } else {
-            handleAnalysis(nil)
-        }
-    }
-    
-    func handleAnalysis(_ error: Error?) {
+    // MARK: Error button handling
+    func displayError(_ error: Error?) {
         if let error = error {
             print(error)
         }
         
-        // For the sake of simplicity we'll always present a generic error which allows the user to retry the analysis.
-        // In a real world application different messages depending on the kind of error might be appropriate.
-        DispatchQueue.main.async { 
-            self.displayError()
+        DispatchQueue.main.async { [weak self] in
+            guard let `self` = self else { return }
+            (self.contentController as? AnalysisViewController)?.hideAnimation()
+            self.showErrorButton()
         }
-    }
-    
-    func handleAnalysis(_ result: GINIResult, fromDocument document: GINIDocument) {
-        let payFive = ["paymentReference", "iban", "bic", "paymentReference", "amountToPay"]
-        let hasPayFive = result.filter { payFive.contains($0.0) }.count > 0
-        
-        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        if hasPayFive {
-            let vc = storyboard.instantiateViewController(withIdentifier: "resultScreen") as! ResultTableViewController
-            vc.result = result
-            vc.document = document
-            self.navigationController?.pushViewController(vc, animated: true)
-        } else {
-            let vc = storyboard.instantiateViewController(withIdentifier: "noResultScreen") as! NoResultViewController
-            self.navigationController?.pushViewController(vc, animated: true)
-        }
-        
-        // Remove analysis screen from navigation stack.
-        if var navigationStack = navigationController?.viewControllers,
-           let index = navigationStack.index(of: self) {
-            navigationStack.remove(at: index)
-            navigationController?.viewControllers = navigationStack
-            if navigationStack.count == 1 {
-                if let resultsScreen = navigationStack.first as? ResultTableViewController {
-                    resultsScreen.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: resultsScreen, action: #selector(resultsScreen.closeAction))
-                }
-            }
-        }
-    }
-    
-    // MARK: Error button handling
-    func displayError() {
-        (contentController as? AnalysisViewController)?.hideAnimation()
-        showErrorButton()
     }
     
     func showErrorButton() {

--- a/Example/GiniVision/ComponentAPIAnalysisViewController.swift
+++ b/Example/GiniVision/ComponentAPIAnalysisViewController.swift
@@ -41,10 +41,29 @@ class ComponentAPIAnalysisViewController: UIViewController {
         
         // 2. Create the analysis view controller
         guard let document = document else { return }
+        
+        // In case that they view is loaded but is not analysing (i.e: user import a PDF with Open With feature), it should start.
+        if !AnalysisManager.sharedManager.isAnalyzing {
+            AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
+        }
+        
         contentController = AnalysisViewController(document)
         
         // 3. Display the analysis view controller
         displayContent(contentController)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard let navController = navigationController else { return }
+        if isFirstViewController(inNavController: navController){
+            navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Abbrechen", style: .plain, target: self, action: #selector(closeAction))
+        }
+    }
+    
+    func closeAction() {
+        dismiss(animated: true, completion: nil)
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/Example/GiniVision/ComponentAPIAnalysisViewController.swift
+++ b/Example/GiniVision/ComponentAPIAnalysisViewController.swift
@@ -42,7 +42,7 @@ class ComponentAPIAnalysisViewController: UIViewController {
         // 2. Create the analysis view controller
         guard let document = document else { return }
         
-        // In case that they view is loaded but is not analysing (i.e: user import a PDF with Open With feature), it should start.
+        // In case that the view is loaded but is not analysing (i.e: user imported a PDF with the Open With feature), it should start.
         if !AnalysisManager.sharedManager.isAnalyzing {
             AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
         }

--- a/Example/GiniVision/ComponentAPIAnalysisViewController.swift
+++ b/Example/GiniVision/ComponentAPIAnalysisViewController.swift
@@ -57,7 +57,7 @@ class ComponentAPIAnalysisViewController: UIViewController {
         super.viewWillAppear(animated)
         
         guard let navController = navigationController else { return }
-        if isFirstViewController(inNavController: navController){
+        if isFirstViewController(inNavController: navController) {
             navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Abbrechen", style: .plain, target: self, action: #selector(closeAction))
         }
     }
@@ -172,6 +172,11 @@ class ComponentAPIAnalysisViewController: UIViewController {
            let index = navigationStack.index(of: self) {
             navigationStack.remove(at: index)
             navigationController?.viewControllers = navigationStack
+            if navigationStack.count == 1 {
+                if let resultsScreen = navigationStack.first as? ResultTableViewController {
+                    resultsScreen.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: resultsScreen, action: #selector(resultsScreen.closeAction))
+                }
+            }
         }
     }
     

--- a/Example/GiniVision/ComponentAPICameraViewController.swift
+++ b/Example/GiniVision/ComponentAPICameraViewController.swift
@@ -9,6 +9,11 @@
 import UIKit
 import GiniVision
 
+protocol ComponentAPICameraScreenDelegate:class {
+    func didPick(document:GiniVisionDocument)
+    func didTapClose()
+}
+
 /**
  View controller showing how to implement the camera using the Component API of the Gini Vision Library for iOS.
  */
@@ -16,28 +21,17 @@ class ComponentAPICameraViewController: UIViewController {
     
     @IBOutlet var containerView: UIView!
     var contentController = UIViewController()
-    
-    var document: GiniVisionDocument?
+    var delegate:ComponentAPICameraScreenDelegate?
     
     // MARK: View life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        /*************************************************************************
-         * CAMERA SCREEN OF THE COMPONENT API OF THE GINI VISION LIBRARY FOR IOS *
-         *************************************************************************/
-        
-        // 1. Create and set a custom configuration object needs to be done once before using any component of the Component API.
-        let giniConfiguration = GiniConfiguration()
-        giniConfiguration.debugModeOn = true
-        GiniVision.setConfiguration(giniConfiguration)
-        
         // 2. Create the camera view controller
         contentController = CameraViewController(successBlock:
             { document, _ in
-                self.document = document
                 DispatchQueue.main.async {
-                    self.goToNextScreen(withDocument: document)
+                    self.delegate?.didPick(document: document)
                 }
         }, failureBlock: { error in
             print("Component API camera view controller received error:\n\(error)")
@@ -69,28 +63,7 @@ class ComponentAPICameraViewController: UIViewController {
     
     // MARK: User actions
     @IBAction func back(_ sender: AnyObject) {
-        dismiss(animated: true, completion: nil)
+        delegate?.didTapClose()
     }
-    
-    // MARK: Navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let document = document {
-            if let vc = segue.destination as? ComponentAPIReviewViewController {
-                vc.document = document
-            } else if let vc = segue.destination as? ComponentAPIAnalysisViewController {
-                vc.document = document
-            }
-            self.document = nil
-        }
-    }
-    
-    fileprivate func goToNextScreen(withDocument document:GiniVisionDocument) {
-        if document.isReviewable {
-            performSegue(withIdentifier: "showReview", sender: nil)
-        } else {
-            performSegue(withIdentifier: "showAnalysisFromCamera", sender: self)
-        }
-    }
-    
 }
 

--- a/Example/GiniVision/ComponentAPICameraViewController.swift
+++ b/Example/GiniVision/ComponentAPICameraViewController.swift
@@ -75,14 +75,10 @@ class ComponentAPICameraViewController: UIViewController {
     // MARK: Navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let document = document {
-            if segue.identifier == "showReview" {
-                if let vc = segue.destination as? ComponentAPIReviewViewController {
-                    vc.document = document
-                }
-            } else if segue.identifier == "showAnalysisFromCamera" {
-                if let vc = segue.destination as? ComponentAPIAnalysisViewController {
-                    vc.document = document
-                }
+            if let vc = segue.destination as? ComponentAPIReviewViewController {
+                vc.document = document
+            } else if let vc = segue.destination as? ComponentAPIAnalysisViewController {
+                vc.document = document
             }
             self.document = nil
         }

--- a/Example/GiniVision/ComponentAPICameraViewController.swift
+++ b/Example/GiniVision/ComponentAPICameraViewController.swift
@@ -89,10 +89,10 @@ class ComponentAPICameraViewController: UIViewController {
     }
     
     fileprivate func goToNextScreen(withDocument document:GiniVisionDocument) {
-        if document.type == .PDF {
-            performSegue(withIdentifier: "showAnalysisFromCamera", sender: self)
-        } else {
+        if document.isReviewable {
             performSegue(withIdentifier: "showReview", sender: nil)
+        } else {
+            performSegue(withIdentifier: "showAnalysisFromCamera", sender: self)
         }
     }
     

--- a/Example/GiniVision/ComponentAPICameraViewController.swift
+++ b/Example/GiniVision/ComponentAPICameraViewController.swift
@@ -50,8 +50,13 @@ class ComponentAPICameraViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if document != nil {
-            performSegue(withIdentifier: "showReview", sender: nil)
+        if let document = document {
+            if document.type == .PDF {
+                performSegue(withIdentifier: "showAnalysisFromCamera", sender: self)
+            } else {
+                performSegue(withIdentifier: "showReview", sender: nil)
+            }
+            AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
         }
         
         navigationController?.setNavigationBarHidden(true, animated: animated)
@@ -78,11 +83,17 @@ class ComponentAPICameraViewController: UIViewController {
     
     // MARK: Navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "showReview" {
-            if let document = document,
-                let vc = segue.destination as? ComponentAPIReviewViewController {
-                vc.document = document
+        if let document = document {
+            if segue.identifier == "showReview" {
+                if let vc = segue.destination as? ComponentAPIReviewViewController {
+                    vc.document = document
+                }
+            } else if segue.identifier == "showAnalysisFromCamera" {
+                if let vc = segue.destination as? ComponentAPIAnalysisViewController {
+                    vc.document = document
+                }
             }
+            self.document = nil
         }
     }
     

--- a/Example/GiniVision/ComponentAPICameraViewController.swift
+++ b/Example/GiniVision/ComponentAPICameraViewController.swift
@@ -37,7 +37,7 @@ class ComponentAPICameraViewController: UIViewController {
             { document, _ in
                 self.document = document
                 DispatchQueue.main.async {
-                    self.performSegue(withIdentifier: "showReview", sender: self)
+                    self.goToNextScreen(withDocument: document)
                 }
         }, failureBlock: { error in
             print("Component API camera view controller received error:\n\(error)")
@@ -51,11 +51,7 @@ class ComponentAPICameraViewController: UIViewController {
         super.viewWillAppear(animated)
         
         if let document = document {
-            if document.type == .PDF {
-                performSegue(withIdentifier: "showAnalysisFromCamera", sender: self)
-            } else {
-                performSegue(withIdentifier: "showReview", sender: nil)
-            }
+            goToNextScreen(withDocument: document)
             AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
         }
         
@@ -95,6 +91,19 @@ class ComponentAPICameraViewController: UIViewController {
             }
             self.document = nil
         }
+    }
+    
+    fileprivate func goToNextScreen(withDocument document:GiniVisionDocument) {
+        if document.type == .PDF {
+            performSegue(withIdentifier: "showAnalysisFromCamera", sender: self)
+        } else {
+            performSegue(withIdentifier: "showReview", sender: nil)
+        }
+        
+        // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
+        // to have results in as early as possible.
+        
+        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
     }
     
 }

--- a/Example/GiniVision/ComponentAPICameraViewController.swift
+++ b/Example/GiniVision/ComponentAPICameraViewController.swift
@@ -50,11 +50,6 @@ class ComponentAPICameraViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if let document = document {
-            goToNextScreen(withDocument: document)
-            AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
-        }
-        
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     
@@ -99,11 +94,6 @@ class ComponentAPICameraViewController: UIViewController {
         } else {
             performSegue(withIdentifier: "showReview", sender: nil)
         }
-        
-        // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
-        // to have results in as early as possible.
-        
-        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
     }
     
 }

--- a/Example/GiniVision/ComponentAPICoordinator.swift
+++ b/Example/GiniVision/ComponentAPICoordinator.swift
@@ -1,0 +1,253 @@
+//
+//  ComponentAPICoordinator.swift
+//  GiniVision_Example
+//
+//  Created by Enrique del Pozo Gómez on 9/25/17.
+//  Copyright © 2017 Gini. All rights reserved.
+//
+
+import Foundation
+import GiniVision
+import Gini_iOS_SDK
+
+final class ComponentAPICoordinator {
+    
+    fileprivate var document:GiniVisionDocument?
+    fileprivate var navigationController: UINavigationController?
+    fileprivate var tabBarController: UITabBarController?
+    fileprivate var analysisScreen: ComponentAPIAnalysisViewController? {
+        return navigationController?.childViewControllers.flatMap { $0 as? ComponentAPIAnalysisViewController }.first
+    }
+    
+    init(document:GiniVisionDocument?){
+        self.document = document
+        
+        // 1. Create and set a custom configuration object needs to be done once before using any component of the Component API.
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.debugModeOn = true
+        GiniVision.setConfiguration(giniConfiguration)
+    }
+    
+    func start(from rootViewController:UIViewController) {
+        if let tabBar = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPI") as? UITabBarController,
+            let navBar = tabBar.viewControllers?.first as? UINavigationController {
+            self.tabBarController = tabBar
+            self.navigationController = navBar
+            if let document = document {
+                if document.isReviewable {
+                    showReviewScreen(withDocument: document)
+                } else {
+                    showAnalysisScreen(withDocument: document)
+                }
+            } else {
+                showCameraScreen()
+            }
+            
+            rootViewController.present(tabBar, animated: true, completion: nil)
+        }
+    }
+    
+    // MARK: Show screens
+    fileprivate func showCameraScreen() {
+        let cameraContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPICamera") as! ComponentAPICameraViewController
+        cameraContainer.delegate = self
+        navigationController?.pushViewController(cameraContainer, animated: true)
+    }
+    
+    fileprivate func showReviewScreen(withDocument document: GiniVisionDocument) {
+        let reviewContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIReview") as! ComponentAPIReviewViewController
+        reviewContainer.delegate = self
+        reviewContainer.document = document
+        addCloseButtonIfNeeded(onViewController: reviewContainer)
+        
+        // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
+        // to have results in as early as possible.
+        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
+        
+        navigationController?.pushViewController(reviewContainer, animated: true)
+    }
+    
+    fileprivate func showAnalysisScreen(withDocument document: GiniVisionDocument) {
+        let analysisContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIAnalysis") as! ComponentAPIAnalysisViewController
+        analysisContainer.delegate = self
+        analysisContainer.document = document
+        addCloseButtonIfNeeded(onViewController: analysisContainer)
+        
+        // In case that the view is loaded but is not analysing (i.e: user imported a PDF with the Open With feature), it should start.
+        if !AnalysisManager.sharedManager.isAnalyzing {
+            AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
+        }
+        
+        navigationController?.pushViewController(analysisContainer, animated: true)
+    }
+    
+    fileprivate func showResultsTableScreen(forDocument document: GINIDocument, withResult result:GINIResult) {
+        let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "resultScreen") as! ResultTableViewController
+        vc.result = result
+        vc.document = document
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    fileprivate func showNoResultsScreen() {
+        let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "noResultScreen") as! NoResultViewController
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
+    // MARK: Other
+    @objc fileprivate func dismissTabBarController() {
+        AnalysisManager.sharedManager.cancelAnalysis()
+        tabBarController?.dismiss(animated: true, completion: nil)
+    }
+    
+    fileprivate func addCloseButtonIfNeeded(onViewController viewController: UIViewController) {
+        if let navBar = navigationController, navBar.viewControllers.isEmpty {
+            viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(dismissTabBarController))
+        }
+    }
+    
+    fileprivate func removeFromStack(_ viewController: UIViewController) {
+        if var navigationStack = navigationController?.viewControllers,
+            let index = navigationStack.index(of: viewController) {
+            navigationStack.remove(at: index)
+            
+            navigationController?.setViewControllers(navigationStack, animated: false)
+        }
+    }
+}
+
+// MARK: ComponentAPICameraScreenDelegate
+
+extension ComponentAPICoordinator: ComponentAPICameraScreenDelegate {
+    func didPick(document: GiniVisionDocument) {
+        if document.isReviewable {
+            showReviewScreen(withDocument: document)
+        } else {
+            showAnalysisScreen(withDocument: document)
+        }
+    }
+    
+    func didTapClose() {
+        dismissTabBarController()
+    }
+}
+
+// MARK: ComponentAPIReviewScreenDelegate
+
+extension ComponentAPICoordinator: ComponentAPIReviewScreenDelegate {
+    
+    func didReview(documentReviewed: GiniVisionDocument) {
+        // Analyze reviewed data because changes were made by the user during review.
+        if documentReviewed.data != document?.data {
+            document = documentReviewed
+            if let documentData = document?.data {
+                AnalysisManager.sharedManager.analyzeDocument(withData: documentData, cancelationToken: CancelationToken(), completion: nil)
+                showAnalysisScreen(withDocument: documentReviewed)
+            }
+            return
+        }
+        
+        // Present already existing results retrieved from the first analysis process initiated in `viewDidLoad`.
+        if let result = AnalysisManager.sharedManager.result,
+            let document = AnalysisManager.sharedManager.document {
+            handleAnalysis(result, fromDocument: document)
+            return
+        }
+        
+        // Restart analysis if it was canceled and is currently not running.
+        if !AnalysisManager.sharedManager.isAnalyzing {
+            if let documentData = document?.data {
+                AnalysisManager.sharedManager.analyzeDocument(withData: documentData, cancelationToken: CancelationToken(), completion: nil)
+            }
+        }
+        
+        // Show analysis screen if no results are in yet and no changes were made.
+        showAnalysisScreen(withDocument: documentReviewed)
+    }
+    
+    func didCancelReview() {
+        AnalysisManager.sharedManager.cancelAnalysis()
+    }
+}
+
+// MARK: ComponentAPIAnalysisScreenDelegate
+
+extension ComponentAPICoordinator: ComponentAPIAnalysisScreenDelegate {
+    func didTapErrorButton() {
+        if let document = document {
+            AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
+        }
+    }
+    
+    func didCancelAnalysis() {
+        AnalysisManager.sharedManager.cancelAnalysis()
+    }
+    
+    func didAppear() {
+        // Subscribe to analysis events which will be fired when the analysis process ends.
+        // Either with a valid result or an error.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAnalysis(errorNotification:)), name: NSNotification.Name(rawValue: GINIAnalysisManagerDidReceiveErrorNotification), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAnalysis(resultNotification:)), name: NSNotification.Name(rawValue: GINIAnalysisManagerDidReceiveResultNotification), object: nil)
+        
+        // Because results may come in during view controller transition,
+        // check for already existent results in shared analysis manager.
+        handleExistinResults()
+    }
+    
+    func didDisappear() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+}
+
+// MARK: Handle analysis results
+
+extension ComponentAPICoordinator {
+    fileprivate func handleAnalysis(_ result: GINIResult, fromDocument document: GINIDocument) {
+        let payFive = ["paymentReference", "iban", "bic", "paymentReference", "amountToPay"]
+        let hasPayFive = result.filter { payFive.contains($0.0) }.count > 0
+        
+        if hasPayFive {
+            showResultsTableScreen(forDocument: document, withResult: result)
+        } else {
+            showNoResultsScreen()
+        }
+        
+        if let analysisScreen = analysisScreen {
+            removeFromStack(analysisScreen)
+        }
+        
+        if navigationController?.viewControllers.count == 2 {
+            if let resultsScreen = (navigationController?.viewControllers.flatMap{ $0 as? ResultTableViewController }.first) {
+                resultsScreen.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(dismissTabBarController))
+            }
+        }
+    }
+    
+    fileprivate func handleExistinResults() {
+        if let result = AnalysisManager.sharedManager.result,
+            let document = AnalysisManager.sharedManager.document {
+            handleAnalysis(result, fromDocument: document)
+        } else if let error = AnalysisManager.sharedManager.error {
+            analysisScreen?.displayError(error)
+        }
+    }
+    
+    @objc fileprivate func handleAnalysis(errorNotification notification: Notification) {
+        let error = notification.userInfo?[GINIAnalysisManagerErrorUserInfoKey] as? NSError
+        analysisScreen?.displayError(error)
+    }
+    
+    @objc fileprivate func handleAnalysis(resultNotification notification: Notification) {
+        if let result = notification.userInfo?[GINIAnalysisManagerResultDictionaryUserInfoKey] as? GINIResult,
+            let document = notification.userInfo?[GINIAnalysisManagerDocumentUserInfoKey] as? GINIDocument {
+            handleAnalysis(result, fromDocument: document)
+        } else {
+            analysisScreen?.displayError(nil)
+        }
+    }
+}
+
+
+
+
+

--- a/Example/GiniVision/ComponentAPICoordinator.swift
+++ b/Example/GiniVision/ComponentAPICoordinator.swift
@@ -18,6 +18,9 @@ final class ComponentAPICoordinator {
     fileprivate var analysisScreen: ComponentAPIAnalysisViewController? {
         return navigationController?.childViewControllers.flatMap { $0 as? ComponentAPIAnalysisViewController }.first
     }
+    fileprivate var resultsScreen: ResultTableViewController? {
+        return navigationController?.childViewControllers.flatMap { $0 as? ResultTableViewController }.first
+    }
     
     init(document:GiniVisionDocument?){
         self.document = document
@@ -90,6 +93,7 @@ final class ComponentAPICoordinator {
     
     fileprivate func showNoResultsScreen() {
         let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "noResultScreen") as! NoResultViewController
+        vc.delegate = self
         navigationController?.pushViewController(vc, animated: true)
     }
     
@@ -199,6 +203,18 @@ extension ComponentAPICoordinator: ComponentAPIAnalysisScreenDelegate {
 
 }
 
+// MARK: NoResultsScreenDelegate
+
+extension ComponentAPICoordinator: NoResultsScreenDelegate {
+    func didTapRetry() {
+        if let navVC = navigationController, navVC.viewControllers.count != 1 {
+            _ = navVC.popToRootViewController(animated: true)
+        } else {
+            dismissTabBarController()
+        }
+    }
+}
+
 // MARK: Handle analysis results
 
 extension ComponentAPICoordinator {
@@ -217,7 +233,7 @@ extension ComponentAPICoordinator {
         }
         
         if navigationController?.viewControllers.count == 2 {
-            if let resultsScreen = (navigationController?.viewControllers.flatMap{ $0 as? ResultTableViewController }.first) {
+            if let resultsScreen = resultsScreen {
                 resultsScreen.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(dismissTabBarController))
             }
         }

--- a/Example/GiniVision/ComponentAPIReviewViewController.swift
+++ b/Example/GiniVision/ComponentAPIReviewViewController.swift
@@ -32,12 +32,7 @@ class ComponentAPIReviewViewController: UIViewController {
         
         guard let document = document else { return }
         originalDocument = document
-        
-        // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
-        // to have results in as early as possible.
-
-        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
-        
+                
         /*************************************************************************
          * REVIEW SCREEN OF THE COMPONENT API OF THE GINI VISION LIBRARY FOR IOS *
          *************************************************************************/
@@ -47,14 +42,11 @@ class ComponentAPIReviewViewController: UIViewController {
         
         // 2. Create the review view controller
         contentController = ReviewViewController(document, successBlock:
-            { [unowned self] (document, shouldFinish) in
+            { [unowned self] document in
                 print("Component API review view controller received image data")
                 // Update current image data when image is rotated by user
                 self.document = document
-                
-                if shouldFinish {
-                    self.showAnalysis(self)
-                }
+
             }, failureBlock: { error in
                 print("Component API review view controller received error:\n\(error)")
             })

--- a/Example/GiniVision/ComponentAPIReviewViewController.swift
+++ b/Example/GiniVision/ComponentAPIReviewViewController.swift
@@ -35,7 +35,6 @@ class ComponentAPIReviewViewController: UIViewController {
         
         // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
         // to have results in as early as possible.
-        
         AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
                 
         /*************************************************************************
@@ -65,7 +64,7 @@ class ComponentAPIReviewViewController: UIViewController {
         super.viewWillAppear(animated)
         
         guard let navController = navigationController else { return }
-        if isFirstViewController(inNavController: navController){
+        if isFirstViewController(inNavController: navController) {
             navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(closeAction))
         }
     }

--- a/Example/GiniVision/ComponentAPIReviewViewController.swift
+++ b/Example/GiniVision/ComponentAPIReviewViewController.swift
@@ -10,6 +10,12 @@ import UIKit
 import GiniVision
 import Gini_iOS_SDK
 
+protocol ComponentAPIReviewScreenDelegate:class {
+    func didReview(documentReviewed:GiniVisionDocument)
+    func didCancelReview()
+}
+
+
 /**
  View controller showing how to implement the review screen using the Component API of the Gini Vision Library for iOS and
  how to process the previously captured image using the Gini SDK for iOS
@@ -18,6 +24,7 @@ class ComponentAPIReviewViewController: UIViewController {
     
     @IBOutlet var containerView: UIView!
     var contentController = UIViewController()
+    var delegate: ComponentAPIReviewScreenDelegate?
     
     /**
      The image data of the captured document to be reviewed.
@@ -33,18 +40,12 @@ class ComponentAPIReviewViewController: UIViewController {
         guard let document = document else { return }
         originalDocument = document
         
-        // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
-        // to have results in as early as possible.
-        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
-                
         /*************************************************************************
          * REVIEW SCREEN OF THE COMPONENT API OF THE GINI VISION LIBRARY FOR IOS *
          *************************************************************************/
+
         
-        // (1. If not already done: Create and set a custom configuration object)
-        // See `ComponentAPICameraViewController.swift` for implementation details.
-        
-        // 2. Create the review view controller
+        // 1. Create the review view controller
         contentController = ReviewViewController(document, successBlock:
             { [unowned self] document in
                 print("Component API review view controller received image data")
@@ -55,22 +56,9 @@ class ComponentAPIReviewViewController: UIViewController {
                 print("Component API review view controller received error:\n\(error)")
             })
         
-        // 3. Display the review view controller
+        // 2. Display the review view controller
         displayContent(contentController)
         
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        guard let navController = navigationController else { return }
-        if isFirstViewController(inNavController: navController) {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(closeAction))
-        }
-    }
-    
-    func closeAction() {
-        dismiss(animated: true, completion: nil)
     }
     
     override func didMove(toParentViewController parent: UIViewController?) {
@@ -78,7 +66,15 @@ class ComponentAPIReviewViewController: UIViewController {
         
         // Cancel analysis process to avoid unnecessary network calls.
         if parent == nil {
-            AnalysisManager.sharedManager.cancelAnalysis()
+//            delegate?.didCancelReview()
+        }
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        if isMovingFromParentViewController || isBeingDismissed {
+            delegate?.didCancelReview()
         }
     }
     
@@ -92,59 +88,8 @@ class ComponentAPIReviewViewController: UIViewController {
     
     // MARK: User actions
     @IBAction func showAnalysis(_ sender: AnyObject) {
-        
-        // Analyze reviewed data because changes were made by the user during review.
-        if document?.data != originalDocument?.data {
-            originalDocument = document
-            if let documentData = document?.data {
-                AnalysisManager.sharedManager.analyzeDocument(withData: documentData, cancelationToken: CancelationToken(), completion: nil)
-                performSegue(withIdentifier: "showAnalysis", sender: self)
-            }
-            return
-        }
-        
-        // Present already existing results retrieved from the first analysis process initiated in `viewDidLoad`.
-        if let result = AnalysisManager.sharedManager.result,
-           let document = AnalysisManager.sharedManager.document {
-            handleAnalysis(result, fromDocument: document)
-            return
-        }
-        
-        // Restart analysis if it was canceled and is currently not running.
-        if !AnalysisManager.sharedManager.isAnalyzing {
-            if let documentData = document?.data {
-                AnalysisManager.sharedManager.analyzeDocument(withData: documentData, cancelationToken: CancelationToken(), completion: nil)
-            }
-        }
-        
-        // Show analysis screen if no results are in yet and no changes were made.
-        performSegue(withIdentifier: "showAnalysis", sender: self)
-    }
-    
-    // MARK: Handle results from analysis process
-    func handleAnalysis(_ result: GINIResult, fromDocument document: GINIDocument) {
-        let payFive = ["paymentReference", "iban", "bic", "paymentReference", "amountToPay"]
-        let hasPayFive = result.filter { payFive.contains($0.0) }.count > 0
-        
-        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        if hasPayFive {
-            let vc = storyboard.instantiateViewController(withIdentifier: "resultScreen") as! ResultTableViewController
-            vc.result = result
-            vc.document = document
-            navigationController?.pushViewController(vc, animated: true)
-        } else {
-            let vc = storyboard.instantiateViewController(withIdentifier: "noResultScreen") as! NoResultViewController
-            navigationController?.pushViewController(vc, animated: true)
-        }
-    }
-    
-    // MARK: Navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "showAnalysis" {
-            if let vc = segue.destination as? ComponentAPIAnalysisViewController {
-                // Set image data as input for the analysis view controller
-                vc.document = document
-            }
+        if let document = document {
+            delegate?.didReview(documentReviewed: document)
         }
     }
 }

--- a/Example/GiniVision/ComponentAPIReviewViewController.swift
+++ b/Example/GiniVision/ComponentAPIReviewViewController.swift
@@ -32,6 +32,11 @@ class ComponentAPIReviewViewController: UIViewController {
         
         guard let document = document else { return }
         originalDocument = document
+        
+        // Analogouse to the Screen API the image data should be analyzed right away with the Gini SDK for iOS
+        // to have results in as early as possible.
+        
+        AnalysisManager.sharedManager.analyzeDocument(withData: document.data, cancelationToken: CancelationToken(), completion: nil)
                 
         /*************************************************************************
          * REVIEW SCREEN OF THE COMPONENT API OF THE GINI VISION LIBRARY FOR IOS *
@@ -53,6 +58,20 @@ class ComponentAPIReviewViewController: UIViewController {
         
         // 3. Display the review view controller
         displayContent(contentController)
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        guard let navController = navigationController else { return }
+        if isFirstViewController(inNavController: navController){
+            navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(closeAction))
+        }
+    }
+    
+    func closeAction() {
+        dismiss(animated: true, completion: nil)
     }
     
     override func didMove(toParentViewController parent: UIViewController?) {

--- a/Example/GiniVision/ComponentAPIReviewViewController.swift
+++ b/Example/GiniVision/ComponentAPIReviewViewController.swift
@@ -69,10 +69,6 @@ class ComponentAPIReviewViewController: UIViewController {
         // Cancel analysis process to avoid unnecessary network calls.
         if parent == nil {
             AnalysisManager.sharedManager.cancelAnalysis()
-        } else {
-            if let nav = parent as? UINavigationController, let cameraContainer = nav.viewControllers[nav.viewControllers.count - 2] as? ComponentAPICameraViewController {
-                cameraContainer.document = nil
-            }
         }
     }
     

--- a/Example/GiniVision/Extensions.swift
+++ b/Example/GiniVision/Extensions.swift
@@ -3,7 +3,7 @@
 //  GiniVision_Example
 //
 //  Created by Enrique del Pozo Gómez on 9/20/17.
-//  Copyright © 2017 CocoaPods. All rights reserved.
+//  Copyright © 2017 Gini. All rights reserved.
 //
 
 import Foundation

--- a/Example/GiniVision/Extensions.swift
+++ b/Example/GiniVision/Extensions.swift
@@ -1,0 +1,19 @@
+//
+//  Extensions.swift
+//  GiniVision_Example
+//
+//  Created by Enrique del Pozo Gómez on 9/20/17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+    func isFirstViewController(inNavController navController:UINavigationController) -> Bool {
+        if navController.viewControllers.count == 1 {
+            return true
+        }
+        return false
+    }
+}

--- a/Example/GiniVision/NoResultViewController.swift
+++ b/Example/GiniVision/NoResultViewController.swift
@@ -8,9 +8,14 @@
 
 import UIKit
 
+protocol NoResultsScreenDelegate:class {
+    func didTapRetry()
+}
+
 class NoResultViewController: UIViewController {
     
     @IBOutlet var rotateImageView: UIImageView!
+    var delegate:NoResultsScreenDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,10 +24,6 @@ class NoResultViewController: UIViewController {
     }
     
     @IBAction func retry(_ sender: AnyObject) {
-        if let navVC = navigationController, !isFirstViewController(inNavController: navVC) {
-            _ = navVC.popToRootViewController(animated: true)
-        } else {
-            dismiss(animated: true, completion: nil)
-        }
+        delegate?.didTapRetry()
     }
 }

--- a/Example/GiniVision/NoResultViewController.swift
+++ b/Example/GiniVision/NoResultViewController.swift
@@ -19,6 +19,10 @@ class NoResultViewController: UIViewController {
     }
     
     @IBAction func retry(_ sender: AnyObject) {
-        _ = self.navigationController?.popToRootViewController(animated: true)
+        if let navVC = navigationController, !isFirstViewController(inNavController: navVC) {
+            _ = navVC.popToRootViewController(animated: true)
+        } else {
+            dismiss(animated: true, completion: nil)
+        }
     }
 }

--- a/Example/GiniVision/ResultTableViewController.swift
+++ b/Example/GiniVision/ResultTableViewController.swift
@@ -33,10 +33,16 @@ class ResultTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(closeAction))
+        
         // If a valid document is set, send feedback on it.
         // This is just to show case how to give feedback using the Gini SDK for iOS.
         // In a real world application feedback should be triggered after the user has evaluated and eventually corrected the extractions.
         sendFeedback(forDocument: document)
+    }
+    
+    func closeAction() {
+        dismiss(animated: true, completion: nil)
     }
     
     func sendFeedback(forDocument document: GINIDocument) {

--- a/Example/GiniVision/ResultTableViewController.swift
+++ b/Example/GiniVision/ResultTableViewController.swift
@@ -32,15 +32,11 @@ class ResultTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-                
+
         // If a valid document is set, send feedback on it.
         // This is just to show case how to give feedback using the Gini SDK for iOS.
         // In a real world application feedback should be triggered after the user has evaluated and eventually corrected the extractions.
         sendFeedback(forDocument: document)
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
     }
         
     func closeAction() {

--- a/Example/GiniVision/ResultTableViewController.swift
+++ b/Example/GiniVision/ResultTableViewController.swift
@@ -38,10 +38,6 @@ class ResultTableViewController: UITableViewController {
         // In a real world application feedback should be triggered after the user has evaluated and eventually corrected the extractions.
         sendFeedback(forDocument: document)
     }
-        
-    func closeAction() {
-        dismiss(animated: true, completion: nil)
-    }
     
     func sendFeedback(forDocument document: GINIDocument) {
         

--- a/Example/GiniVision/ResultTableViewController.swift
+++ b/Example/GiniVision/ResultTableViewController.swift
@@ -32,15 +32,17 @@ class ResultTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Schließen", style: .plain, target: self, action: #selector(closeAction))
-        
+                
         // If a valid document is set, send feedback on it.
         // This is just to show case how to give feedback using the Gini SDK for iOS.
         // In a real world application feedback should be triggered after the user has evaluated and eventually corrected the extractions.
         sendFeedback(forDocument: document)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+        
     func closeAction() {
         dismiss(animated: true, completion: nil)
     }

--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -100,15 +100,15 @@ class ScreenAPIViewController: UIViewController {
         if let tabBar = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPI") as? UITabBarController,
             let navBar = tabBar.viewControllers?.first as? UINavigationController {
             if let document = document {
-                if document.type == .PDF {
-                    if let analysisContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIAnalysis") as? ComponentAPIAnalysisViewController {
-                        analysisContainer.document = document
-                        navBar.setViewControllers([analysisContainer], animated: false)
-                    }
-                }else {
+                if document.isReviewable {
                     if let reviewContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIReview") as? ComponentAPIReviewViewController {
                         reviewContainer.document = document
                         navBar.setViewControllers([reviewContainer], animated: false)
+                    }
+                }else {
+                    if let analysisContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIAnalysis") as? ComponentAPIAnalysisViewController {
+                        analysisContainer.document = document
+                        navBar.setViewControllers([analysisContainer], animated: false)
                     }
                 }
             }

--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -105,7 +105,7 @@ class ScreenAPIViewController: UIViewController {
                         reviewContainer.document = document
                         navBar.setViewControllers([reviewContainer], animated: false)
                     }
-                }else {
+                } else {
                     if let analysisContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIAnalysis") as? ComponentAPIAnalysisViewController {
                         analysisContainer.document = document
                         navBar.setViewControllers([analysisContainer], animated: false)

--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -71,7 +71,7 @@ class ScreenAPIViewController: UIViewController {
          ************************************************************************/
         
         // 1. Create the Gini Vision Library view controller, set a delegate object and pass in the configuration object
-        let vc = giniScreenAPI(withImportedFile: nil)
+        let vc = giniScreenAPI(withImportedDocument: nil)
         
         // 2. Present the Gini Vision Library Screen API modally
         present(vc, animated: true, completion: nil)
@@ -79,7 +79,7 @@ class ScreenAPIViewController: UIViewController {
         // 3. Handle callbacks send out via the `GINIVisionDelegate` to get results, errors or updates on other user actions
     }
     
-    func giniScreenAPI(withImportedFile fileData:Data?, appName:String? = nil) -> UIViewController {
+    func giniScreenAPI(withImportedDocument document:GiniVisionDocument?) -> UIViewController {
         
         // 1. Create a custom configuration object
         let giniConfiguration = GiniConfiguration()
@@ -92,18 +92,15 @@ class ScreenAPIViewController: UIViewController {
         }
         
         // 2. Create the Gini Vision Library view controller, set a delegate object and pass in the configuration object
-        return GiniVision.viewController(withDelegate: self, withConfiguration: giniConfiguration, importedFile: fileData)
+        return GiniVision.viewController(withDelegate: self, withConfiguration: giniConfiguration, importedDocument: document)
     }
     
-    func giniComponentAPI(withImportedFile fileData:Data?, appName:String? = nil) -> UIViewController? {
+
+    func giniComponentAPI(withImportedDocument document:GiniVisionDocument?) -> UIViewController? {
         if let tabBar = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPI") as? UITabBarController,
             let navBar = tabBar.viewControllers?.first as? UINavigationController,
             let cameraContainer = navBar.viewControllers.first as? ComponentAPICameraViewController {
-            
-            let documentBuilder = GiniVisionDocumentBuilder(data: fileData, documentSource: DocumentSource.appName(name: appName))
-            documentBuilder.importMethod = .openWith
-            
-            if let document = documentBuilder.build() {
+            if let document = document {
                 cameraContainer.document = document
             }
             

--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -98,10 +98,19 @@ class ScreenAPIViewController: UIViewController {
 
     func giniComponentAPI(withImportedDocument document:GiniVisionDocument?) -> UIViewController? {
         if let tabBar = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPI") as? UITabBarController,
-            let navBar = tabBar.viewControllers?.first as? UINavigationController,
-            let cameraContainer = navBar.viewControllers.first as? ComponentAPICameraViewController {
+            let navBar = tabBar.viewControllers?.first as? UINavigationController {
             if let document = document {
-                cameraContainer.document = document
+                if document.type == .PDF {
+                    if let analysisContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIAnalysis") as? ComponentAPIAnalysisViewController {
+                        analysisContainer.document = document
+                        navBar.setViewControllers([analysisContainer], animated: false)
+                    }
+                }else {
+                    if let reviewContainer = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ComponentAPIReview") as? ComponentAPIReviewViewController {
+                        reviewContainer.document = document
+                        navBar.setViewControllers([reviewContainer], animated: false)
+                    }
+                }
             }
             
             return tabBar

--- a/Example/GiniVision/SelectAPIViewController.swift
+++ b/Example/GiniVision/SelectAPIViewController.swift
@@ -14,7 +14,7 @@ import Gini_iOS_SDK
  View controller showing how to capture an image of a document using the Screen API of the Gini Vision Library for iOS
  and how to process it using the Gini SDK for iOS.
  */
-class ScreenAPIViewController: UIViewController {
+class SelectAPIViewController: UIViewController {
     
     @IBOutlet weak var metaInformationLabel: UILabel!
     
@@ -197,7 +197,7 @@ class ScreenAPIViewController: UIViewController {
 }
 
 // MARK: Gini Vision delegate
-extension ScreenAPIViewController: GiniVisionDelegate {
+extension SelectAPIViewController: GiniVisionDelegate {
     
     func didImport(_ document: GiniVisionDocument) {
         print("Document imported")

--- a/Example/GiniVision/SelectAPIViewController.swift
+++ b/Example/GiniVision/SelectAPIViewController.swift
@@ -79,6 +79,12 @@ class SelectAPIViewController: UIViewController {
         // 3. Handle callbacks send out via the `GINIVisionDelegate` to get results, errors or updates on other user actions
     }
     
+    @IBAction func launchComponentAPI(_ sender: Any) {
+        
+        let componentAPICoordinator = ComponentAPICoordinator(document: nil)
+        componentAPICoordinator.start(from: self)
+    }
+    
     func giniScreenAPI(withImportedDocument document:GiniVisionDocument?) -> UIViewController {
         
         // 1. Create a custom configuration object

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -49,10 +49,12 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
                     self.navigationController?.pushViewController(viewController, animated: true)
                 }
                 
-            }, failureBlock: { error in
+            }, failureBlock: {[unowned self] error in
                 switch error {
                 case CameraError.notAuthorizedToUseDevice:
                     print("GiniVision: Camera authorization denied.")
+                case is DocumentValidationError:
+                    self.showNotValidDocumentError()
                 default:
                     print("GiniVision: Unknown error when using camera.")
                 }
@@ -153,6 +155,15 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
         ConstraintUtils.addActiveConstraint(item: containerView, attribute: .trailing, relatedBy: .equal, toItem: superview, attribute: .trailing, multiplier: 1, constant: 0)
         ConstraintUtils.addActiveConstraint(item: containerView, attribute: .bottom, relatedBy: .equal, toItem: superview, attribute: .bottom, multiplier: 1, constant: 0)
         ConstraintUtils.addActiveConstraint(item: containerView, attribute: .leading, relatedBy: .equal, toItem: superview, attribute: .leading, multiplier: 1, constant: 0)
+    }
+    
+    fileprivate func showNotValidDocumentError() {
+        let alertViewController = UIAlertController(title: "Ungültiges Dokument", message: "Das von Ihnen gewählte Dokument ist ungültig", preferredStyle: .alert)
+        alertViewController.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+            alertViewController.dismiss(animated: true, completion: nil)
+        }))
+        
+        self.contentController.present(alertViewController, animated: true, completion: nil)
     }
 
 }

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -31,15 +31,22 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
         contentController = CameraViewController(successBlock:
             { document, isImported in
                 let delegate = (self.navigationController as? GiniNavigationViewController)?.giniDelegate
+                let viewController:UIViewController
                 if isImported {
+                    if document.type == .PDF {
+                        viewController = AnalysisContainerViewController(document: document)
+                    } else {
+                        viewController = ReviewContainerViewController(document: document)
+                    }
                     delegate?.didImport?(document)
                 } else {
+                    viewController = ReviewContainerViewController(document: document)
                     delegate?.didCapture(document.data)
                 }
                 
                 // Push review container view controller
                 DispatchQueue.main.async {
-                    self.navigationController?.pushViewController(ReviewContainerViewController(document: document), animated: true)
+                    self.navigationController?.pushViewController(viewController, animated: true)
                 }
                 
             }, failureBlock: { error in

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -33,10 +33,10 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
                 let delegate = (self.navigationController as? GiniNavigationViewController)?.giniDelegate
                 let viewController:UIViewController
                 if isImported {
-                    if document.type == .PDF {
-                        viewController = AnalysisContainerViewController(document: document)
-                    } else {
+                    if document.isReviewable {
                         viewController = ReviewContainerViewController(document: document)
+                    } else {
+                        viewController = AnalysisContainerViewController(document: document)
                     }
                     delegate?.didImport?(document)
                 } else {

--- a/GiniVision/Classes/GiniImageDocument.swift
+++ b/GiniVision/Classes/GiniImageDocument.swift
@@ -16,6 +16,7 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     public var type: GiniVisionDocumentType = .Image
     public var data:Data
     public var previewImage: UIImage?
+    public var isReviewable: Bool
     
     fileprivate let metaInformationManager:ImageMetaInformationManager
     
@@ -29,6 +30,7 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     
     init(data: Data, imageSource:DocumentSource, imageImportMethod:DocumentImportMethod? = nil, deviceOrientation:UIInterfaceOrientation? = nil) {
         self.previewImage = UIImage(data: data)
+        self.isReviewable = true
         self.metaInformationManager = ImageMetaInformationManager(imageData: data, deviceOrientation:deviceOrientation, imageSource:imageSource, imageImportMethod:imageImportMethod)
         
         if let dataWithMetadata = metaInformationManager.imageByAddingMetadata() {

--- a/GiniVision/Classes/GiniPDFDocument.swift
+++ b/GiniVision/Classes/GiniPDFDocument.swift
@@ -16,6 +16,7 @@ final public class GiniPDFDocument: NSObject, GiniVisionDocument {
     public var type: GiniVisionDocumentType = .PDF
     public let data:Data
     public var previewImage: UIImage?
+    public var isReviewable: Bool
     
     private let MAX_PDF_PAGES_COUNT = 10
     private(set) var numberPages:Int = 0
@@ -29,6 +30,7 @@ final public class GiniPDFDocument: NSObject, GiniVisionDocument {
     
     init(data:Data) {
         self.data = data
+        self.isReviewable = false
         super.init()
         
         if let dataProvider = CGDataProvider(data: data as CFData), let pdfDocument = CGPDFDocument(dataProvider) {

--- a/GiniVision/Classes/GiniVision.swift
+++ b/GiniVision/Classes/GiniVision.swift
@@ -93,7 +93,7 @@ import UIKit
      - note: Screen API only.
      
      - parameter delegate: An instance conforming to the `GiniVisionDelegate` protocol.
-     - parameter importedDocument:  A document which comes from other a source different than CameraViewController. It should be validated before calling this method.
+     - parameter importedDocument:  A document which comes from a source different than CameraViewController. It should be validated before calling this method.
      
      - returns: A presentable navigation view controller.
      */
@@ -123,7 +123,7 @@ import UIKit
      
      - parameter delegate:      An instance conforming to the `GiniVisionDelegate` protocol.
      - parameter configuration: The configuration to set.
-     - parameter importedDocument:  A document which comes from other a source different than CameraViewController. It should be validated before calling this method.
+     - parameter importedDocument:  A document which comes from a source different than CameraViewController. It should be validated before calling this method.
      
      - returns: A presentable navigation view controller.
      */

--- a/GiniVision/Classes/GiniVision.swift
+++ b/GiniVision/Classes/GiniVision.swift
@@ -93,16 +93,14 @@ import UIKit
      - note: Screen API only.
      
      - parameter delegate: An instance conforming to the `GiniVisionDelegate` protocol.
-     - parameter importedFile:  A document which comes from other a source different than CameraViewController (optional)
+     - parameter importedDocument:  A document which comes from other a source different than CameraViewController. It should be validated before calling this method.
      
      - returns: A presentable navigation view controller.
      */
-    public class func viewController(withDelegate delegate: GiniVisionDelegate, importedFile:Data? = nil) -> UIViewController {
+    public class func viewController(withDelegate delegate: GiniVisionDelegate, importedDocument:GiniVisionDocument? = nil) -> UIViewController {
         let viewController:UIViewController
-        let documentBuilder = GiniVisionDocumentBuilder(data:importedFile, documentSource: .external)
-        documentBuilder.importMethod = .openWith
         
-        if let document = documentBuilder.build() {
+        if let document = importedDocument {
             viewController = ReviewContainerViewController(document: document)
         } else {
             viewController = CameraContainerViewController()
@@ -120,13 +118,13 @@ import UIKit
      
      - parameter delegate:      An instance conforming to the `GiniVisionDelegate` protocol.
      - parameter configuration: The configuration to set.
-     - parameter importedFile:  A document which comes from other a source different than CameraViewController (optional)
+     - parameter importedDocument:  A document which comes from other a source different than CameraViewController. It should be validated before calling this method.
      
      - returns: A presentable navigation view controller.
      */
-    public class func viewController(withDelegate delegate: GiniVisionDelegate, withConfiguration configuration: GiniConfiguration, importedFile:Data? = nil) -> UIViewController {
+    public class func viewController(withDelegate delegate: GiniVisionDelegate, withConfiguration configuration: GiniConfiguration, importedDocument:GiniVisionDocument? = nil) -> UIViewController {
         setConfiguration(configuration)
-        return viewController(withDelegate: delegate, importedFile:importedFile)
+        return viewController(withDelegate: delegate, importedDocument:importedDocument)
     }
     
     /**

--- a/GiniVision/Classes/GiniVision.swift
+++ b/GiniVision/Classes/GiniVision.swift
@@ -101,10 +101,10 @@ import UIKit
         let viewController:UIViewController
         
         if let document = importedDocument {
-            if document.type == .PDF {
-                viewController = AnalysisContainerViewController(document: document)
-            } else {
+            if document.isReviewable {
                 viewController = ReviewContainerViewController(document: document)
+            } else {
+                viewController = AnalysisContainerViewController(document: document)
             }
             delegate.didImport?(document)
         } else {

--- a/GiniVision/Classes/GiniVision.swift
+++ b/GiniVision/Classes/GiniVision.swift
@@ -101,7 +101,12 @@ import UIKit
         let viewController:UIViewController
         
         if let document = importedDocument {
-            viewController = ReviewContainerViewController(document: document)
+            if document.type == .PDF {
+                viewController = AnalysisContainerViewController(document: document)
+            } else {
+                viewController = ReviewContainerViewController(document: document)
+            }
+            delegate.didImport?(document)
         } else {
             viewController = CameraContainerViewController()
         }

--- a/GiniVision/Classes/GiniVisionDocument.swift
+++ b/GiniVision/Classes/GiniVisionDocument.swift
@@ -12,6 +12,7 @@ import Foundation
     var type:GiniVisionDocumentType { get }
     var data:Data { get }
     var previewImage:UIImage? { get }
+    var isReviewable:Bool { get }
     
     func checkType() throws
 }

--- a/GiniVision/Classes/ReviewContainerViewController.swift
+++ b/GiniVision/Classes/ReviewContainerViewController.swift
@@ -35,13 +35,10 @@ internal class ReviewContainerViewController: UIViewController, ContainerViewCon
         
         // Configure content controller and update image data on success
         contentController = ReviewViewController(self.document!, successBlock:
-            { [unowned self] (document, shouldProceedToAnalysisScreen) in
+            { [unowned self] document in
                 self.document = document
                 self.changes = true
-                
-                if shouldProceedToAnalysisScreen {
-                    self.analyse()
-                }
+       
             }, failureBlock: { error in
                 print(error)
             })

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -20,7 +20,7 @@ public typealias ReviewSuccessBlock = (_ imageData: Data) -> ()
  
  - note: Component API only.
  */
-public typealias ReviewScreenSuccessBlock = (_ document: GiniVisionDocument, _ shouldProceedToAnalysisScreen:Bool) -> ()
+public typealias ReviewScreenSuccessBlock = (_ document: GiniVisionDocument) -> ()
 
 /**
  Block that will be executed when an error occurs on the review screen. It contains a review specific error.
@@ -163,7 +163,7 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> ()
     @nonobjc
     @available(*, deprecated)
     public convenience init(_ imageData:Data, success: @escaping ReviewSuccessBlock, failure: @escaping ReviewErrorBlock) {
-        self.init(GiniImageDocument(data: imageData, imageSource: .external), successBlock: { (document,_) in
+        self.init(GiniImageDocument(data: imageData, imageSource: .external), successBlock: { document in
             success(document.data)
         }, failureBlock: { error in
             failure(error as! ReviewError)
@@ -210,8 +210,7 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> ()
         
         imageView.image = rotatedImage
         imageDocument.rotateImage(degrees: 90, imageOrientation: rotatedImage.imageOrientation)
-        
-        successBlock?(imageDocument, false)
+        successBlock?(imageDocument)
     }
     
     fileprivate func rotateImage(_ image: UIImage?) -> UIImage? {

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -201,22 +201,6 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> ()
         DispatchQueue.main.async {
             (self.topView as? NoticeView)?.show()
         }
-        
-        if let currentDocument = currentDocument {
-            // Validate document before review
-            do {
-                try currentDocument.validate()
-            } catch let error as DocumentValidationError {
-                failureBlock!(error)
-            } catch _ {
-                failureBlock!(DocumentValidationError.unknown)
-            }
-            
-            // If the document is a PDF, go to Analysis screen
-            if currentDocument.type == .PDF {
-                successBlock?(currentDocument, true)
-            }
-        }
     }
     
     // MARK: Rotation handling


### PR DESCRIPTION
Some documents are not reviewable, so they do not have to go through the review screen. On the Component API 

### How to test
Import a PDF and see that it doesn't go through the review screen. If instead you import an image or take a picture with the camera, it should be reviewable from review screen. 
Also using the "Open with" method, you should have the same result.

### Merging
Automatic.

### Ticket 
Issue #64   
