### PR TITLE
Show photo library permissions denied dialog

### DIFF
--- a/GiniVision/Assets/Localizable.strings
+++ b/GiniVision/Assets/Localizable.strings
@@ -21,7 +21,7 @@
 "ginivision.camera.captureButton" = "Auslösen";
 "ginivision.camera.notAuthorized" = "Um Dokumente zu fotografieren, erlaube Gini Pay den Zugriff auf die Kamera.";
 "ginivision.camera.notAuthorizedButton" = "Zugriff erlauben";
-"ginivision.camera.filepicker.photoLibraryAccessDenied" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Bilder benötigt.";
+"ginivision.camera.filepicker.photoLibraryAccessDenied" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Fotos benötigt.";
 
 "ginivision.onboarding.firstPage"  = "Dokument\nflach\nfotografieren";
 "ginivision.onboarding.secondPage" = "Handy parallel\nzum Dokument\nhalten";

--- a/GiniVision/Assets/Localizable.strings
+++ b/GiniVision/Assets/Localizable.strings
@@ -20,6 +20,7 @@
 
 "ginivision.camera.captureButton" = "Auslösen";
 "ginivision.camera.notAuthorized" = "Um Dokumente zu fotografieren, erlaube Gini Pay den Zugriff auf die Kamera.";
+"ginivision.camera.notAuthorizedPhotoLibrary" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Bilder benötigt.";
 "ginivision.camera.notAuthorizedButton" = "Zugriff erlauben";
 
 "ginivision.onboarding.firstPage"  = "Dokument\nflach\nfotografieren";

--- a/GiniVision/Assets/Localizable.strings
+++ b/GiniVision/Assets/Localizable.strings
@@ -20,8 +20,8 @@
 
 "ginivision.camera.captureButton" = "Auslösen";
 "ginivision.camera.notAuthorized" = "Um Dokumente zu fotografieren, erlaube Gini Pay den Zugriff auf die Kamera.";
-"ginivision.camera.notAuthorizedPhotoLibrary" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Bilder benötigt.";
 "ginivision.camera.notAuthorizedButton" = "Zugriff erlauben";
+"ginivision.camera.filepicker.photoLibraryAccessDenied" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Bilder benötigt.";
 
 "ginivision.onboarding.firstPage"  = "Dokument\nflach\nfotografieren";
 "ginivision.onboarding.secondPage" = "Handy parallel\nzum Dokument\nhalten";

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -53,7 +53,7 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
             switch error {
             case CameraError.notAuthorizedToUseDevice:
                 print("GiniVision: Camera authorization denied.")
-            case CameraError.notAuthorizedToAccessPhotoLibrary:
+            case FilePickerError.photoLibraryAccessDenied:
                 self.showPhotoLibraryPermissionDeniedError()
             case is DocumentValidationError:
                 self.showNotValidDocumentError()
@@ -170,7 +170,7 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
     }
     
     fileprivate func showPhotoLibraryPermissionDeniedError() {
-        let alertMessage = NSLocalizedString("ginivision.camera.notAuthorizedPhotoLibrary",bundle: Bundle(for: GiniVision.self), comment: "This message is shown when Photo library permission is denied")
+        let alertMessage = NSLocalizedString("ginivision.camera.filepicker.photoLibraryAccessDenied",bundle: Bundle(for: GiniVision.self), comment: "This message is shown when Photo library permission is denied")
         
         let alertViewController = UIAlertController(title: nil, message: alertMessage, preferredStyle: .alert)
         

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -53,6 +53,8 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
                 switch error {
                 case CameraError.notAuthorizedToUseDevice:
                     print("GiniVision: Camera authorization denied.")
+                case CameraError.notAuthorizedToAccessPhotoLibrary:
+                    print("GiniVision: Camera authorization denied.")
                 case is DocumentValidationError:
                     self.showNotValidDocumentError()
                 default:

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -53,8 +53,6 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
             switch error {
             case CameraError.notAuthorizedToUseDevice:
                 print("GiniVision: Camera authorization denied.")
-            case FilePickerError.photoLibraryAccessDenied:
-                self.showPhotoLibraryPermissionDeniedError()
             case is DocumentValidationError:
                 self.showNotValidDocumentError()
             default:
@@ -168,29 +166,4 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
         
         self.contentController.present(alertViewController, animated: true, completion: nil)
     }
-    
-    fileprivate func showPhotoLibraryPermissionDeniedError() {
-        let alertMessage = NSLocalizedString("ginivision.camera.filepicker.photoLibraryAccessDenied",bundle: Bundle(for: GiniVision.self), comment: "This message is shown when Photo library permission is denied")
-        
-        let alertViewController = UIAlertController(title: nil, message: alertMessage, preferredStyle: .alert)
-        
-        alertViewController.addAction(UIAlertAction(title: "Abbrechen", style: .cancel, handler: { _ in
-            alertViewController.dismiss(animated: true, completion: nil)
-        }))
-        
-        alertViewController.addAction(UIAlertAction(title: "Zugriff erteilen", style: .default, handler: {[unowned self] _ in
-            alertViewController.dismiss(animated: true, completion: nil)
-            self.openAppSettings()
-        }))
-        
-        self.contentController.present(alertViewController, animated: true, completion: nil)
-    }
-    
-    fileprivate func openAppSettings() {
-        guard let settingsUrl = URL(string: UIApplicationOpenSettingsURLString) else { return }
-        if UIApplication.shared.canOpenURL(settingsUrl) {
-            UIApplication.shared.openURL(settingsUrl)
-        }
-    }
-    
 }

--- a/GiniVision/Classes/CameraNotAuthorizedView.swift
+++ b/GiniVision/Classes/CameraNotAuthorizedView.swift
@@ -62,7 +62,7 @@ internal class CameraNotAuthorizedView: UIView {
     }
     
     @IBAction func openSettings(_ sender: AnyObject) {
-        UIApplication.shared.openURL(URL(string: UIApplicationOpenSettingsURLString)!)
+        UIApplication.shared.openAppSettings()
     }
     
     // MARK: Constraints

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -355,7 +355,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
         
         let alertViewController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertViewController.addAction(UIAlertAction(title: "Photos", style: .default) { [unowned self] _ in
-            self.filePickerManager.showGalleryPicker(from: self)
+            self.filePickerManager.showGalleryPicker(from: self, errorHandler: self.failureBlock!)
         })
         
         alertViewController.addAction(UIAlertAction(title: "Documents", style: .default) { [unowned self] _ in

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -355,7 +355,11 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
         
         let alertViewController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertViewController.addAction(UIAlertAction(title: "Photos", style: .default) { [unowned self] _ in
-            self.filePickerManager.showGalleryPicker(from: self, errorHandler: self.failureBlock!)
+            self.filePickerManager.showGalleryPicker(from: self, errorHandler: { [unowned self] error in
+                if let error = error as? FilePickerError, error == FilePickerError.photoLibraryAccessDenied {
+                    self.showPhotoLibraryPermissionDeniedError()
+                }
+            })
         })
         
         alertViewController.addAction(UIAlertAction(title: "Documents", style: .default) { [unowned self] _ in
@@ -375,6 +379,25 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
     fileprivate func addDropInteraction() {
         let dropInteraction = UIDropInteraction(delegate: filePickerManager)
         view.addInteraction(dropInteraction)
+    }
+    
+    
+    // MARK: Photo library permission denied error
+    fileprivate func showPhotoLibraryPermissionDeniedError() {
+        let alertMessage = GiniConfiguration.sharedConfiguration.photoLibraryAccessDeniedMessageText
+        
+        let alertViewController = UIAlertController(title: nil, message: alertMessage, preferredStyle: .alert)
+        
+        alertViewController.addAction(UIAlertAction(title: "Abbrechen", style: .cancel, handler: { _ in
+            alertViewController.dismiss(animated: true, completion: nil)
+        }))
+        
+        alertViewController.addAction(UIAlertAction(title: "Zugriff erteilen", style: .default, handler: {_ in
+            alertViewController.dismiss(animated: true, completion: nil)
+            UIApplication.shared.openAppSettings()
+        }))
+        
+        self.present(alertViewController, animated: true, completion: nil)
     }
     
     // MARK: Focus handling

--- a/GiniVision/Classes/Extensions.swift
+++ b/GiniVision/Classes/Extensions.swift
@@ -228,4 +228,13 @@ internal extension Data {
     
 }
 
+internal extension UIApplication {
+    func openAppSettings() {
+        guard let settingsUrl = URL(string: UIApplicationOpenSettingsURLString) else { return }
+        if self.canOpenURL(settingsUrl) {
+            self.openURL(settingsUrl)
+        }
+    }
+}
+
 

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -32,7 +32,7 @@ internal final class FilePickerManager:NSObject {
         from.present(documentPicker, animated: true, completion: nil)
     }
     
-    // MARK: FilePicked from gallery or document pickers
+    // MARK: File data picked from gallery or document pickers
     
     fileprivate func filePicked(withData data: Data) {
         let documentBuilder = GiniVisionDocumentBuilder(data: data, documentSource: .external)
@@ -50,13 +50,13 @@ internal final class FilePickerManager:NSObject {
         case .authorized:
             authorizedHandler()
         case .denied, .restricted:
-            deniedHandler(CameraError.notAuthorizedToAccessPhotoLibrary)
+            deniedHandler(FilePickerError.photoLibraryAccessDenied)
         case .notDetermined:
             PHPhotoLibrary.requestAuthorization { status in
                 if status == PHAuthorizationStatus.authorized {
                     authorizedHandler()
                 } else {
-                    deniedHandler(CameraError.notAuthorizedToAccessPhotoLibrary)
+                    deniedHandler(FilePickerError.photoLibraryAccessDenied)
                 }
             }
         }

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -32,6 +32,8 @@ internal final class FilePickerManager:NSObject {
         from.present(documentPicker, animated: true, completion: nil)
     }
     
+    // MARK: FilePicked from gallery or document pickers
+    
     fileprivate func filePicked(withData data: Data) {
         let documentBuilder = GiniVisionDocumentBuilder(data: data, documentSource: .external)
         documentBuilder.importMethod = .picker
@@ -41,7 +43,7 @@ internal final class FilePickerManager:NSObject {
         }
     }
     
-    // MARK: - Photo library permission
+    // MARK: Photo library permission
     
     fileprivate func checkPhotoLibraryAccessPermission(deniedHandler: @escaping (_ error: GiniVisionError) -> (), authorizedHandler: @escaping (() -> ())) {
         switch PHPhotoLibrary.authorizationStatus() {

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -145,6 +145,11 @@ import UIKit
     public var cameraCaptureButtonTitle = NSLocalizedStringPreferred("ginivision.camera.captureButton", comment: "Title for capture button in camera screen will be used exclusively for accessibility label")
     
     /**
+     Sets the descriptional text when photo library access was denied, advising the user to authorize the photo library access in the settings application.
+     */
+    public var photoLibraryAccessDeniedMessageText = NSLocalizedStringPreferred("ginivision.camera.filepicker.photoLibraryAccessDenied", comment: "This message is shown when Photo library permission is denied")
+    
+    /**
      Sets the descriptional text when camera access was denied, advising the user to authorize the camera in the settings application.
      */
     public var cameraNotAuthorizedText = NSLocalizedStringPreferred("ginivision.camera.notAuthorized", comment: "Description text when the camera is not authorized and the user is advised to change that in the settings app")

--- a/GiniVision/Classes/GiniError.swift
+++ b/GiniVision/Classes/GiniError.swift
@@ -39,7 +39,7 @@ public enum ReviewError: GiniVisionError {
 }
 
 /**
- Errors throw on the file picker
+ Errors thrown on the file picker
  */
 
 public enum FilePickerError: GiniVisionError {

--- a/GiniVision/Classes/GiniError.swift
+++ b/GiniVision/Classes/GiniError.swift
@@ -20,6 +20,9 @@ public enum CameraError: GiniVisionError {
     /// Camera can not be loaded because the user has denied authorization in the past.
     case notAuthorizedToUseDevice
     
+    /// Camera can not be loaded because the user has denied authorization in the past.
+    case notAuthorizedToAccessPhotoLibrary
+    
     /// No valid input device could be found for capturing.
     case noInputDevice
     

--- a/GiniVision/Classes/GiniError.swift
+++ b/GiniVision/Classes/GiniError.swift
@@ -20,9 +20,6 @@ public enum CameraError: GiniVisionError {
     /// Camera can not be loaded because the user has denied authorization in the past.
     case notAuthorizedToUseDevice
     
-    /// Camera can not be loaded because the user has denied authorization in the past.
-    case notAuthorizedToAccessPhotoLibrary
-    
     /// No valid input device could be found for capturing.
     case noInputDevice
     
@@ -39,6 +36,17 @@ public enum ReviewError: GiniVisionError {
     /// Unknown error during review.
     case unknown
     
+}
+
+/**
+ Errors throw on the file picker
+ */
+
+public enum FilePickerError: GiniVisionError {
+    
+    /// Camera roll can not be loaded because the user has denied authorization in the past.
+    case photoLibraryAccessDenied
+
 }
 
 /**


### PR DESCRIPTION
When photo library permission is denied, it should appear a dialog giving the chance to grant it on iOS settings.

### How to test
Reinstall app, choose _Fotos_ option on file import dialog and deny permissions. Then try again to open the Camera roll and see that the dialog appears.

### Merging
Automatic.

### Ticket 
Issue #65     
