### PR TITLE
Fix Constraints class typo

### DIFF
--- a/GiniVision/Classes/AnalysisViewController.swift
+++ b/GiniVision/Classes/AnalysisViewController.swift
@@ -182,33 +182,33 @@ import UIKit
         self.view.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
-        Contraints.active(item: imageView, attr: .top, relatedBy: .equal, to: self.topLayoutGuide, attr: .bottom,
+        Constraints.active(item: imageView, attr: .top, relatedBy: .equal, to: self.topLayoutGuide, attr: .bottom,
                           priority: 999)
-        Contraints.active(item: imageView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide, attr: .top,
+        Constraints.active(item: imageView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide, attr: .top,
                           priority: 999)
-        Contraints.active(item: imageView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
-        Contraints.active(item: imageView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
+        Constraints.active(item: imageView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
+        Constraints.active(item: imageView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
     }
     
     fileprivate func addOverlay() {
         self.view.insertSubview(overlayView, aboveSubview: imageView)
         overlayView.translatesAutoresizingMaskIntoConstraints = false
         
-        Contraints.active(item: overlayView, attr: .top, relatedBy: .equal, to: imageView, attr: .top)
-        Contraints.active(item: overlayView, attr: .trailing, relatedBy: .equal, to: imageView, attr: .trailing)
-        Contraints.active(item: overlayView, attr: .bottom, relatedBy: .equal, to: imageView, attr: .bottom)
-        Contraints.active(item: overlayView, attr: .leading, relatedBy: .equal, to: imageView, attr: .leading)
+        Constraints.active(item: overlayView, attr: .top, relatedBy: .equal, to: imageView, attr: .top)
+        Constraints.active(item: overlayView, attr: .trailing, relatedBy: .equal, to: imageView, attr: .trailing)
+        Constraints.active(item: overlayView, attr: .bottom, relatedBy: .equal, to: imageView, attr: .bottom)
+        Constraints.active(item: overlayView, attr: .leading, relatedBy: .equal, to: imageView, attr: .leading)
     }
     
     fileprivate func addLoadingText(below: UIView) {
         self.view.addSubview(loadingIndicatorText)
         loadingIndicatorText.translatesAutoresizingMaskIntoConstraints = false
         
-        Contraints.active(item: loadingIndicatorText, attr: .trailing, relatedBy: .equal, to: imageView,
+        Constraints.active(item: loadingIndicatorText, attr: .trailing, relatedBy: .equal, to: imageView,
                           attr: .trailing)
-        Contraints.active(item: loadingIndicatorText, attr: .top, relatedBy: .equal, to: below, attr: .bottom,
+        Constraints.active(item: loadingIndicatorText, attr: .top, relatedBy: .equal, to: below, attr: .bottom,
                           constant: 16)
-        Contraints.active(item: loadingIndicatorText, attr: .leading, relatedBy: .equal, to: imageView, attr: .leading)
+        Constraints.active(item: loadingIndicatorText, attr: .leading, relatedBy: .equal, to: imageView, attr: .leading)
     }
     
     fileprivate func addLoadingView(intoContainer container: UIView? = nil) {
@@ -219,22 +219,22 @@ import UIKit
             self.view.addSubview(container)
             container.addSubview(loadingIndicatorView)
             
-            Contraints.active(item: container, attr: .centerX, relatedBy: .equal, to: self.view, attr: .centerX)
-            Contraints.active(item: container, attr: .centerY, relatedBy: .equal, to: self.view, attr: .centerY)
-            Contraints.active(item: container, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+            Constraints.active(item: container, attr: .centerX, relatedBy: .equal, to: self.view, attr: .centerX)
+            Constraints.active(item: container, attr: .centerY, relatedBy: .equal, to: self.view, attr: .centerY)
+            Constraints.active(item: container, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                               constant: AnalysisViewController.loadingIndicatorContainerHeight)
-            Contraints.active(item: container, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+            Constraints.active(item: container, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                               constant: AnalysisViewController.loadingIndicatorContainerHeight)
-            Contraints.active(item: loadingIndicatorView, attr: .centerX, relatedBy: .equal, to: container,
+            Constraints.active(item: loadingIndicatorView, attr: .centerX, relatedBy: .equal, to: container,
                               attr: .centerX, constant: 1.5)
-            Contraints.active(item: loadingIndicatorView, attr: .centerY, relatedBy: .equal, to: container,
+            Constraints.active(item: loadingIndicatorView, attr: .centerY, relatedBy: .equal, to: container,
                               attr: .centerY, constant: 1.5)
             
         } else {
             self.view.addSubview(loadingIndicatorView)
-            Contraints.active(item: loadingIndicatorView, attr: .centerX, relatedBy: .equal, to: self.view,
+            Constraints.active(item: loadingIndicatorView, attr: .centerX, relatedBy: .equal, to: self.view,
                               attr: .centerX)
-            Contraints.active(item: loadingIndicatorView, attr: .centerY, relatedBy: .equal, to: self.view,
+            Constraints.active(item: loadingIndicatorView, attr: .centerY, relatedBy: .equal, to: self.view,
                               attr: .centerY)
         }
     }

--- a/GiniVision/Classes/CameraNotAuthorizedView.swift
+++ b/GiniVision/Classes/CameraNotAuthorizedView.swift
@@ -77,41 +77,41 @@ internal class CameraNotAuthorizedView: UIView {
         
         // Content view
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: contentView, attr: .top, relatedBy: .greaterThanOrEqual, to: superview, attr: .top,
+        Constraints.active(item: contentView, attr: .top, relatedBy: .greaterThanOrEqual, to: superview, attr: .top,
                           constant: 30)
-        Contraints.active(item: contentView, attr: .centerX, relatedBy: .equal, to: superview, attr: .centerX)
-        Contraints.active(item: contentView, attr: .centerY, relatedBy: .equal, to: superview, attr: .centerY,
+        Constraints.active(item: contentView, attr: .centerX, relatedBy: .equal, to: superview, attr: .centerX)
+        Constraints.active(item: contentView, attr: .centerY, relatedBy: .equal, to: superview, attr: .centerY,
                           constant: 5, priority: 999)
         
         // Image view
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: imageView, attr: .top, relatedBy: .equal, to: contentView, attr: .top)
-        Contraints.active(item: imageView, attr: .width, relatedBy: .lessThanOrEqual, to: nil, attr: .width,
+        Constraints.active(item: imageView, attr: .top, relatedBy: .equal, to: contentView, attr: .top)
+        Constraints.active(item: imageView, attr: .width, relatedBy: .lessThanOrEqual, to: nil, attr: .width,
                           constant: 204)
-        Contraints.active(item: imageView, attr: .width, relatedBy: .greaterThanOrEqual, to: nil, attr: .width,
+        Constraints.active(item: imageView, attr: .width, relatedBy: .greaterThanOrEqual, to: nil, attr: .width,
                           constant: 75)
-        Contraints.active(item: imageView, attr: .height, relatedBy: .lessThanOrEqual, to: nil, attr: .height,
+        Constraints.active(item: imageView, attr: .height, relatedBy: .lessThanOrEqual, to: nil, attr: .height,
                           constant: 75)
-        Contraints.active(item: imageView, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
+        Constraints.active(item: imageView, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
                           constant: 50)
-        Contraints.active(item: imageView, attr: .centerX, relatedBy: .equal, to: contentView, attr: .centerX)
+        Constraints.active(item: imageView, attr: .centerX, relatedBy: .equal, to: contentView, attr: .centerX)
         
         // Text label
         label.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: label, attr: .top, relatedBy: .equal, to: imageView, attr: .bottom, constant: 35)
-        Contraints.active(item: label, attr: .trailing, relatedBy: .equal, to: contentView, attr: .trailing)
-        Contraints.active(item: label, attr: .leading, relatedBy: .equal, to: contentView, attr: .leading)
-        Contraints.active(item: label, attr: .width, relatedBy: .equal, to: nil, attr: .width, constant: 250)
-        Contraints.active(item: label, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
+        Constraints.active(item: label, attr: .top, relatedBy: .equal, to: imageView, attr: .bottom, constant: 35)
+        Constraints.active(item: label, attr: .trailing, relatedBy: .equal, to: contentView, attr: .trailing)
+        Constraints.active(item: label, attr: .leading, relatedBy: .equal, to: contentView, attr: .leading)
+        Constraints.active(item: label, attr: .width, relatedBy: .equal, to: nil, attr: .width, constant: 250)
+        Constraints.active(item: label, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
                           constant: 70)
         
         // Button
         button.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: button, attr: .top, relatedBy: .equal, to: label, attr: .bottom, constant: 10)
-        Contraints.active(item: button, attr: .bottom, relatedBy: .equal, to: contentView, attr: .bottom)
-        Contraints.active(item: button, attr: .width, relatedBy: .equal, to: label, attr: .width)
-        Contraints.active(item: button, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 35)
-        Contraints.active(item: button, attr: .centerX, relatedBy: .equal, to: contentView, attr: .centerX)
+        Constraints.active(item: button, attr: .top, relatedBy: .equal, to: label, attr: .bottom, constant: 10)
+        Constraints.active(item: button, attr: .bottom, relatedBy: .equal, to: contentView, attr: .bottom)
+        Constraints.active(item: button, attr: .width, relatedBy: .equal, to: label, attr: .width)
+        Constraints.active(item: button, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 35)
+        Constraints.active(item: button, attr: .centerX, relatedBy: .equal, to: contentView, attr: .centerX)
     }
     
 }

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -661,16 +661,16 @@ extension CameraViewController {
         previewView.translatesAutoresizingMaskIntoConstraints = false
         
         if UIDevice.current.isIpad {
-            Contraints.active(item: previewView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
-            Contraints.active(item: previewView, attr: .bottom, relatedBy: .equal, to: self.view, attr: .bottom)
-            Contraints.active(item: previewView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
-            Contraints.active(item: previewView, attr: .trailing, relatedBy: .equal, to: controlsView, attr: .leading,
+            Constraints.active(item: previewView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
+            Constraints.active(item: previewView, attr: .bottom, relatedBy: .equal, to: self.view, attr: .bottom)
+            Constraints.active(item: previewView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
+            Constraints.active(item: previewView, attr: .trailing, relatedBy: .equal, to: controlsView, attr: .leading,
                               priority: 750)
         } else {
             // lower priority constraints - will make the preview "want" to get bigger
-            Contraints.active(item: previewView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
-            Contraints.active(item: previewView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
-            Contraints.active(item: previewView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
+            Constraints.active(item: previewView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
+            Constraints.active(item: previewView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
+            Constraints.active(item: previewView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
         }
     }
     
@@ -678,37 +678,37 @@ extension CameraViewController {
         controlsView.translatesAutoresizingMaskIntoConstraints = false
         
         if UIDevice.current.isIpad {
-            Contraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
-            Contraints.active(item: controlsView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
-            Contraints.active(item: controlsView, attr: .bottom, relatedBy: .equal, to: self.view, attr: .bottom)
-            Contraints.active(item: controlsView, attr: .leading, relatedBy: .equal, to: previewView, attr: .trailing,
+            Constraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
+            Constraints.active(item: controlsView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
+            Constraints.active(item: controlsView, attr: .bottom, relatedBy: .equal, to: self.view, attr: .bottom)
+            Constraints.active(item: controlsView, attr: .leading, relatedBy: .equal, to: previewView, attr: .trailing,
                               priority: 750)
         } else {
-            Contraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: previewView, attr: .bottom)
-            Contraints.active(item: controlsView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide,
+            Constraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: previewView, attr: .bottom)
+            Constraints.active(item: controlsView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide,
                               attr: .top)
-            Contraints.active(item: controlsView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
-            Contraints.active(item: controlsView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
+            Constraints.active(item: controlsView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
+            Constraints.active(item: controlsView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
         }
     }
     
     fileprivate func addControlsViewButtonsConstraints() {
         captureButton.translatesAutoresizingMaskIntoConstraints = false
         
-        Contraints.active(item: captureButton, attr: .width, relatedBy: .equal, to: nil, attr: .width, constant: 70)
-        Contraints.active(item: captureButton, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 70)
+        Constraints.active(item: captureButton, attr: .width, relatedBy: .equal, to: nil, attr: .width, constant: 70)
+        Constraints.active(item: captureButton, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 70)
         
         if UIDevice.current.isIpad {
-            Contraints.active(item: captureButton, attr: .centerY, relatedBy: .equal, to: controlsView, attr: .centerY)
-            Contraints.active(item: captureButton, attr: .trailing, relatedBy: .equal, to: controlsView,
+            Constraints.active(item: captureButton, attr: .centerY, relatedBy: .equal, to: controlsView, attr: .centerY)
+            Constraints.active(item: captureButton, attr: .trailing, relatedBy: .equal, to: controlsView,
                               attr: .trailing, constant: -16)
-            Contraints.active(item: captureButton, attr: .leading, relatedBy: .equal, to: controlsView, attr: .leading,
+            Constraints.active(item: captureButton, attr: .leading, relatedBy: .equal, to: controlsView, attr: .leading,
                               constant: 16, priority: 750)
         } else {
-            Contraints.active(item: captureButton, attr: .centerX, relatedBy: .equal, to: controlsView, attr: .centerX)
-            Contraints.active(item: captureButton, attr: .top, relatedBy: .equal, to: controlsView, attr: .top,
+            Constraints.active(item: captureButton, attr: .centerX, relatedBy: .equal, to: controlsView, attr: .centerX)
+            Constraints.active(item: captureButton, attr: .top, relatedBy: .equal, to: controlsView, attr: .top,
                               constant: 16)
-            Contraints.active(item: captureButton, attr: .bottom, relatedBy: .equal, to: controlsView, attr: .bottom,
+            Constraints.active(item: captureButton, attr: .bottom, relatedBy: .equal, to: controlsView, attr: .bottom,
                               constant: -16, priority: 750)
         }
     }
@@ -716,18 +716,18 @@ extension CameraViewController {
     fileprivate func addImportButtonConstraints() {
         importFileButton.translatesAutoresizingMaskIntoConstraints = false
         if UIDevice.current.isIpad {
-            Contraints.active(item: importFileButton, attr: .trailing, relatedBy: .equal, to: controlsView,
+            Constraints.active(item: importFileButton, attr: .trailing, relatedBy: .equal, to: controlsView,
                               attr: .trailing)
-            Contraints.active(item: importFileButton, attr: .leading, relatedBy: .equal, to: controlsView,
+            Constraints.active(item: importFileButton, attr: .leading, relatedBy: .equal, to: controlsView,
                               attr: .leading)
-            Contraints.active(item: importFileButton, attr: .top, relatedBy: .equal, to: captureButton,
+            Constraints.active(item: importFileButton, attr: .top, relatedBy: .equal, to: captureButton,
                               attr: .bottom, constant: 60)
         } else {
-            Contraints.active(item: importFileButton, attr: .centerY, relatedBy: .equal, to: controlsView,
+            Constraints.active(item: importFileButton, attr: .centerY, relatedBy: .equal, to: controlsView,
                               attr: .centerY, priority: 750)
-            Contraints.active(item: importFileButton, attr: .leading, relatedBy: .equal, to: controlsView,
+            Constraints.active(item: importFileButton, attr: .leading, relatedBy: .equal, to: controlsView,
                               attr: .leading)
-            Contraints.active(item: importFileButton, attr: .trailing, relatedBy: .equal, to: captureButton,
+            Constraints.active(item: importFileButton, attr: .trailing, relatedBy: .equal, to: captureButton,
                               attr: .leading, priority: 750)
         }
     }
@@ -743,10 +743,10 @@ extension CameraViewController {
         super.view.addSubview(view)
         
         view.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: view, attr: .width, relatedBy: .equal, to: super.view, attr: .width)
-        Contraints.active(item: view, attr: .height, relatedBy: .equal, to: super.view, attr: .height)
-        Contraints.active(item: view, attr: .centerX, relatedBy: .equal, to: super.view, attr: .centerX)
-        Contraints.active(item: view, attr: .centerY, relatedBy: .equal, to: super.view, attr: .centerY)
+        Constraints.active(item: view, attr: .width, relatedBy: .equal, to: super.view, attr: .width)
+        Constraints.active(item: view, attr: .height, relatedBy: .equal, to: super.view, attr: .height)
+        Constraints.active(item: view, attr: .centerX, relatedBy: .equal, to: super.view, attr: .centerX)
+        Constraints.active(item: view, attr: .centerY, relatedBy: .equal, to: super.view, attr: .centerY)
         
         // Hide camera UI
         hideCameraOverlay()
@@ -762,9 +762,9 @@ extension CameraViewController {
         previewView.addSubview(defaultImageView)
         
         defaultImageView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: defaultImageView, attr: .width, relatedBy: .equal, to: previewView, attr: .width)
-        Contraints.active(item: defaultImageView, attr: .height, relatedBy: .equal, to: previewView, attr: .height)
-        Contraints.active(item: defaultImageView, attr: .centerX, relatedBy: .equal, to: previewView, attr: .centerX)
-        Contraints.active(item: defaultImageView, attr: .centerY, relatedBy: .equal, to: previewView, attr: .centerY)
+        Constraints.active(item: defaultImageView, attr: .width, relatedBy: .equal, to: previewView, attr: .width)
+        Constraints.active(item: defaultImageView, attr: .height, relatedBy: .equal, to: previewView, attr: .height)
+        Constraints.active(item: defaultImageView, attr: .centerX, relatedBy: .equal, to: previewView, attr: .centerX)
+        Constraints.active(item: defaultImageView, attr: .centerY, relatedBy: .equal, to: previewView, attr: .centerY)
     }
 }

--- a/GiniVision/Classes/CaptureSuggestionsCollectionCell.swift
+++ b/GiniVision/Classes/CaptureSuggestionsCollectionCell.swift
@@ -37,22 +37,22 @@ final class CaptureSuggestionsCollectionCell: UICollectionViewCell {
     }
     
     private func addConstraints() {
-        Contraints.active(item: suggestionImage, attr: .top, relatedBy: .equal, to: self, attr: .top, priority: 999)
-        Contraints.active(item: suggestionImage, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
+        Constraints.active(item: suggestionImage, attr: .top, relatedBy: .equal, to: self, attr: .top, priority: 999)
+        Constraints.active(item: suggestionImage, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
                           priority: 999)
-        Contraints.active(item: suggestionImage, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
+        Constraints.active(item: suggestionImage, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
                           constant: 20)
-        Contraints.active(item: suggestionImage, attr: .trailing, relatedBy: .equal, to: suggestionText,
+        Constraints.active(item: suggestionImage, attr: .trailing, relatedBy: .equal, to: suggestionText,
                           attr: .leading, constant: -20)
-        Contraints.active(item: suggestionImage, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: suggestionImage, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: 85)
-        Contraints.active(item: suggestionImage, attr: .height, relatedBy: .lessThanOrEqual, to: nil,
+        Constraints.active(item: suggestionImage, attr: .height, relatedBy: .lessThanOrEqual, to: nil,
                           attr: .notAnAttribute, constant: 85)
-        Contraints.active(item: suggestionImage, attr: .centerY, relatedBy: .equal, to: self, attr: .centerY)
+        Constraints.active(item: suggestionImage, attr: .centerY, relatedBy: .equal, to: self, attr: .centerY)
         
-        Contraints.active(item: suggestionText, attr: .top, relatedBy: .equal, to: self, attr: .top)
-        Contraints.active(item: suggestionText, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
-        Contraints.active(item: suggestionText, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: suggestionText, attr: .top, relatedBy: .equal, to: self, attr: .top)
+        Constraints.active(item: suggestionText, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
+        Constraints.active(item: suggestionText, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -20, priority: 999)
     }
 }

--- a/GiniVision/Classes/CaptureSuggestionsCollectionHeader.swift
+++ b/GiniVision/Classes/CaptureSuggestionsCollectionHeader.swift
@@ -87,54 +87,54 @@ final class CaptureSuggestionsCollectionHeader: UICollectionReusableView {
     
     private func addConstraints() {
         // Top view container bottom line
-        Contraints.active(item: topViewContainerBottomLine, attr: .height, relatedBy: .equal, to: nil,
+        Constraints.active(item: topViewContainerBottomLine, attr: .height, relatedBy: .equal, to: nil,
                           attr: .notAnAttribute, constant: 0.5)
-        Contraints.active(item: topViewContainerBottomLine, attr: .width, relatedBy: .equal, to: topViewContainer,
+        Constraints.active(item: topViewContainerBottomLine, attr: .width, relatedBy: .equal, to: topViewContainer,
                           attr: .width)
-        Contraints.active(item: topViewContainerBottomLine, attr: .top, relatedBy: .equal, to: topViewContainer,
+        Constraints.active(item: topViewContainerBottomLine, attr: .top, relatedBy: .equal, to: topViewContainer,
                           attr: .bottom)
         
         // Top Container
-        Contraints.active(item: topViewContainer, attr: .top, relatedBy: .equal, to: self, attr: .top)
-        Contraints.active(item: topViewContainer, attr: .leading, relatedBy: .equal, to: self, attr: .leading)
-        Contraints.active(item: topViewContainer, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing)
-        Contraints.active(item: topViewContainer, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: topViewContainer, attr: .top, relatedBy: .equal, to: self, attr: .top)
+        Constraints.active(item: topViewContainer, attr: .leading, relatedBy: .equal, to: self, attr: .leading)
+        Constraints.active(item: topViewContainer, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing)
+        Constraints.active(item: topViewContainer, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: 100)
         bottomTopViewContainerConstraint = NSLayoutConstraint(item: topViewContainer, attribute: .bottom,
                                                               relatedBy: .equal, toItem: self, attribute: .bottom,
                                                               multiplier: 1, constant: 0)
 
         // Top Icon
-        Contraints.active(item: topViewIcon, attr: .top, relatedBy: .equal, to: topViewContainer, attr: .top,
+        Constraints.active(item: topViewIcon, attr: .top, relatedBy: .equal, to: topViewContainer, attr: .top,
                           constant: 16)
-        Contraints.active(item: topViewIcon, attr: .bottom, relatedBy: .equal, to: topViewContainer, attr: .bottom,
+        Constraints.active(item: topViewIcon, attr: .bottom, relatedBy: .equal, to: topViewContainer, attr: .bottom,
                           constant: -16)
-        Contraints.active(item: topViewIcon, attr: .leading, relatedBy: .equal, to: topViewContainer, attr: .leading,
+        Constraints.active(item: topViewIcon, attr: .leading, relatedBy: .equal, to: topViewContainer, attr: .leading,
                           constant: 16)
-        Contraints.active(item: topViewIcon, attr: .trailing, relatedBy: .equal, to: topViewText, attr: .leading,
+        Constraints.active(item: topViewIcon, attr: .trailing, relatedBy: .equal, to: topViewText, attr: .leading,
                           constant: -16)
-        Contraints.active(item: topViewIcon, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: topViewIcon, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: topViewIconWidth)
         
         // Top text
-        Contraints.active(item: topViewText, attr: .top, relatedBy: .equal, to: topViewContainer, attr: .top,
+        Constraints.active(item: topViewText, attr: .top, relatedBy: .equal, to: topViewContainer, attr: .top,
                           constant: 16)
-        Contraints.active(item: topViewText, attr: .bottom, relatedBy: .equal, to: topViewContainer, attr: .bottom,
+        Constraints.active(item: topViewText, attr: .bottom, relatedBy: .equal, to: topViewContainer, attr: .bottom,
                           constant: -16)
-        Contraints.active(item: topViewText, attr: .trailing, relatedBy: .equal, to: topViewContainer, attr: .trailing,
+        Constraints.active(item: topViewText, attr: .trailing, relatedBy: .equal, to: topViewContainer, attr: .trailing,
                           constant: -16, priority: 999)
         leadingTopViewTextConstraint = NSLayoutConstraint(item: topViewText, attribute: .leading, relatedBy: .equal,
                                                           toItem: topViewContainer, attribute: .leading, multiplier: 1,
                                                           constant: 16)
         
         // Sub header title
-        Contraints.active(item: subHeaderTitle, attr: .top, relatedBy: .equal, to: topViewContainerBottomLine,
+        Constraints.active(item: subHeaderTitle, attr: .top, relatedBy: .equal, to: topViewContainerBottomLine,
                           attr: .bottom, constant: 20)
-        Contraints.active(item: subHeaderTitle, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
+        Constraints.active(item: subHeaderTitle, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
                           constant: 20)
-        Contraints.active(item: subHeaderTitle, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: subHeaderTitle, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -20)
-        Contraints.active(item: subHeaderTitle, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
+        Constraints.active(item: subHeaderTitle, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
         
     }
 }

--- a/GiniVision/Classes/CaptureSuggestionsView.swift
+++ b/GiniVision/Classes/CaptureSuggestionsView.swift
@@ -93,57 +93,57 @@ final class CaptureSuggestionsView: UIView {
         bottomConstraint = NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal,
                                               toItem: superViewBottomLayout, attribute: .top, multiplier: 1,
                                               constant: containerHeight)
-        Contraints.active(item: self, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
-        Contraints.active(item: self, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
-        Contraints.active(item: self, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: self, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
+        Constraints.active(item: self, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
+        Constraints.active(item: self, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: containerHeight)
-        Contraints.active(constraint: bottomConstraint)
+        Constraints.active(constraint: bottomConstraint)
 
         // suggestionTitle
-        Contraints.active(item: suggestionTitle, attr: .top, relatedBy: .equal, to: self, attr: .top)
-        Contraints.active(item: suggestionTitle, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
+        Constraints.active(item: suggestionTitle, attr: .top, relatedBy: .equal, to: self, attr: .top)
+        Constraints.active(item: suggestionTitle, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
                           constant: 8)
-        Contraints.active(item: suggestionTitle, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: suggestionTitle, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -8, priority: 999)
-        Contraints.active(item: suggestionTitle, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: suggestionTitle, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: suggestionTitleHeight)
 
         // suggestionContainer
         itemSeparationConstraint = NSLayoutConstraint(item: suggestionContainer, attribute: .top, relatedBy: .equal,
                                                       toItem: suggestionTitle, attribute: .bottom, multiplier: 1,
                                                       constant: 0)
-        Contraints.active(item: suggestionContainer, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: suggestionContainer, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: containerHeight - suggestionTitleHeight)
-        Contraints.active(constraint: itemSeparationConstraint)
+        Constraints.active(constraint: itemSeparationConstraint)
         
         // suggestionIcon
-        Contraints.active(item: suggestionIcon, attr: .leading, relatedBy: .equal, to: suggestionContainer,
+        Constraints.active(item: suggestionIcon, attr: .leading, relatedBy: .equal, to: suggestionContainer,
                           attr: .leading)
-        Contraints.active(item: suggestionIcon, attr: .height, relatedBy: .lessThanOrEqual, to: nil,
+        Constraints.active(item: suggestionIcon, attr: .height, relatedBy: .lessThanOrEqual, to: nil,
                           attr: .notAnAttribute, constant: 48)
-        Contraints.active(item: suggestionIcon, attr: .width, relatedBy: .equal, to: suggestionIcon, attr: .height)
-        Contraints.active(item: suggestionIcon, attr: .centerY, relatedBy: .equal, to: suggestionContainer,
+        Constraints.active(item: suggestionIcon, attr: .width, relatedBy: .equal, to: suggestionIcon, attr: .height)
+        Constraints.active(item: suggestionIcon, attr: .centerY, relatedBy: .equal, to: suggestionContainer,
                           attr: .centerY)
-        Contraints.active(item: suggestionIcon, attr: .trailing, relatedBy: .equal, to: suggestionText, attr: .leading,
+        Constraints.active(item: suggestionIcon, attr: .trailing, relatedBy: .equal, to: suggestionText, attr: .leading,
                           constant: -16)
         
         // suggestionText
-        Contraints.active(item: suggestionText, attr: .top, relatedBy: .equal, to: suggestionContainer, attr: .top,
+        Constraints.active(item: suggestionText, attr: .top, relatedBy: .equal, to: suggestionContainer, attr: .top,
                           constant: 16, priority: 999)
-        Contraints.active(item: suggestionText, attr: .trailing, relatedBy: .equal, to: suggestionContainer,
+        Constraints.active(item: suggestionText, attr: .trailing, relatedBy: .equal, to: suggestionContainer,
                           attr: .trailing, priority: 999)
-        Contraints.active(item: suggestionText, attr: .bottom, relatedBy: .equal, to: suggestionContainer,
+        Constraints.active(item: suggestionText, attr: .bottom, relatedBy: .equal, to: suggestionContainer,
                           attr: .bottom, constant: -16, priority: 999)
         
         // Center on align to margins depending on device
         if UIDevice.current.isIpad {
-            Contraints.active(item: suggestionContainer, attr: .width, relatedBy: .lessThanOrEqual, to: self,
+            Constraints.active(item: suggestionContainer, attr: .width, relatedBy: .lessThanOrEqual, to: self,
                               attr: .width, multiplier: 0.9)
-            Contraints.active(item: suggestionText, attr: .centerX, relatedBy: .equal, to: self, attr: .centerX)
+            Constraints.active(item: suggestionText, attr: .centerX, relatedBy: .equal, to: self, attr: .centerX)
         } else {
-            Contraints.active(item: suggestionContainer, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
+            Constraints.active(item: suggestionContainer, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
                               constant: 20)
-            Contraints.active(item: suggestionContainer, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+            Constraints.active(item: suggestionContainer, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                               constant: -20, priority: 999)
         }
     }

--- a/GiniVision/Classes/GiniVisionUtils.swift
+++ b/GiniVision/Classes/GiniVisionUtils.swift
@@ -105,7 +105,7 @@ internal enum FontWeight {
     }
 }
 
-internal class Contraints {
+internal class Constraints {
     
     class func active(item view1: Any,
                       attr attr1: NSLayoutAttribute,

--- a/GiniVision/Classes/ImageAnalysisNoResultsViewController.swift
+++ b/GiniVision/Classes/ImageAnalysisNoResultsViewController.swift
@@ -126,29 +126,29 @@ public final class ImageAnalysisNoResultsViewController: UIViewController {
     fileprivate func addConstraints() {
         
         // Collection View
-        Contraints.active(item: suggestionsCollectionView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
-        Contraints.active(item: self.view, attr: .leading, relatedBy: .equal, to: suggestionsCollectionView,
+        Constraints.active(item: suggestionsCollectionView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
+        Constraints.active(item: self.view, attr: .leading, relatedBy: .equal, to: suggestionsCollectionView,
                           attr: .leading)
-        Contraints.active(item: self.view, attr: .trailing, relatedBy: .equal, to: suggestionsCollectionView,
+        Constraints.active(item: self.view, attr: .trailing, relatedBy: .equal, to: suggestionsCollectionView,
                           attr: .trailing)
         
         // Button
         if bottomButtonText != nil {
-            Contraints.active(item: self.bottomLayoutGuide, attr: .top, relatedBy: .equal, to: bottomButton,
+            Constraints.active(item: self.bottomLayoutGuide, attr: .top, relatedBy: .equal, to: bottomButton,
                               attr: .bottom, constant: 20)
-            Contraints.active(item: self.view, attr: .leading, relatedBy: .equal, to: bottomButton, attr: .leading,
+            Constraints.active(item: self.view, attr: .leading, relatedBy: .equal, to: bottomButton, attr: .leading,
                               constant: -20, priority: 999)
-            Contraints.active(item: self.view, attr: .trailing, relatedBy: .equal, to: bottomButton, attr: .trailing,
+            Constraints.active(item: self.view, attr: .trailing, relatedBy: .equal, to: bottomButton, attr: .trailing,
                               constant: 20, priority: 999)
-            Contraints.active(item: self.view, attr: .centerX, relatedBy: .equal, to: bottomButton, attr: .centerX)
-            Contraints.active(item: bottomButton, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+            Constraints.active(item: self.view, attr: .centerX, relatedBy: .equal, to: bottomButton, attr: .centerX)
+            Constraints.active(item: bottomButton, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                               constant: 60)
-            Contraints.active(item: bottomButton, attr: .width, relatedBy: .lessThanOrEqual, to: nil,
+            Constraints.active(item: bottomButton, attr: .width, relatedBy: .lessThanOrEqual, to: nil,
                               attr: .notAnAttribute, constant: 375)
-            Contraints.active(item: bottomButton, attr: .top, relatedBy: .equal, to: suggestionsCollectionView,
+            Constraints.active(item: bottomButton, attr: .top, relatedBy: .equal, to: suggestionsCollectionView,
                               attr: .bottom, constant: 0, priority: 999)
         } else {
-            Contraints.active(item: self.view, attr: .bottom, relatedBy: .equal, to: suggestionsCollectionView,
+            Constraints.active(item: self.view, attr: .bottom, relatedBy: .equal, to: suggestionsCollectionView,
                               attr: .bottom, constant: 0, priority: 999)
         }
 

--- a/GiniVision/Classes/NoticeView.swift
+++ b/GiniVision/Classes/NoticeView.swift
@@ -129,19 +129,19 @@ internal class NoticeView: UIView {
             
             // Superview
             self.translatesAutoresizingMaskIntoConstraints = false
-            Contraints.active(item: self, attr: .top, relatedBy: .equal, to: superview, attr: .top)
-            Contraints.active(item: self, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
-            Contraints.active(item: self, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
-            Contraints.active(item: self, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 35)
+            Constraints.active(item: self, attr: .top, relatedBy: .equal, to: superview, attr: .top)
+            Constraints.active(item: self, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
+            Constraints.active(item: self, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
+            Constraints.active(item: self, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 35)
         }
         
         // Text label
         textLabel.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: textLabel, attr: .top, relatedBy: .equal, to: self, attr: .top)
-        Contraints.active(item: textLabel, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: textLabel, attr: .top, relatedBy: .equal, to: self, attr: .top)
+        Constraints.active(item: textLabel, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -20, priority: 999)
-        Contraints.active(item: textLabel, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
-        Contraints.active(item: textLabel, attr: .leading, relatedBy: .equal, to: self, attr: .leading, constant: 20)
+        Constraints.active(item: textLabel, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
+        Constraints.active(item: textLabel, attr: .leading, relatedBy: .equal, to: self, attr: .leading, constant: 20)
     }
     
 }

--- a/GiniVision/Classes/OnboardingContainerViewController.swift
+++ b/GiniVision/Classes/OnboardingContainerViewController.swift
@@ -123,34 +123,34 @@ internal class OnboardingContainerViewController: UIViewController, ContainerVie
         
         // Container view
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: containerView, attr: .top, relatedBy: .equal, to: superview, attr: .top)
-        Contraints.active(item: containerView, attr: .bottom, relatedBy: .greaterThanOrEqual, to: superview,
+        Constraints.active(item: containerView, attr: .top, relatedBy: .equal, to: superview, attr: .top)
+        Constraints.active(item: containerView, attr: .bottom, relatedBy: .greaterThanOrEqual, to: superview,
                           attr: .bottom, priority: 750)
-        Contraints.active(item: containerView, attr: .width, relatedBy: .equal, to: superview, attr: .width,
+        Constraints.active(item: containerView, attr: .width, relatedBy: .equal, to: superview, attr: .width,
                           priority: 750)
-        Contraints.active(item: containerView, attr: .width, relatedBy: .lessThanOrEqual, to: superview,
+        Constraints.active(item: containerView, attr: .width, relatedBy: .lessThanOrEqual, to: superview,
                           attr: .width, priority: 999)
-        Contraints.active(item: containerView, attr: .centerX, relatedBy: .equal, to: superview, attr: .centerX)
+        Constraints.active(item: containerView, attr: .centerX, relatedBy: .equal, to: superview, attr: .centerX)
         
         // Page control container view
         pageControlContainerView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: pageControlContainerView, attr: .top, relatedBy: .equal, to: containerView,
+        Constraints.active(item: pageControlContainerView, attr: .top, relatedBy: .equal, to: containerView,
                           attr: .bottom, priority: 750)
-        Contraints.active(item: pageControlContainerView, attr: .trailing, relatedBy: .equal, to: superview,
+        Constraints.active(item: pageControlContainerView, attr: .trailing, relatedBy: .equal, to: superview,
                           attr: .trailing)
-        Contraints.active(item: pageControlContainerView, attr: .bottom, relatedBy: .equal, to: superview,
+        Constraints.active(item: pageControlContainerView, attr: .bottom, relatedBy: .equal, to: superview,
                           attr: .bottom)
-        Contraints.active(item: pageControlContainerView, attr: .leading, relatedBy: .equal, to: superview,
+        Constraints.active(item: pageControlContainerView, attr: .leading, relatedBy: .equal, to: superview,
                           attr: .leading)
-        Contraints.active(item: pageControlContainerView, attr: .height, relatedBy: .greaterThanOrEqual,
+        Constraints.active(item: pageControlContainerView, attr: .height, relatedBy: .greaterThanOrEqual,
                           to: pageControl, attr: .height, multiplier: 1.1)
         
         // Page control
         pageControl.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: pageControl, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 55)
-        Contraints.active(item: pageControl, attr: .centerX, relatedBy: .equal, to: pageControlContainerView,
+        Constraints.active(item: pageControl, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 55)
+        Constraints.active(item: pageControl, attr: .centerX, relatedBy: .equal, to: pageControlContainerView,
                           attr: .centerX)
-        Contraints.active(item: pageControl, attr: .centerY, relatedBy: .equal, to: pageControlContainerView,
+        Constraints.active(item: pageControl, attr: .centerY, relatedBy: .equal, to: pageControlContainerView,
                           attr: .centerY)
     }
 }

--- a/GiniVision/Classes/OnboardingPage.swift
+++ b/GiniVision/Classes/OnboardingPage.swift
@@ -95,34 +95,34 @@ import UIKit
             
         // Content view
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: contentView, attr: .top, relatedBy: .greaterThanOrEqual, to: superview, attr: .top,
+        Constraints.active(item: contentView, attr: .top, relatedBy: .greaterThanOrEqual, to: superview, attr: .top,
                           constant: 30)
-        Contraints.active(item: contentView, attr: .centerX, relatedBy: .equal, to: superview, attr: .centerX)
-        Contraints.active(item: contentView, attr: .centerY, relatedBy: .equal, to: superview, attr: .centerY,
+        Constraints.active(item: contentView, attr: .centerX, relatedBy: .equal, to: superview, attr: .centerX)
+        Constraints.active(item: contentView, attr: .centerY, relatedBy: .equal, to: superview, attr: .centerY,
                           constant: 5, priority: 999)
     
         // Image view
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: imageView, attr: .top, relatedBy: .equal, to: contentView, attr: .top)
-        Contraints.active(item: imageView, attr: .width, relatedBy: .lessThanOrEqual, to: nil, attr: .width,
+        Constraints.active(item: imageView, attr: .top, relatedBy: .equal, to: contentView, attr: .top)
+        Constraints.active(item: imageView, attr: .width, relatedBy: .lessThanOrEqual, to: nil, attr: .width,
                           constant: 612)
-        Contraints.active(item: imageView, attr: .width, relatedBy: .greaterThanOrEqual, to: nil, attr: .width,
+        Constraints.active(item: imageView, attr: .width, relatedBy: .greaterThanOrEqual, to: nil, attr: .width,
                           constant: 75)
-        Contraints.active(item: imageView, attr: .height, relatedBy: .lessThanOrEqual, to: nil, attr: .height,
+        Constraints.active(item: imageView, attr: .height, relatedBy: .lessThanOrEqual, to: nil, attr: .height,
                           constant: 360)
-        Contraints.active(item: imageView, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
+        Constraints.active(item: imageView, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
                           constant: 100)
-        Contraints.active(item: imageView, attr: .centerX, relatedBy: .equal, to: contentView, attr: .centerX)
+        Constraints.active(item: imageView, attr: .centerX, relatedBy: .equal, to: contentView, attr: .centerX)
 
         // Text label
         textLabel.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: textLabel, attr: .top, relatedBy: .equal, to: imageView, attr: .bottom, constant: 35)
-        Contraints.active(item: textLabel, attr: .trailing, relatedBy: .equal, to: contentView, attr: .trailing)
-        Contraints.active(item: textLabel, attr: .bottom, relatedBy: .equal, to: contentView, attr: .bottom)
-        Contraints.active(item: textLabel, attr: .leading, relatedBy: .equal, to: contentView, attr: .leading)
-        Contraints.active(item: textLabel, attr: .width, relatedBy: .equal, to: superview, attr: .width,
+        Constraints.active(item: textLabel, attr: .top, relatedBy: .equal, to: imageView, attr: .bottom, constant: 35)
+        Constraints.active(item: textLabel, attr: .trailing, relatedBy: .equal, to: contentView, attr: .trailing)
+        Constraints.active(item: textLabel, attr: .bottom, relatedBy: .equal, to: contentView, attr: .bottom)
+        Constraints.active(item: textLabel, attr: .leading, relatedBy: .equal, to: contentView, attr: .leading)
+        Constraints.active(item: textLabel, attr: .width, relatedBy: .equal, to: superview, attr: .width,
                           multiplier: 2/3)
-        Contraints.active(item: textLabel, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
+        Constraints.active(item: textLabel, attr: .height, relatedBy: .greaterThanOrEqual, to: nil, attr: .height,
                           constant: 70)
     }
     

--- a/GiniVision/Classes/OnboardingViewController.swift
+++ b/GiniVision/Classes/OnboardingViewController.swift
@@ -156,32 +156,32 @@ import UIKit
         
         // Scroll view
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: scrollView, attr: .top, relatedBy: .equal, to: superview, attr: .top)
-        Contraints.active(item: scrollView, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
-        Contraints.active(item: scrollView, attr: .bottom, relatedBy: .equal, to: superview, attr: .bottom)
-        Contraints.active(item: scrollView, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
+        Constraints.active(item: scrollView, attr: .top, relatedBy: .equal, to: superview, attr: .top)
+        Constraints.active(item: scrollView, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
+        Constraints.active(item: scrollView, attr: .bottom, relatedBy: .equal, to: superview, attr: .bottom)
+        Constraints.active(item: scrollView, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
         
         // Content view
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        Contraints.active(item: contentView, attr: .top, relatedBy: .equal, to: scrollView, attr: .top)
-        Contraints.active(item: contentView, attr: .trailing, relatedBy: .equal, to: scrollView, attr: .trailing)
-        Contraints.active(item: contentView, attr: .bottom, relatedBy: .equal, to: scrollView, attr: .bottom)
-        Contraints.active(item: contentView, attr: .leading, relatedBy: .equal, to: scrollView, attr: .leading)
-        Contraints.active(item: contentView, attr: .width, relatedBy: .equal, to: scrollView, attr: .width,
+        Constraints.active(item: contentView, attr: .top, relatedBy: .equal, to: scrollView, attr: .top)
+        Constraints.active(item: contentView, attr: .trailing, relatedBy: .equal, to: scrollView, attr: .trailing)
+        Constraints.active(item: contentView, attr: .bottom, relatedBy: .equal, to: scrollView, attr: .bottom)
+        Constraints.active(item: contentView, attr: .leading, relatedBy: .equal, to: scrollView, attr: .leading)
+        Constraints.active(item: contentView, attr: .width, relatedBy: .equal, to: scrollView, attr: .width,
                           multiplier: pagesCount)
-        Contraints.active(item: contentView, attr: .height, relatedBy: .equal, to: scrollView, attr: .height)
+        Constraints.active(item: contentView, attr: .height, relatedBy: .equal, to: scrollView, attr: .height)
         
         for page in pages {
             page.translatesAutoresizingMaskIntoConstraints = false
-            Contraints.active(item: page, attr: .top, relatedBy: .equal, to: contentView, attr: .top)
-            Contraints.active(item: page, attr: .bottom, relatedBy: .equal, to: contentView, attr: .bottom)
-            Contraints.active(item: page, attr: .width, relatedBy: .equal, to: contentView, attr: .width,
+            Constraints.active(item: page, attr: .top, relatedBy: .equal, to: contentView, attr: .top)
+            Constraints.active(item: page, attr: .bottom, relatedBy: .equal, to: contentView, attr: .bottom)
+            Constraints.active(item: page, attr: .width, relatedBy: .equal, to: contentView, attr: .width,
                               multiplier: 1/pagesCount)
             if page == pages.first {
-                Contraints.active(item: page, attr: .leading, relatedBy: .equal, to: contentView, attr: .leading)
+                Constraints.active(item: page, attr: .leading, relatedBy: .equal, to: contentView, attr: .leading)
             } else {
                 let previousPage = pages[pages.index(of: page)! - 1]
-                Contraints.active(item: page, attr: .leading, relatedBy: .equal, to: previousPage, attr: .trailing)
+                Constraints.active(item: page, attr: .leading, relatedBy: .equal, to: previousPage, attr: .trailing)
             }
         }
     }

--- a/GiniVision/Classes/OpenWithTutorialCollectionCell.swift
+++ b/GiniVision/Classes/OpenWithTutorialCollectionCell.swift
@@ -87,49 +87,49 @@ final class OpenWithTutorialCollectionCell: UICollectionViewCell {
     private func addConstrains() {
         
         // stepIndicator
-        Contraints.active(item: stepIndicator, attr: .centerX, relatedBy: .equal, to: stepIndicatorCircle,
+        Constraints.active(item: stepIndicator, attr: .centerX, relatedBy: .equal, to: stepIndicatorCircle,
                           attr: .centerX)
-        Contraints.active(item: stepIndicator, attr: .centerY, relatedBy: .equal, to: stepIndicatorCircle,
+        Constraints.active(item: stepIndicator, attr: .centerY, relatedBy: .equal, to: stepIndicatorCircle,
                           attr: .centerY)
         
         // stepIndicatorCircle
-        Contraints.active(item: stepIndicatorCircle, attr: .height, relatedBy: .equal, to: nil,
+        Constraints.active(item: stepIndicatorCircle, attr: .height, relatedBy: .equal, to: nil,
                           attr: .notAnAttribute, constant: stepIndicatorCircleSize.height)
-        Contraints.active(item: stepIndicatorCircle, attr: .width, relatedBy: .equal, to: nil,
+        Constraints.active(item: stepIndicatorCircle, attr: .width, relatedBy: .equal, to: nil,
                           attr: .notAnAttribute, constant: stepIndicatorCircleSize.width)
-        Contraints.active(item: stepIndicatorCircle, attr: .top, relatedBy: .equal, to: self,
+        Constraints.active(item: stepIndicatorCircle, attr: .top, relatedBy: .equal, to: self,
                           attr: .top, constant: padding.top)
-        Contraints.active(item: stepIndicatorCircle, attr: .leading, relatedBy: .equal, to: self,
+        Constraints.active(item: stepIndicatorCircle, attr: .leading, relatedBy: .equal, to: self,
                           attr: .leading, constant: padding.left)
         
         // stepTitle
-        Contraints.active(item: stepTitle, attr: .top, relatedBy: .equal, to: stepIndicatorCircle,
+        Constraints.active(item: stepTitle, attr: .top, relatedBy: .equal, to: stepIndicatorCircle,
                           attr: .bottom, constant: indicatorToTitleDistance)
-        Contraints.active(item: stepTitle, attr: .leading, relatedBy: .equal, to: self,
+        Constraints.active(item: stepTitle, attr: .leading, relatedBy: .equal, to: self,
                           attr: .leading, constant: padding.left)
-        Contraints.active(item: stepTitle, attr: .trailing, relatedBy: .equal, to: self,
+        Constraints.active(item: stepTitle, attr: .trailing, relatedBy: .equal, to: self,
                           attr: .trailing, constant: -padding.right)
         
         // stepSubTitle
-        Contraints.active(item: stepSubTitle, attr: .top, relatedBy: .equal, to: stepTitle,
+        Constraints.active(item: stepSubTitle, attr: .top, relatedBy: .equal, to: stepTitle,
                           attr: .bottom, constant: titleToSubtitleDistance)
-        Contraints.active(item: stepSubTitle, attr: .leading, relatedBy: .equal, to: self,
+        Constraints.active(item: stepSubTitle, attr: .leading, relatedBy: .equal, to: self,
                           attr: .leading, constant: padding.left)
-        Contraints.active(item: stepSubTitle, attr: .trailing, relatedBy: .equal, to: self,
+        Constraints.active(item: stepSubTitle, attr: .trailing, relatedBy: .equal, to: self,
                           attr: .trailing, constant: -padding.right)
         
         // stepImage
-        Contraints.active(item: stepImage, attr: .top, relatedBy: .equal, to: stepSubTitle,
+        Constraints.active(item: stepImage, attr: .top, relatedBy: .equal, to: stepSubTitle,
                           attr: .bottom, constant: subtitleToImageDistance)
-        Contraints.active(item: stepImage, attr: .leading, relatedBy: .equal, to: self,
+        Constraints.active(item: stepImage, attr: .leading, relatedBy: .equal, to: self,
                           attr: .leading, constant: padding.left, priority: 999)
-        Contraints.active(item: stepImage, attr: .trailing, relatedBy: .equal, to: self,
+        Constraints.active(item: stepImage, attr: .trailing, relatedBy: .equal, to: self,
                           attr: .trailing, constant: -padding.right, priority: 999)
-        Contraints.active(item: stepImage, attr: .centerX, relatedBy: .equal, to: self,
+        Constraints.active(item: stepImage, attr: .centerX, relatedBy: .equal, to: self,
                           attr: .centerX)
-        Contraints.active(item: stepImage, attr: .bottom, relatedBy: .lessThanOrEqual,
+        Constraints.active(item: stepImage, attr: .bottom, relatedBy: .lessThanOrEqual,
                           to: self, attr: .bottom, constant: -padding.bottom, priority: 999)
-        Contraints.active(item: stepImage, attr: .height, relatedBy: .equal, to: nil,
+        Constraints.active(item: stepImage, attr: .height, relatedBy: .equal, to: nil,
                           attr: .notAnAttribute, constant: imageHeight)
         
     }

--- a/GiniVision/Classes/OpenWithTutorialCollectionHeader.swift
+++ b/GiniVision/Classes/OpenWithTutorialCollectionHeader.swift
@@ -52,24 +52,24 @@ final class OpenWithTutorialCollectionHeader: UICollectionReusableView {
     }
     
     private func addConstraints() {
-        Contraints.active(item: headerContainer, attr: .top, relatedBy: .equal, to: self, attr: .top)
-        Contraints.active(item: headerContainer, attr: .leading, relatedBy: .equal, to: self, attr: .leading)
-        Contraints.active(item: headerContainer, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing)
+        Constraints.active(item: headerContainer, attr: .top, relatedBy: .equal, to: self, attr: .top)
+        Constraints.active(item: headerContainer, attr: .leading, relatedBy: .equal, to: self, attr: .leading)
+        Constraints.active(item: headerContainer, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing)
         
-        Contraints.active(item: headerTitle, attr: .top, relatedBy: .equal, to: headerContainer, attr: .top,
+        Constraints.active(item: headerTitle, attr: .top, relatedBy: .equal, to: headerContainer, attr: .top,
                           constant: padding.top)
-        Contraints.active(item: headerTitle, attr: .leading, relatedBy: .equal, to: headerContainer, attr: .leading,
+        Constraints.active(item: headerTitle, attr: .leading, relatedBy: .equal, to: headerContainer, attr: .leading,
                           constant: padding.left)
-        Contraints.active(item: headerTitle, attr: .trailing, relatedBy: .equal, to: headerContainer, attr: .trailing,
+        Constraints.active(item: headerTitle, attr: .trailing, relatedBy: .equal, to: headerContainer, attr: .trailing,
                           constant: -padding.right)
-        Contraints.active(item: headerTitle, attr: .bottom, relatedBy: .equal, to: headerContainer, attr: .bottom,
+        Constraints.active(item: headerTitle, attr: .bottom, relatedBy: .equal, to: headerContainer, attr: .bottom,
                           constant: -padding.bottom)
         
-        Contraints.active(item: bottomLine, attr: .top, relatedBy: .equal, to: headerContainer, attr: .bottom)
-        Contraints.active(item: bottomLine, attr: .leading, relatedBy: .equal, to: self, attr: .leading)
-        Contraints.active(item: bottomLine, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing)
-        Contraints.active(item: bottomLine, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
-        Contraints.active(item: bottomLine, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: bottomLine, attr: .top, relatedBy: .equal, to: headerContainer, attr: .bottom)
+        Constraints.active(item: bottomLine, attr: .leading, relatedBy: .equal, to: self, attr: .leading)
+        Constraints.active(item: bottomLine, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing)
+        Constraints.active(item: bottomLine, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom)
+        Constraints.active(item: bottomLine, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: 1)
     }
 }

--- a/GiniVision/Classes/PDFInformationView.swift
+++ b/GiniVision/Classes/PDFInformationView.swift
@@ -66,27 +66,27 @@ final class PDFInformationView: UIView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         
-        Contraints.active(item: self, attr: .top, relatedBy: .equal, to: superview, attr: .top)
-        Contraints.active(item: self, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
-        Contraints.active(item: self, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
-        Contraints.active(item: self, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute, constant: 95)
+        Constraints.active(item: self, attr: .top, relatedBy: .equal, to: superview, attr: .top)
+        Constraints.active(item: self, attr: .leading, relatedBy: .equal, to: superview, attr: .leading)
+        Constraints.active(item: self, attr: .trailing, relatedBy: .equal, to: superview, attr: .trailing)
+        Constraints.active(item: self, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute, constant: 95)
 
         if let viewBelow = viewBelow {
-            Contraints.active(item: self, attr: .bottom, relatedBy: .equal, to: viewBelow, attr: .top)
+            Constraints.active(item: self, attr: .bottom, relatedBy: .equal, to: viewBelow, attr: .top)
         }
         
-        Contraints.active(item: titleLabel, attr: .top, relatedBy: .equal, to: self, attr: .top, constant: 16)
-        Contraints.active(item: titleLabel, attr: .bottom, relatedBy: .equal, to: subtitleLabel, attr: .top,
+        Constraints.active(item: titleLabel, attr: .top, relatedBy: .equal, to: self, attr: .top, constant: 16)
+        Constraints.active(item: titleLabel, attr: .bottom, relatedBy: .equal, to: subtitleLabel, attr: .top,
                           constant: -16)
-        Contraints.active(item: titleLabel, attr: .leading, relatedBy: .equal, to: self, attr: .leading, constant: 16)
-        Contraints.active(item: titleLabel, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: titleLabel, attr: .leading, relatedBy: .equal, to: self, attr: .leading, constant: 16)
+        Constraints.active(item: titleLabel, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -16, priority: 999)
 
-        Contraints.active(item: subtitleLabel, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
+        Constraints.active(item: subtitleLabel, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
                           constant: 16)
-        Contraints.active(item: subtitleLabel, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: subtitleLabel, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -16, priority: 999)
-        Contraints.active(item: subtitleLabel, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
+        Constraints.active(item: subtitleLabel, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
                           constant: -16, priority: 999)
 
     }

--- a/GiniVision/Classes/QRCodeDetectedPopupView.swift
+++ b/GiniVision/Classes/QRCodeDetectedPopupView.swift
@@ -75,13 +75,13 @@ final class QRCodeDetectedPopupView: UIView {
     }
     
     fileprivate func addConstraints(onSuperView superView: UIView, refView: UIView) {
-        Contraints.active(item: self, attr: .width, relatedBy: .lessThanOrEqual, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: self, attr: .width, relatedBy: .lessThanOrEqual, to: nil, attr: .notAnAttribute,
                           constant: maxWidth)
-        Contraints.active(item: self, attr: .leading, relatedBy: .greaterThanOrEqual, to: superView, attr: .leading,
+        Constraints.active(item: self, attr: .leading, relatedBy: .greaterThanOrEqual, to: superView, attr: .leading,
                           constant: margin.left)
-        Contraints.active(item: self, attr: .trailing, relatedBy: .lessThanOrEqual, to: superView, attr: .trailing,
+        Constraints.active(item: self, attr: .trailing, relatedBy: .lessThanOrEqual, to: superView, attr: .trailing,
                           constant: -margin.right)
-        Contraints.active(item: self, attr: .centerX, relatedBy: .equal, to: refView, attr: .centerX)
+        Constraints.active(item: self, attr: .centerX, relatedBy: .equal, to: refView, attr: .centerX)
         bottomConstraint = NSLayoutConstraint(item: self,
                                               attribute: .bottom,
                                               relatedBy: .equal,
@@ -92,28 +92,28 @@ final class QRCodeDetectedPopupView: UIView {
                                                 padding.top +
                                                 padding.bottom +
                                                 margin.bottom)
-        Contraints.active(constraint: bottomConstraint!)
+        Constraints.active(constraint: bottomConstraint!)
         
-        Contraints.active(item: qrImage, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: qrImage, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: imageSize.width)
-        Contraints.active(item: qrImage, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: qrImage, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: imageSize.height)
-        Contraints.active(item: qrImage, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
+        Constraints.active(item: qrImage, attr: .leading, relatedBy: .equal, to: self, attr: .leading,
                           constant: padding.left)
-        Contraints.active(item: qrImage, attr: .top, relatedBy: .equal, to: self, attr: .top, constant: padding.top)
-        Contraints.active(item: qrImage, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
+        Constraints.active(item: qrImage, attr: .top, relatedBy: .equal, to: self, attr: .top, constant: padding.top)
+        Constraints.active(item: qrImage, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
                           constant: -padding.bottom)
-        Contraints.active(item: qrImage, attr: .trailing, relatedBy: .equal, to: qrText, attr: .leading,
+        Constraints.active(item: qrImage, attr: .trailing, relatedBy: .equal, to: qrText, attr: .leading,
                           constant: -padding.right / 2, priority: 999)
         
-        Contraints.active(item: qrText, attr: .centerY, relatedBy: .equal, to: qrImage, attr: .centerY)
-        Contraints.active(item: qrText, attr: .trailing, relatedBy: .lessThanOrEqual, to: proceedButton, attr: .leading,
+        Constraints.active(item: qrText, attr: .centerY, relatedBy: .equal, to: qrImage, attr: .centerY)
+        Constraints.active(item: qrText, attr: .trailing, relatedBy: .lessThanOrEqual, to: proceedButton, attr: .leading,
                           constant: -padding.right)
-        Contraints.active(item: proceedButton, attr: .centerY, relatedBy: .equal, to: qrImage, attr: .centerY)
-        Contraints.active(item: proceedButton, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
+        Constraints.active(item: proceedButton, attr: .centerY, relatedBy: .equal, to: qrImage, attr: .centerY)
+        Constraints.active(item: proceedButton, attr: .trailing, relatedBy: .equal, to: self, attr: .trailing,
                           constant: -padding.right)
         if let minButtonWidth = proceedButton.titleLabel?.intrinsicContentSize.width {
-            Contraints.active(item: proceedButton, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+            Constraints.active(item: proceedButton, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                               constant: minButtonWidth)
         }
 

--- a/GiniVision/Classes/ReviewViewController.swift
+++ b/GiniVision/Classes/ReviewViewController.swift
@@ -298,10 +298,10 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> Void
     // MARK: Constraints
     fileprivate func addConstraints() {
         // Scroll view
-        Contraints.active(item: scrollView, attr: .top, relatedBy: .equal, to: topLayoutGuide, attr: .bottom)
-        Contraints.active(item: scrollView, attr: .trailing, relatedBy: .equal, to: view, attr: .trailing)
-        Contraints.active(item: scrollView, attr: .bottom, relatedBy: .equal, to: bottomLayoutGuide, attr: .top)
-        Contraints.active(item: scrollView, attr: .leading, relatedBy: .equal, to: view, attr: .leading)
+        Constraints.active(item: scrollView, attr: .top, relatedBy: .equal, to: topLayoutGuide, attr: .bottom)
+        Constraints.active(item: scrollView, attr: .trailing, relatedBy: .equal, to: view, attr: .trailing)
+        Constraints.active(item: scrollView, attr: .bottom, relatedBy: .equal, to: bottomLayoutGuide, attr: .top)
+        Constraints.active(item: scrollView, attr: .leading, relatedBy: .equal, to: view, attr: .leading)
         
         // Image view
         imageViewTopConstraint = NSLayoutConstraint(item: imageView, attribute: .top, relatedBy: .equal,
@@ -315,40 +315,40 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> Void
         imageViewLeadingConstraint = NSLayoutConstraint(item: imageView, attribute: .leading, relatedBy: .equal,
                                                         toItem: scrollView, attribute: .leading, multiplier: 1,
                                                         constant: 0)
-        Contraints.active(constraint: imageViewTopConstraint)
-        Contraints.active(constraint: imageViewTrailingConstraint)
-        Contraints.active(constraint: imageViewBottomConstraint)
-        Contraints.active(constraint: imageViewLeadingConstraint)
+        Constraints.active(constraint: imageViewTopConstraint)
+        Constraints.active(constraint: imageViewTrailingConstraint)
+        Constraints.active(constraint: imageViewBottomConstraint)
+        Constraints.active(constraint: imageViewLeadingConstraint)
         
         // Top view
-        Contraints.active(item: topView, attr: .top, relatedBy: .equal, to: topLayoutGuide, attr: .bottom)
-        Contraints.active(item: topView, attr: .trailing, relatedBy: .equal, to: view, attr: .trailing)
-        Contraints.active(item: topView, attr: .leading, relatedBy: .equal, to: view, attr: .leading)
-        Contraints.active(item: topView, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 35)
+        Constraints.active(item: topView, attr: .top, relatedBy: .equal, to: topLayoutGuide, attr: .bottom)
+        Constraints.active(item: topView, attr: .trailing, relatedBy: .equal, to: view, attr: .trailing)
+        Constraints.active(item: topView, attr: .leading, relatedBy: .equal, to: view, attr: .leading)
+        Constraints.active(item: topView, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 35)
         
         // Bottom view
-        Contraints.active(item: bottomView, attr: .top, relatedBy: .equal, to: scrollView, attr: .bottom, priority: 750)
-        Contraints.active(item: bottomView, attr: .trailing, relatedBy: .equal, to: view, attr: .trailing)
-        Contraints.active(item: bottomView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide, attr: .top)
-        Contraints.active(item: bottomView, attr: .leading, relatedBy: .equal, to: view, attr: .leading)
+        Constraints.active(item: bottomView, attr: .top, relatedBy: .equal, to: scrollView, attr: .bottom, priority: 750)
+        Constraints.active(item: bottomView, attr: .trailing, relatedBy: .equal, to: view, attr: .trailing)
+        Constraints.active(item: bottomView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide, attr: .top)
+        Constraints.active(item: bottomView, attr: .leading, relatedBy: .equal, to: view, attr: .leading)
         
         // Rotate button
-        Contraints.active(item: rotateButton, attr: .leading, relatedBy: .equal, to: bottomView, attr: .leading,
+        Constraints.active(item: rotateButton, attr: .leading, relatedBy: .equal, to: bottomView, attr: .leading,
                           constant: 15)
-        Contraints.active(item: rotateButton, attr: .width, relatedBy: .equal, to: nil, attr: .width, constant: 33)
-        Contraints.active(item: rotateButton, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 33)
-        Contraints.active(item: rotateButton, attr: .centerY, relatedBy: .equal, to: bottomView, attr: .centerY)
-        Contraints.active(item: rotateButton, attr: .top, relatedBy: .equal, to: bottomView, attr: .top, constant: 10)
-        Contraints.active(item: rotateButton, attr: .bottom, relatedBy: .equal, to: bottomView, attr: .bottom,
+        Constraints.active(item: rotateButton, attr: .width, relatedBy: .equal, to: nil, attr: .width, constant: 33)
+        Constraints.active(item: rotateButton, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 33)
+        Constraints.active(item: rotateButton, attr: .centerY, relatedBy: .equal, to: bottomView, attr: .centerY)
+        Constraints.active(item: rotateButton, attr: .top, relatedBy: .equal, to: bottomView, attr: .top, constant: 10)
+        Constraints.active(item: rotateButton, attr: .bottom, relatedBy: .equal, to: bottomView, attr: .bottom,
                           constant: -10)
 
         // Bottom label
-        Contraints.active(item: bottomLabel, attr: .trailing, relatedBy: .equal, to: bottomView, attr: .trailing,
+        Constraints.active(item: bottomLabel, attr: .trailing, relatedBy: .equal, to: bottomView, attr: .trailing,
                           constant: -20)
-        Contraints.active(item: bottomLabel, attr: .leading, relatedBy: .equal, to: rotateButton, attr: .trailing,
+        Constraints.active(item: bottomLabel, attr: .leading, relatedBy: .equal, to: rotateButton, attr: .trailing,
                           constant: 30, priority: 999)
-        Contraints.active(item: bottomLabel, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 33)
-        Contraints.active(item: bottomLabel, attr: .centerY, relatedBy: .equal, to: bottomView, attr: .centerY)
+        Constraints.active(item: bottomLabel, attr: .height, relatedBy: .equal, to: nil, attr: .height, constant: 33)
+        Constraints.active(item: bottomLabel, attr: .centerY, relatedBy: .equal, to: bottomView, attr: .centerY)
     }
     
 }

--- a/GiniVision/Classes/SupportedFormatsTableViewCell.swift
+++ b/GiniVision/Classes/SupportedFormatsTableViewCell.swift
@@ -42,12 +42,12 @@ final class SupportedFormatsTableViewCell: UITableViewCell {
     }
     
     private func addConstraints() {
-        Contraints.active(item: imageBackgroundView, attr: .centerX, relatedBy: .equal, to: imageView!, attr: .centerX)
-        Contraints.active(item: imageBackgroundView, attr: .centerY, relatedBy: .equal, to: imageView!, attr: .centerY)
+        Constraints.active(item: imageBackgroundView, attr: .centerX, relatedBy: .equal, to: imageView!, attr: .centerX)
+        Constraints.active(item: imageBackgroundView, attr: .centerY, relatedBy: .equal, to: imageView!, attr: .centerY)
         
-        Contraints.active(item: imageBackgroundView, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: imageBackgroundView, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: 22)
-        Contraints.active(item: imageBackgroundView, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: imageBackgroundView, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: 22)
     }
 }

--- a/GiniVision/Classes/ToolTipView.swift
+++ b/GiniVision/Classes/ToolTipView.swift
@@ -171,32 +171,32 @@ final class ToolTipView: UIView {
         tipContainer.translatesAutoresizingMaskIntoConstraints = false
         
         // tipContainer
-        Contraints.active(item: self, attr: .top, relatedBy: .equal, to: tipContainer, attr: .top,
+        Constraints.active(item: self, attr: .top, relatedBy: .equal, to: tipContainer, attr: .top,
                           constant: -margin.top)
-        Contraints.active(item: self, attr: .bottom, relatedBy: .equal, to: tipContainer, attr: .bottom,
+        Constraints.active(item: self, attr: .bottom, relatedBy: .equal, to: tipContainer, attr: .bottom,
                           constant: margin.bottom)
-        Contraints.active(item: self, attr: .leading, relatedBy: .equal, to: tipContainer, attr: .leading,
+        Constraints.active(item: self, attr: .leading, relatedBy: .equal, to: tipContainer, attr: .leading,
                           constant: -margin.left)
-        Contraints.active(item: self, attr: .trailing, relatedBy: .equal, to: tipContainer, attr: .trailing,
+        Constraints.active(item: self, attr: .trailing, relatedBy: .equal, to: tipContainer, attr: .trailing,
                           constant: margin.right)
         
         // textLabel
-        Contraints.active(item: tipContainer, attr: .top, relatedBy: .equal, to: textLabel, attr: .top,
+        Constraints.active(item: tipContainer, attr: .top, relatedBy: .equal, to: textLabel, attr: .top,
                           constant: -padding.top)
-        Contraints.active(item: tipContainer, attr: .bottom, relatedBy: .equal, to: textLabel, attr: .bottom,
+        Constraints.active(item: tipContainer, attr: .bottom, relatedBy: .equal, to: textLabel, attr: .bottom,
                           constant: padding.bottom)
-        Contraints.active(item: tipContainer, attr: .leading, relatedBy: .equal, to: textLabel, attr: .leading,
+        Constraints.active(item: tipContainer, attr: .leading, relatedBy: .equal, to: textLabel, attr: .leading,
                           constant: -padding.left)
         
         // closeButton
-        Contraints.active(item: closeButton, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: closeButton, attr: .width, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: closeButtonWidth)
-        Contraints.active(item: closeButton, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
+        Constraints.active(item: closeButton, attr: .height, relatedBy: .equal, to: nil, attr: .notAnAttribute,
                           constant: closeButtonHeight)
-        Contraints.active(item: closeButton, attr: .centerY, relatedBy: .equal, to: tipContainer, attr: .centerY)
-        Contraints.active(item: closeButton, attr: .leading, relatedBy: .equal, to: textLabel, attr: .trailing,
+        Constraints.active(item: closeButton, attr: .centerY, relatedBy: .equal, to: tipContainer, attr: .centerY)
+        Constraints.active(item: closeButton, attr: .leading, relatedBy: .equal, to: textLabel, attr: .trailing,
                           constant: itemSeparation)
-        Contraints.active(item: tipContainer, attr: .trailing, relatedBy: .equal, to: closeButton, attr: .trailing,
+        Constraints.active(item: tipContainer, attr: .trailing, relatedBy: .equal, to: closeButton, attr: .trailing,
                           constant: padding.right)
         
         self.setNeedsLayout()


### PR DESCRIPTION
There was a typo in `Constraints` class, being `Contraints` instead of `Constraints.`

### How to test
Nothing to test. 

### Merging
Automatic

Issue #150  
