### PR TITLE
Handle polling outside of API SDK

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,13 +12,13 @@ PODS:
   - Gini-iOS-SDK/Pinning (0.6.0):
     - Bolts (~> 1.1.5)
     - TrustKit (~> 1.5.2)
-  - GiniVision (3.3.1):
-    - GiniVision/Core (= 3.3.1)
-  - GiniVision/Core (3.3.1)
-  - GiniVision/Networking (3.3.1):
+  - GiniVision (3.3.2):
+    - GiniVision/Core (= 3.3.2)
+  - GiniVision/Core (3.3.2)
+  - GiniVision/Networking (3.3.2):
     - Gini-iOS-SDK (~> 0.6.0)
     - GiniVision/Core
-  - GiniVision/Networking+Pinning (3.3.1):
+  - GiniVision/Networking+Pinning (3.3.2):
     - Gini-iOS-SDK/Pinning (~> 0.6.0)
     - GiniVision/Networking
   - TrustKit (1.5.2)
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
   Gini-iOS-SDK: 75c35076dbbdeff5b7ac8c90b8cbd63274dbc209
-  GiniVision: fad74e4d50a2e1e0cbe195ae5a02496d50732fa9
+  GiniVision: 3d4de31ecc91cdf9c7a044aa9b1d5119b82204da
   TrustKit: fd852155aa95a02da40e2c2e0aa9060937a88abe
 
 PODFILE CHECKSUM: a97fff156f9bde6d14ac0f3ed6a158ec9bd4f008

--- a/GiniVision/Classes/Networking/APIService.swift
+++ b/GiniVision/Classes/Networking/APIService.swift
@@ -99,7 +99,7 @@ final class APIService: APIServiceProtocol {
                     task = BFTask(error: error)
                 }
                 
-                task.continue(self.handleAnalysisResultsBlock(cancelationToken: token,
+                task.continue(self.handleAnalysisResults(cancelationToken: token,
                                                               startDate: startDate,
                                                               completion: completion))
             }
@@ -185,9 +185,9 @@ extension APIService {
         }
     }
     
-    fileprivate func handleAnalysisResultsBlock(cancelationToken token: CancelationToken,
-                                                startDate: Date,
-                                                completion: @escaping (Result<[String: Extraction]>) -> Void)
+    fileprivate func handleAnalysisResults(cancelationToken token: CancelationToken,
+                                           startDate: Date,
+                                           completion: @escaping (Result<[String: Extraction]>) -> Void)
         -> BFContinuationBlock? {
             
         return { [weak self] (task: BFTask?) in

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -69,15 +69,14 @@ extension GiniScreenAPICoordinator {
     func analyzeDocument(visionDocument document: GiniVisionDocument) {
         cancelAnalysis()
         
-        apiService?.analyze(document: document, cancelationToken: CancelationToken()) { [weak self] result, _, error in
-            guard let result = result else {
-                if let error = error {
-                    self?.show(error: error)
-                    return
-                }
-                return
+        apiService?.analyze(document: document, cancelationToken: CancelationToken()) { [weak self] result in
+            switch result {
+            case .success(let response):
+                self?.present(result: response)
+            case .failure(let error):
+                self?.show(error: error)
+                
             }
-            self?.present(result: result)
         }
     }
     

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -70,8 +70,7 @@ extension GiniScreenAPICoordinator {
         cancelAnalysis()
         
         apiService?
-            .analyzeDocument(withData: document.data,
-                             cancelationToken: CancelationToken()) { [weak self] result, _, error in
+            .analyzeDocument(withData: document.data) { [weak self] result, _, error in
                                 guard let result = result else {
                                     if let error = error {
                                         self?.show(error: error)

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -37,9 +37,9 @@ extension GiniScreenAPICoordinator {
         }
     }
     
-    var apiService: APIService? {
+    var apiService: APIServiceProtocol? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKey.apiService) as? APIService
+            return objc_getAssociatedObject(self, &AssociatedKey.apiService) as? APIServiceProtocol
         }
         
         set {
@@ -69,16 +69,15 @@ extension GiniScreenAPICoordinator {
     func analyzeDocument(visionDocument document: GiniVisionDocument) {
         cancelAnalysis()
         
-        apiService?
-            .analyzeDocument(withData: document.data) { [weak self] result, _, error in
-                                guard let result = result else {
-                                    if let error = error {
-                                        self?.show(error: error)
-                                        return
-                                    }
-                                    return
-                                }
-                                self?.present(result: result)
+        apiService?.analyze(document: document, cancelationToken: CancelationToken()) { [weak self] result, _, error in
+            guard let result = result else {
+                if let error = error {
+                    self?.show(error: error)
+                    return
+                }
+                return
+            }
+            self?.present(result: result)
         }
     }
     
@@ -91,8 +90,8 @@ extension GiniScreenAPICoordinator {
             if let visionDocument = visionDocuments.first {
                 self.resultsDelegate?.giniVision([visionDocument],
                                                  analysisDidFinishWithResults: result) { [weak self] feedback in
-                    guard let `self` = self else { return }                    
-                    self.apiService?.sendFeedback(withResults: feedback)
+                                                    guard let `self` = self else { return }
+                                                    self.apiService?.sendFeedback(withResults: feedback)
                 }
             }
         } else {


### PR DESCRIPTION
In order to track when a user has cancelled the analysis, it is necessary to handle the polling of a document outside of the API SDK.
The printed logs will be shown in a future custom Logger, so they will be removed once the logger is created in a different PR.

### How to test
Run the app and analyze a document. In the middle of the analysis go back and see that the log shows the polling status.

### Merging
Automatic

Issue #174  