### PR TITLE
Fixed issue on UIDocumentViewController status bar for iPads

### DIFF
--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -40,10 +40,14 @@ internal final class FilePickerManager: NSObject {
     }
     
     func showDocumentPicker(from: UIViewController,
-                            giniConfiguration: GiniConfiguration = GiniConfiguration.sharedConfiguration) {
+                            giniConfiguration: GiniConfiguration = GiniConfiguration.sharedConfiguration,
+                            device: UIDevice = UIDevice.current) {
         let documentPicker = UIDocumentPickerViewController(documentTypes: acceptedDocumentTypes, in: .import)
         documentPicker.delegate = self
-        setStatusBarStyle(to: .default)
+        
+        if !device.isIpad {
+            setStatusBarStyle(to: .default)
+        }
 
         from.present(documentPicker, animated: true, completion: nil)
     }

--- a/GiniVision/Classes/FilePickerManager.swift
+++ b/GiniVision/Classes/FilePickerManager.swift
@@ -45,6 +45,9 @@ internal final class FilePickerManager: NSObject {
         let documentPicker = UIDocumentPickerViewController(documentTypes: acceptedDocumentTypes, in: .import)
         documentPicker.delegate = self
         
+        // This is needed since the UIDocumentPickerViewController on iPad is presented over the current view controller
+        // without covering the previous screen. This causes that the `viewWillAppear` method is not being called
+        // in the current view controller.
         if !device.isIpad {
             setStatusBarStyle(to: .default)
         }


### PR DESCRIPTION
When presenting a UIDocumentViewController on iPads, the view controller that presents it doesn't disappear.

### How to test
Run the app on an iPad, try to import a document and see that the status bar is changed properly.

### Merging
Automatic

