### PR TITLE
Custom document validations

### DIFF
--- a/Example/GiniVision/SelectAPIViewController.swift
+++ b/Example/GiniVision/SelectAPIViewController.swift
@@ -93,9 +93,11 @@ class SelectAPIViewController: UIViewController {
         giniConfiguration.fileImportSupportedTypes = .pdf_and_images
         giniConfiguration.navigationBarItemTintColor = UIColor.white
         giniConfiguration.customDocumentValidations = { document in
-            print(document.type)
-            let previewImage = document.previewImage
-            print("Validate document")
+            // As an example of custom document validation, we add a more strict check for file size
+            let maxFileSize = 5 * 1024 * 1024
+            if document.data.count > maxFileSize {
+                throw DocumentValidationError.custom(message: "Diese Datei ist leider größer als 5MB")
+            }
         }
         
         // Make sure the app always behaves the same when run from UITests

--- a/Example/GiniVision/SelectAPIViewController.swift
+++ b/Example/GiniVision/SelectAPIViewController.swift
@@ -92,6 +92,11 @@ class SelectAPIViewController: UIViewController {
         giniConfiguration.debugModeOn = true
         giniConfiguration.fileImportSupportedTypes = .pdf_and_images
         giniConfiguration.navigationBarItemTintColor = UIColor.white
+        giniConfiguration.customDocumentValidations = { document in
+            print(document.type)
+            let previewImage = document.previewImage
+            print("Validate document")
+        }
         
         // Make sure the app always behaves the same when run from UITests
         if isUITest {

--- a/GiniVision/Classes/CameraContainerViewController.swift
+++ b/GiniVision/Classes/CameraContainerViewController.swift
@@ -29,7 +29,8 @@ internal class CameraContainerViewController: UIViewController, ContainerViewCon
         super.init(nibName: nil, bundle: nil)
         // Configure content controller and call delegate method on success
         contentController = CameraViewController(successBlock:
-            { document, isImported in
+            { [weak self ] document, isImported in
+                guard let `self` = self else { return }
                 let delegate = (self.navigationController as? GiniNavigationViewController)?.giniDelegate
                 let viewController:UIViewController
                 if isImported {

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -388,19 +388,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> ()
     
     fileprivate func showNotValidDocumentError(error: DocumentValidationError) {
         
-        let errorMessage:String
-        switch error {
-        case .exceededMaxFileSize:
-            errorMessage = GiniConfiguration.sharedConfiguration.documentValidationErrorExcedeedFileSize
-        case .pdfPageLengthExceeded:
-            errorMessage = GiniConfiguration.sharedConfiguration.documentValidationErrorTooManyPages
-        case .fileFormatNotValid, .imageFormatNotValid:
-            errorMessage = GiniConfiguration.sharedConfiguration.documentValidationErrorWrongFormat
-        default:
-            errorMessage = GiniConfiguration.sharedConfiguration.documentValidationErrorGeneral
-        }
-        
-        let alertViewController = UIAlertController(title: nil, message: errorMessage, preferredStyle: .alert)
+        let alertViewController = UIAlertController(title: nil, message: error.message, preferredStyle: .alert)
         alertViewController.addAction(UIAlertAction(title: "Abbrechen", style: .cancel, handler: { _ in
             alertViewController.dismiss(animated: true, completion: nil)
         }))

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -133,7 +133,7 @@ import UIKit
     public var documentValidationErrorWrongFormat = NSLocalizedStringPreferred("ginivision.camera.documentValidationError.wrongFormat", comment: "Message text error shown in camera screen when a file has a wrong format (neither PDF, JPEG, GIF, TIFF or PNG)")
 
     /**
-     Sets custom validations that can be done apart from the default ones (file size, file type...). It should throw a DocumentValidationError.custom(message) error
+     Sets custom validations that can be done apart from the default ones (file size, file type...). It should throw a `DocumentValidationError.custom(message)` error.
      */
     public var customDocumentValidations: ((GiniVisionDocument) throws -> ())? = { _ in}
     

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -133,6 +133,11 @@ import UIKit
     public var documentValidationErrorWrongFormat = NSLocalizedStringPreferred("ginivision.camera.documentValidationError.wrongFormat", comment: "Message text error shown in camera screen when a file has a wrong format (neither PDF, JPEG, GIF, TIFF or PNG)")
 
     /**
+     Sets custom validations that can be done apart from the default ones (file size, file type...). It should throw a DocumentValidationError.custom(message) error
+     */
+    public var customDocumentValidations: ((GiniVisionDocument) throws -> ())? = { _ in}
+    
+    /**
      Set the types supported by the file import feature. `none` by default
 
      */

--- a/GiniVision/Classes/GiniError.swift
+++ b/GiniVision/Classes/GiniError.swift
@@ -54,6 +54,24 @@ public enum FilePickerError: GiniVisionError {
  */
 public enum DocumentValidationError: GiniVisionError{
     
+    var message:String {
+        switch self {
+        case .exceededMaxFileSize:
+            print()
+            return GiniConfiguration.sharedConfiguration.documentValidationErrorExcedeedFileSize
+        case .imageFormatNotValid:
+            return GiniConfiguration.sharedConfiguration.documentValidationErrorWrongFormat
+        case .fileFormatNotValid:
+            return GiniConfiguration.sharedConfiguration.documentValidationErrorWrongFormat
+        case .pdfPageLengthExceeded:
+            return GiniConfiguration.sharedConfiguration.documentValidationErrorTooManyPages
+        case .custom(let message):
+            return message
+        case .unknown:
+            return GiniConfiguration.sharedConfiguration.documentValidationErrorGeneral
+        }
+    }
+    
     /// Unknown error during review.
     case unknown
     
@@ -68,6 +86,9 @@ public enum DocumentValidationError: GiniVisionError{
     
     /// PDF length exceeded
     case pdfPageLengthExceeded
+    
+    /// Custom validation error
+    case custom(message: String)
     
 }
 

--- a/GiniVision/Classes/GiniError.swift
+++ b/GiniVision/Classes/GiniError.swift
@@ -52,7 +52,25 @@ public enum FilePickerError: GiniVisionError {
 /**
  Errors thrown validating a document (image or pdf).
  */
-public enum DocumentValidationError: GiniVisionError{
+public enum DocumentValidationError: GiniVisionError, Equatable {
+    
+    /// Unknown error during review.
+    case unknown
+    
+    /// Exceeded max file size
+    case exceededMaxFileSize
+    
+    /// Image format not valid
+    case imageFormatNotValid
+    
+    /// File format not valid
+    case fileFormatNotValid
+    
+    /// PDF length exceeded
+    case pdfPageLengthExceeded
+    
+    /// Custom validation error
+    case custom(message: String)
     
     var message:String {
         switch self {
@@ -72,23 +90,9 @@ public enum DocumentValidationError: GiniVisionError{
         }
     }
     
-    /// Unknown error during review.
-    case unknown
-    
-    /// Exceeded max file size
-    case exceededMaxFileSize
-    
-    /// Image format not valid
-    case imageFormatNotValid
-    
-    /// File format not valid
-    case fileFormatNotValid
-    
-    /// PDF length exceeded
-    case pdfPageLengthExceeded
-    
-    /// Custom validation error
-    case custom(message: String)
+    public static func ==(lhs: DocumentValidationError, rhs: DocumentValidationError) -> Bool {
+        return lhs.message == rhs.message
+    }
     
 }
 

--- a/GiniVision/Classes/GiniError.swift
+++ b/GiniVision/Classes/GiniError.swift
@@ -75,7 +75,6 @@ public enum DocumentValidationError: GiniVisionError, Equatable {
     var message:String {
         switch self {
         case .exceededMaxFileSize:
-            print()
             return GiniConfiguration.sharedConfiguration.documentValidationErrorExcedeedFileSize
         case .imageFormatNotValid:
             return GiniConfiguration.sharedConfiguration.documentValidationErrorWrongFormat

--- a/GiniVision/Classes/GiniVisionDocument.swift
+++ b/GiniVision/Classes/GiniVisionDocument.swift
@@ -71,6 +71,11 @@ extension GiniVisionDocument {
         return 10 * 1024 * 1024
     }
     
+
+    fileprivate var customDocumentValidations: ((GiniVisionDocument) throws -> ())? {
+        return GiniConfiguration.sharedConfiguration.customDocumentValidations
+    }
+    
     // MARK: File validation
     /**
      Validates a document, checking if it has the correct size and type.
@@ -83,6 +88,7 @@ extension GiniVisionDocument {
         let document = self
         if !maxFileSizeExceeded(forData: document.data) {
             try checkType()
+            try customDocumentValidations?(self)
         } else {
             throw DocumentValidationError.exceededMaxFileSize
         }

--- a/GiniVision/Classes/GiniVisionDocument.swift
+++ b/GiniVision/Classes/GiniVisionDocument.swift
@@ -77,10 +77,9 @@ extension GiniVisionDocument {
     
     // MARK: File validation
     /**
-     Validates a document, checking if it has the correct size and type.
+     Validates a document. The validation process is done in the _global_ `DispatchQueue`.
      
-     - Throws: `DocumentValidationError.exceededMaxFileSize` if the size exceeds the max file size
-     Also throws type validation errors, see `checkType` implementations
+     - Throws: `DocumentValidationError.exceededMaxFileSize` is thrown if the document is not valid.
      
      */
     public func validate() throws {

--- a/GiniVision/Classes/GiniVisionDocument.swift
+++ b/GiniVision/Classes/GiniVisionDocument.swift
@@ -70,7 +70,6 @@ extension GiniVisionDocument {
     fileprivate var MAX_FILE_SIZE:Int { // Bytes
         return 10 * 1024 * 1024
     }
-    
 
     fileprivate var customDocumentValidations: ((GiniVisionDocument) throws -> ())? {
         return GiniConfiguration.sharedConfiguration.customDocumentValidations


### PR DESCRIPTION
Apart from the default document validations (file size, file type...), there should be possible to add custom validations.

### How to test
Open the example app, go to the camera screen (either Screen or Component API) and try to import a file with a size higher than 5MB.

### Merging
Automatic.

### Ticket 
Issue #82       