### PR TITLE
Minor fixes

### DIFF
--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -93,7 +93,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     fileprivate lazy var previewView: CameraPreviewView = {
         let previewView = CameraPreviewView()
         (previewView.layer as? AVCaptureVideoPreviewLayer)?.videoGravity = AVLayerVideoGravityResizeAspectFill
-        (previewView.layer as? AVCaptureVideoPreviewLayer)?.connection?.videoOrientation = self.getVideoOrientation()
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(focusAndExposeTap))
         previewView.addGestureRecognizer(tapGesture)
         return previewView
@@ -223,6 +222,8 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     public override func viewDidLoad() {
         super.viewDidLoad()
         
+        updatePreviewViewOrientation() // Video orientation should be updated once the view has been loaded
+        
         if GiniConfiguration.sharedConfiguration.fileImportSupportedTypes != .none {
             enableFileImport()
             if ToolTipView.shouldShowFileImportToolTip {
@@ -274,8 +275,8 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
             guard let `self` = self else {
                 return 
             }
-            let previewLayer = (self.previewView.layer as? AVCaptureVideoPreviewLayer)
-            previewLayer?.connection?.videoOrientation = self.getVideoOrientation()
+            
+            self.updatePreviewViewOrientation()
             self.toolTipView?.arrangeViews()
             
         })
@@ -394,11 +395,16 @@ extension CameraViewController {
         
     }
     
-    fileprivate func getVideoOrientation() -> AVCaptureVideoOrientation {
+    fileprivate func updatePreviewViewOrientation() {
+        let orientation: AVCaptureVideoOrientation
         if UIDevice.current.isIpad {
-            return interfaceOrientationsMapping[UIApplication.shared.statusBarOrientation] ?? .portrait
+            orientation =  interfaceOrientationsMapping[UIApplication.shared.statusBarOrientation] ?? .portrait
+        } else {
+            orientation = .portrait
         }
-        return .portrait
+        
+        let previewLayer = (self.previewView.layer as? AVCaptureVideoPreviewLayer)
+        previewLayer?.connection?.videoOrientation = orientation
     }
     
     fileprivate func showPopup(forQRDetected qrDocument: GiniQRCodeDocument) {

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -56,6 +56,7 @@ internal final class FilePickerManager: NSObject {
     
     fileprivate func checkPhotoLibraryAccessPermission(deniedHandler: @escaping (_ error: GiniVisionError) -> Void,
                                                        authorizedHandler: @escaping (() -> Void)) {
+        
         switch PHPhotoLibrary.authorizationStatus() {
         case .authorized:
             authorizedHandler()
@@ -63,10 +64,12 @@ internal final class FilePickerManager: NSObject {
             deniedHandler(FilePickerError.photoLibraryAccessDenied)
         case .notDetermined:
             PHPhotoLibrary.requestAuthorization { status in
-                if status == PHAuthorizationStatus.authorized {
-                    authorizedHandler()
-                } else {
-                    deniedHandler(FilePickerError.photoLibraryAccessDenied)
+                DispatchQueue.main.async {
+                    if status == PHAuthorizationStatus.authorized {
+                        authorizedHandler()
+                    } else {
+                        deniedHandler(FilePickerError.photoLibraryAccessDenied)
+                    }
                 }
             }
         }

--- a/GiniVision/Classes/GiniVision.swift
+++ b/GiniVision/Classes/GiniVision.swift
@@ -109,7 +109,7 @@ import UIKit
     }
     
     /**
-     Returns a navigation view controller with the camera screen loaded and ready to go. It's the
+     Returns a view controller with the camera screen loaded and ready to go. It's the
      easiest way to get started with the Gini Vision Library as it comes pre-configured and handles
      all screens and transitions out of the box.
      
@@ -119,7 +119,7 @@ import UIKit
      - parameter importedDocument:  A document which comes from a source different than CameraViewController.
      It should be validated before calling this method.
      
-     - returns: A presentable navigation view controller.
+     - returns: A presentable view controller.
      */
     public class func viewController(withDelegate delegate: GiniVisionDelegate,
                                      importedDocument: GiniVisionDocument? = nil) -> UIViewController {
@@ -129,7 +129,7 @@ import UIKit
     }
     
     /**
-     Returns a navigation view controller with the camera screen loaded and ready to go.
+     Returns a view controller with the camera screen loaded and ready to go.
      Allows to set a custom configuration to change the look and feel of the Gini Vision Library.
      
      - note: Screen API only.
@@ -139,7 +139,7 @@ import UIKit
      - parameter importedDocument:  A document which comes from a source different than CameraViewController.
      It should be validated before calling this method.
      
-     - returns: A presentable navigation view controller.
+     - returns: A presentable view controller.
      */
     public class func viewController(withDelegate delegate: GiniVisionDelegate,
                                      withConfiguration configuration: GiniConfiguration,


### PR DESCRIPTION
- On iOS 9 devices when trying to open the Gallery for the first time, after granting the permissions the gallery is not shown.
- Camera preview orientation is not correct when capturing is initialized on landscape (only iPad).

Also clarified documentation for GiniVision class.

### How to test
Run the example app, rotate the device to landscape orientation and open either Screen API or Component API to see that the camera has the correct orientation. 
Also with an iOS 9 device which has never had the app installed (this is important, permissions flags are not reset after uninstalling), run the app and import a picture from the gallery.

### Merging
Automatic.
 
### Issues
Issue #141 