### PR TITLE
Exif handle for GIFs and PNGs.

### DIFF
--- a/GiniVision/Classes/GiniImageDocument.swift
+++ b/GiniVision/Classes/GiniImageDocument.swift
@@ -35,7 +35,6 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
             self.data = dataWithMetadata
         } else {
             self.data = data
-            assertionFailure("It wasn't possible to add metadata to the image")
         }
     }
     
@@ -58,10 +57,7 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
     
     func rotateImage(degrees:Int, imageOrientation:UIImageOrientation) {
         metaInformationManager.rotate(degrees: 90, imageOrientation: imageOrientation)
-        guard let data = metaInformationManager.imageByAddingMetadata() else {
-            assertionFailure("It wasn't possible to add metadata to the image")
-            return
-        }
+        guard let data = metaInformationManager.imageByAddingMetadata() else { return }
         self.data = data
         self.previewImage = UIImage(data: data)
     }

--- a/GiniVision/Classes/ImageMetaInformationManager.swift
+++ b/GiniVision/Classes/ImageMetaInformationManager.swift
@@ -107,7 +107,7 @@ internal class ImageMetaInformationManager {
     
     // Returns the current image but with all meta information added
     func imageByAddingMetadata(withCompression compression: CGFloat = JPEGDefaultCompression) -> Data? {
-        guard let image = imageData, let information = metaInformation else { return nil }
+        guard let image = imageData, let information = metaInformation, (image.isJPEG || image.isTIFF) else { return nil }
         
         let targetData = NSMutableData()
         let destination = CGImageDestinationCreateWithData(targetData, kUTTypeJPEG, 1, nil)


### PR DESCRIPTION
GIFs and PNGs images should not have meta information and should not be converted to JPEG. 

### How to test
Import a PNG or GIF image and see that its bytes count is the same when the image is analyzed.

### Merging
Automatic.

### Ticket 
Issue #61     
