### PR TITLE
Feature custom status bar

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,9 +5,11 @@ PODS:
   - Bolts/AppLinks (1.1.5):
     - Bolts/Tasks
   - Bolts/Tasks (1.1.5)
-  - Gini-iOS-SDK (0.5.2):
-    - Bolts (~> 1.1.0)
-  - GiniVision (3.2.3)
+  - Gini-iOS-SDK (0.6.0):
+    - Gini-iOS-SDK/Core (= 0.6.0)
+  - Gini-iOS-SDK/Core (0.6.0):
+    - Bolts (~> 1.1.5)
+  - GiniVision (3.3.1)
 
 DEPENDENCIES:
   - Gini-iOS-SDK
@@ -19,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
-  Gini-iOS-SDK: 704fb5fb7472b45d675a04c43e40a73732dd3d40
-  GiniVision: c1ef4934e8cf2ac9ca728f33619a9450a7175682
+  Gini-iOS-SDK: 75c35076dbbdeff5b7ac8c90b8cbd63274dbc209
+  GiniVision: b91a085e9628bb6fb9d7fdf6894e8d423b3de591
 
 PODFILE CHECKSUM: a87c082243c89b1f7c8c2bdf8399a28021b79b71
 

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -247,7 +247,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
      */
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setStatusBarStyleIfNeeded(to: GiniConfiguration.sharedConfiguration.statusBarStyle)
+        setStatusBarStyle(to: GiniConfiguration.sharedConfiguration.statusBarStyle)
         camera?.start()
     }
     

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -247,7 +247,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
      */
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        setStatusBarStyleIfNeeded(to: GiniConfiguration.sharedConfiguration.statusBarStyle)
         camera?.start()
     }
     

--- a/GiniVision/Classes/ContainerNavigationController.swift
+++ b/GiniVision/Classes/ContainerNavigationController.swift
@@ -32,6 +32,7 @@ final class ContainerNavigationController: UIViewController {
         self.rootViewController = rootViewController
         self.coordinator = parent
         self.giniConfiguration = giniConfiguration
+        setStatusBarStyleIfNeeded(to: giniConfiguration.statusBarStyle)
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/GiniVision/Classes/ContainerNavigationController.swift
+++ b/GiniVision/Classes/ContainerNavigationController.swift
@@ -12,6 +12,7 @@ final class ContainerNavigationController: UIViewController {
     
     var rootViewController: UINavigationController
     var coordinator: GiniScreenAPICoordinator?
+    var giniConfiguration: GiniConfiguration
     
     override var shouldAutorotate: Bool {
         return true
@@ -21,9 +22,16 @@ final class ContainerNavigationController: UIViewController {
         return UIDevice.current.isIpad ? .all : .portrait
     }
     
-    init(rootViewController: UINavigationController, parent: GiniScreenAPICoordinator) {
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        return giniConfiguration.statusBarStyle
+    }
+    
+    init(rootViewController: UINavigationController,
+         parent: GiniScreenAPICoordinator,
+         giniConfiguration: GiniConfiguration = GiniConfiguration.sharedConfiguration) {
         self.rootViewController = rootViewController
         self.coordinator = parent
+        self.giniConfiguration = giniConfiguration
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/GiniVision/Classes/ContainerNavigationController.swift
+++ b/GiniVision/Classes/ContainerNavigationController.swift
@@ -32,7 +32,7 @@ final class ContainerNavigationController: UIViewController {
         self.rootViewController = rootViewController
         self.coordinator = parent
         self.giniConfiguration = giniConfiguration
-        setStatusBarStyleIfNeeded(to: giniConfiguration.statusBarStyle)
+        setStatusBarStyle(to: giniConfiguration.statusBarStyle)
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -26,18 +26,25 @@ internal final class FilePickerManager: NSObject {
     
     // MARK: Picker presentation
     
-    func showGalleryPicker(from: UIViewController, errorHandler: @escaping (_ error: GiniVisionError) -> Void) {
+    func showGalleryPicker(from: UIViewController,
+                           giniConfiguration: GiniConfiguration = GiniConfiguration.sharedConfiguration,
+                           errorHandler: @escaping (_ error: GiniVisionError) -> Void) {
         checkPhotoLibraryAccessPermission(deniedHandler: errorHandler) {
             let imagePicker: UIImagePickerController = UIImagePickerController()
             imagePicker.sourceType = .photoLibrary
             imagePicker.delegate = self
+            setStatusBarStyleIfNeeded(to: .default)
+            
             from.present(imagePicker, animated: true, completion: nil)
         }
     }
     
-    func showDocumentPicker(from: UIViewController) {
+    func showDocumentPicker(from: UIViewController,
+                            giniConfiguration: GiniConfiguration = GiniConfiguration.sharedConfiguration) {
         let documentPicker = UIDocumentPickerViewController(documentTypes: acceptedDocumentTypes, in: .import)
         documentPicker.delegate = self
+        setStatusBarStyleIfNeeded(to: .default)
+
         from.present(documentPicker, animated: true, completion: nil)
     }
     

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -33,7 +33,7 @@ internal final class FilePickerManager: NSObject {
             let imagePicker: UIImagePickerController = UIImagePickerController()
             imagePicker.sourceType = .photoLibrary
             imagePicker.delegate = self
-            setStatusBarStyleIfNeeded(to: .default)
+            setStatusBarStyle(to: .default)
             
             from.present(imagePicker, animated: true, completion: nil)
         }
@@ -43,7 +43,7 @@ internal final class FilePickerManager: NSObject {
                             giniConfiguration: GiniConfiguration = GiniConfiguration.sharedConfiguration) {
         let documentPicker = UIDocumentPickerViewController(documentTypes: acceptedDocumentTypes, in: .import)
         documentPicker.delegate = self
-        setStatusBarStyleIfNeeded(to: .default)
+        setStatusBarStyle(to: .default)
 
         from.present(documentPicker, animated: true, completion: nil)
     }

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -188,6 +188,15 @@ import UIKit
      */
     public var qrCodeScanningEnabled = false
     
+    /**
+     Indicates the status bar style on the Gini Vision Library.
+     
+     - note: If `UIViewControllerBasedStatusBarAppearance` is set to `false` in the `Info.plist`,
+     it may not work in further versions of iOS since `UIApplication.setStatusBarStyle` method was
+     deprecated on iOS 9.0
+     */
+    public var statusBarStyle = UIStatusBarStyle.lightContent
+    
     // MARK: Camera options
     
     /**

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -189,10 +189,10 @@ import UIKit
     public var qrCodeScanningEnabled = false
     
     /**
-     Indicates the status bar style on the Gini Vision Library.
+     Indicates the status bar style in the Gini Vision Library.
      
      - note: If `UIViewControllerBasedStatusBarAppearance` is set to `false` in the `Info.plist`,
-     it may not work in further versions of iOS since `UIApplication.setStatusBarStyle` method was
+     it may not work in future versions of iOS since the `UIApplication.setStatusBarStyle` method was
      deprecated on iOS 9.0
      */
     public var statusBarStyle = UIStatusBarStyle.lightContent

--- a/GiniVision/Classes/GiniVisionUtils.swift
+++ b/GiniVision/Classes/GiniVisionUtils.swift
@@ -160,3 +160,24 @@ internal struct Colors {
         )
     }
 }
+
+/**
+    Set the status bar style when ViewControllerBasedStatusBarAppearance is disabled.
+ */
+
+internal func setStatusBarStyleIfNeeded(to statusBarStyle: UIStatusBarStyle,
+                                        application: UIApplication = UIApplication.shared) {
+    if !isViewControllerBasedStatusBarStyleEnabled {
+        application.setStatusBarStyle(statusBarStyle, animated: true)
+    }
+}
+
+private let isViewControllerBasedStatusBarStyleEnabled: Bool = {
+    if let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
+        let dict = NSDictionary(contentsOfFile: path) as? [String: Any],
+        let viewControllerBasedStatusBarStyleEnabled = dict["UIViewControllerBasedStatusBarAppearance"] as? Bool {
+        return viewControllerBasedStatusBarStyleEnabled
+    }
+    
+    return true
+}()

--- a/GiniVision/Classes/GiniVisionUtils.swift
+++ b/GiniVision/Classes/GiniVisionUtils.swift
@@ -163,21 +163,10 @@ internal struct Colors {
 
 /**
     Set the status bar style when ViewControllerBasedStatusBarAppearance is disabled.
+    If it is enabled it will not have effect.
  */
 
-internal func setStatusBarStyleIfNeeded(to statusBarStyle: UIStatusBarStyle,
-                                        application: UIApplication = UIApplication.shared) {
-    if !isViewControllerBasedStatusBarStyleEnabled {
-        application.setStatusBarStyle(statusBarStyle, animated: true)
-    }
+internal func setStatusBarStyle(to statusBarStyle: UIStatusBarStyle,
+                                application: UIApplication = UIApplication.shared) {
+    application.setStatusBarStyle(statusBarStyle, animated: true)
 }
-
-private let isViewControllerBasedStatusBarStyleEnabled: Bool = {
-    if let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
-        let dict = NSDictionary(contentsOfFile: path) as? [String: Any],
-        let viewControllerBasedStatusBarStyleEnabled = dict["UIViewControllerBasedStatusBarAppearance"] as? Bool {
-        return viewControllerBasedStatusBarStyleEnabled
-    }
-    
-    return true
-}()


### PR DESCRIPTION
Added status bar style setting to GiniConfiguration, so now it can be customized. It works both when `UIViewControllerBasedStatusBarAppearance` is enabled and disabled. 

### How to test
Run the example app with `UIViewControllerBasedStatusBarAppearance` as NO in the Info.plist file. Check that status bar changes once the GVL is launched.
Do the same but with `UIViewControllerBasedStatusBarAppearance` as `YES` and check that it is also working.

### Merging
Automatic.
 
### Issues
Issue #144  