### PR TITLE
File types supported toggle for file import feature

### DIFF
--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -84,7 +84,7 @@ class ScreenAPIViewController: UIViewController {
         // 1. Create a custom configuration object
         let giniConfiguration = GiniConfiguration()
         giniConfiguration.debugModeOn = true
-        giniConfiguration.fileImportEnabled = true
+        giniConfiguration.fileImportSupportedTypes = .all
         giniConfiguration.navigationBarItemTintColor = UIColor.white
         
         // Make sure the app always behaves the same when run from UITests

--- a/Example/GiniVision/ScreenAPIViewController.swift
+++ b/Example/GiniVision/ScreenAPIViewController.swift
@@ -84,7 +84,7 @@ class ScreenAPIViewController: UIViewController {
         // 1. Create a custom configuration object
         let giniConfiguration = GiniConfiguration()
         giniConfiguration.debugModeOn = true
-        giniConfiguration.fileImportSupportedTypes = .all
+        giniConfiguration.fileImportSupportedTypes = .pdf_and_images
         giniConfiguration.navigationBarItemTintColor = UIColor.white
         
         // Make sure the app always behaves the same when run from UITests

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -356,7 +356,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
         let alertViewController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         var alertViewControllerMessage = "Dokumente importieren"
         
-        if GiniConfiguration.sharedConfiguration.fileImportSupportedTypes == .all {
+        if GiniConfiguration.sharedConfiguration.fileImportSupportedTypes == .pdf_and_images {
             alertViewController.addAction(UIAlertAction(title: "Camera roll", style: .default) { [unowned self] _ in
                 self.filePickerManager.showGalleryPicker(from: self)
             })

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -181,7 +181,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
         // Add constraints
         addConstraints()
         
-        if GiniConfiguration.sharedConfiguration.fileImportEnabled {
+        if GiniConfiguration.sharedConfiguration.fileImportSupportedTypes != .none {
             enableFileImport()
         }
     }
@@ -354,9 +354,12 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
     @objc fileprivate func importDocument(_ sender: AnyObject) {
         
         let alertViewController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alertViewController.addAction(UIAlertAction(title: "Photos", style: .default) { [unowned self] _ in
-            self.filePickerManager.showGalleryPicker(from: self)
-        })
+        
+        if GiniConfiguration.sharedConfiguration.fileImportSupportedTypes == .all {
+            alertViewController.addAction(UIAlertAction(title: "Photos", style: .default) { [unowned self] _ in
+                self.filePickerManager.showGalleryPicker(from: self)
+            })
+        }
         
         alertViewController.addAction(UIAlertAction(title: "Documents", style: .default) { [unowned self] _ in
             self.filePickerManager.showDocumentPicker(from: self)

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -354,21 +354,24 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
     @objc fileprivate func importDocument(_ sender: AnyObject) {
         
         let alertViewController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        var alertViewControllerMessage = "Dokumente importieren"
         
         if GiniConfiguration.sharedConfiguration.fileImportSupportedTypes == .all {
-            alertViewController.addAction(UIAlertAction(title: "Photos", style: .default) { [unowned self] _ in
+            alertViewController.addAction(UIAlertAction(title: "Camera roll", style: .default) { [unowned self] _ in
                 self.filePickerManager.showGalleryPicker(from: self)
             })
+            alertViewControllerMessage = "Fotos oder Dokumente importieren"
         }
         
-        alertViewController.addAction(UIAlertAction(title: "Documents", style: .default) { [unowned self] _ in
+        alertViewController.addAction(UIAlertAction(title: "Dokumente", style: .default) { [unowned self] _ in
             self.filePickerManager.showDocumentPicker(from: self)
         })
         
-        alertViewController.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+        alertViewController.addAction(UIAlertAction(title: "Abbrechen", style: .cancel) { _ in
             alertViewController.dismiss(animated: true, completion: nil)
         })
         
+        alertViewController.message = alertViewControllerMessage
         alertViewController.popoverPresentationController?.sourceView = importFileButton
         
         self.present(alertViewController, animated: true, completion: nil)

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -14,7 +14,7 @@ internal final class FilePickerManager:NSObject {
     var didPickFile:((GiniVisionDocument) -> ()) = { _ in }
     fileprivate var acceptedDocumentTypes:[String] {
         switch GiniConfiguration.sharedConfiguration.fileImportSupportedTypes {
-        case .all:
+        case .pdf_and_images:
             return GiniPDFDocument.acceptedPDFTypes + GiniImageDocument.acceptedImageTypes
         case .pdf:
             return GiniPDFDocument.acceptedPDFTypes
@@ -94,7 +94,7 @@ extension FilePickerManager: UIDocumentPickerDelegate {
 extension FilePickerManager: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         switch GiniConfiguration.sharedConfiguration.fileImportSupportedTypes {
-        case .all:
+        case .pdf_and_images:
             return (session.canLoadObjects(ofClass: GiniImageDocument.self) || session.canLoadObjects(ofClass: GiniPDFDocument.self)) && session.items.count == 1
         case .pdf:
             return session.canLoadObjects(ofClass: GiniPDFDocument.self) && session.items.count == 1

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -12,7 +12,16 @@ import MobileCoreServices
 internal final class FilePickerManager:NSObject {
         
     var didPickFile:((GiniVisionDocument) -> ()) = { _ in }
-    fileprivate var acceptedDocumentTypes = GiniPDFDocument.acceptedPDFTypes + GiniImageDocument.acceptedImageTypes
+    fileprivate var acceptedDocumentTypes:[String] {
+        switch GiniConfiguration.sharedConfiguration.fileImportSupportedTypes {
+        case .all:
+            return GiniPDFDocument.acceptedPDFTypes + GiniImageDocument.acceptedImageTypes
+        case .pdf:
+            return GiniPDFDocument.acceptedPDFTypes
+        case .none:
+            return []
+        }
+    }
     
     // MARK: Picker presentation
     
@@ -84,7 +93,14 @@ extension FilePickerManager: UIDocumentPickerDelegate {
 @available(iOS 11.0, *)
 extension FilePickerManager: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
-        return (session.canLoadObjects(ofClass: GiniImageDocument.self) || session.canLoadObjects(ofClass: GiniPDFDocument.self)) && session.items.count == 1
+        switch GiniConfiguration.sharedConfiguration.fileImportSupportedTypes {
+        case .all:
+            return (session.canLoadObjects(ofClass: GiniImageDocument.self) || session.canLoadObjects(ofClass: GiniPDFDocument.self)) && session.items.count == 1
+        case .pdf:
+            return session.canLoadObjects(ofClass: GiniPDFDocument.self) && session.items.count == 1
+        case .none:
+            return false
+        }
     }
     
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -29,6 +29,11 @@ import UIKit
         return sharedConfiguration.debugModeOn
     }
     
+    public enum GiniVisionImportFileTypes {
+        case none
+        case pdf
+        case all
+    }
     
     
     // MARK: General options
@@ -111,10 +116,10 @@ import UIKit
     // MARK: Camera options
     
     /**
-     Toggles the file import feature.
+     Set the types supported by the file import feature. `none` by default
 
      */
-    public var fileImportEnabled = false
+    public var fileImportSupportedTypes: GiniVisionImportFileTypes = .none
     
     /**
      Sets the title text in the navigation bar on the camera screen.

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -32,7 +32,7 @@ import UIKit
     public enum GiniVisionImportFileTypes {
         case none
         case pdf
-        case all
+        case pdf_and_images
     }
     
     


### PR DESCRIPTION
File types supported for file import feature. It should be specified through `GiniConfiguration`, being `none` by default.

### How to test
Set `fileImportSupportedTypes` to `.all` and see that file import feature is enabled for all types. If instead `.pdf` is set, the app will only handle PDF files (not pictures).
In case that none is specified, it should handle all file types (pictures and pdfs)

### Merging
Automatic.

### Ticket 
Issue #59    
