### PR TITLE
Restrict pdfs when image(s) have been already selected

### DIFF
--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -545,6 +545,7 @@ extension CameraViewController {
         multipageReviewBackgroundView.isHidden = !showingStack
         multipageReviewButton.setImage(image, for: .normal)
         multipageReviewButton.isUserInteractionEnabled = image != nil
+        filePickerManager.isPDFSelectionAllowed = image == nil
     }
     
     func updatePreviewViewOrientation() {

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -784,7 +784,7 @@ extension CameraViewController {
         }
         
         alertViewController.addAction(UIAlertAction(title: "Dokumente", style: .default) { [unowned self] _ in
-            self.documentPickerCoordinator.isPDFSelectionAllowed = self.multipageReviewButton.image(for: .normal) == nil
+            self.documentPickerCoordinator.isPDFSelectionAllowed = !self.imagesAlreadyPicked()
             self.documentPickerCoordinator.showDocumentPicker(from: self)
         })
         
@@ -794,6 +794,10 @@ extension CameraViewController {
         alertViewController.popoverPresentationController?.sourceView = importFileButton
         
         self.present(alertViewController, animated: true, completion: nil)
+    }
+    
+    fileprivate func imagesAlreadyPicked() -> Bool {
+        return self.multipageReviewButton.image(for: .normal) != nil
     }
     
     @available(iOS 11.0, *)

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -545,7 +545,6 @@ extension CameraViewController {
         multipageReviewBackgroundView.isHidden = !showingStack
         multipageReviewButton.setImage(image, for: .normal)
         multipageReviewButton.isUserInteractionEnabled = image != nil
-        filePickerManager.isPDFSelectionAllowed = image == nil
     }
     
     func updatePreviewViewOrientation() {
@@ -785,6 +784,7 @@ extension CameraViewController {
         }
         
         alertViewController.addAction(UIAlertAction(title: "Dokumente", style: .default) { [unowned self] _ in
+            self.documentPickerCoordinator.isPDFSelectionAllowed = self.multipageReviewButton.image(for: .normal) == nil
             self.documentPickerCoordinator.showDocumentPicker(from: self)
         })
         

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -44,7 +44,6 @@ internal final class DocumentPickerCoordinator: NSObject {
     let galleryCoordinator: GalleryCoordinator
     let giniConfiguration: GiniConfiguration
     var isPDFSelectionAllowed: Bool = true
-    var didPickDocuments: (([GiniVisionDocument]) -> Void) = { _ in }
     
     fileprivate var acceptedDocumentTypes: [String] {
         switch giniConfiguration.fileImportSupportedTypes {

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -193,7 +193,7 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
 @available(iOS 11.0, *)
 extension DocumentPickerCoordinator: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
-        if !isPDFDropSelectionAllowed(forSession: session) {
+        guard isPDFDropSelectionAllowed(forSession: session) else {
             return false
         }
         

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -43,13 +43,17 @@ internal final class DocumentPickerCoordinator: NSObject {
     weak var delegate: DocumentPickerCoordinatorDelegate?
     let galleryCoordinator: GalleryCoordinator
     let giniConfiguration: GiniConfiguration
+    var isPDFSelectionAllowed: Bool = true
+    var didPickDocuments: (([GiniVisionDocument]) -> Void) = { _ in }
     
     fileprivate var acceptedDocumentTypes: [String] {
         switch giniConfiguration.fileImportSupportedTypes {
         case .pdf_and_images:
-            return GiniPDFDocument.acceptedPDFTypes + GiniImageDocument.acceptedImageTypes
+            return isPDFSelectionAllowed ?
+                GiniPDFDocument.acceptedPDFTypes + GiniImageDocument.acceptedImageTypes :
+                GiniImageDocument.acceptedImageTypes
         case .pdf:
-            return GiniPDFDocument.acceptedPDFTypes
+            return isPDFSelectionAllowed ? GiniPDFDocument.acceptedPDFTypes : []
         case .none:
             return []
         }
@@ -190,13 +194,17 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
 @available(iOS 11.0, *)
 extension DocumentPickerCoordinator: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
-        let isItemsSelectionAllowed = session.items.count > 1 ? giniConfiguration.multipageEnabled : true
+        if !isPDFDropSelectionAllowed(forSession: session) {
+            return false
+        }
+        
+        let isMultipleItemsSelectionAllowed = session.items.count > 1 ? giniConfiguration.multipageEnabled : true
         switch giniConfiguration.fileImportSupportedTypes {
         case .pdf_and_images:
             return (session.canLoadObjects(ofClass: GiniImageDocument.self) ||
-                session.canLoadObjects(ofClass: GiniPDFDocument.self)) && isItemsSelectionAllowed
+                session.canLoadObjects(ofClass: GiniPDFDocument.self)) && isMultipleItemsSelectionAllowed
         case .pdf:
-            return session.canLoadObjects(ofClass: GiniPDFDocument.self) && isItemsSelectionAllowed
+            return session.canLoadObjects(ofClass: GiniPDFDocument.self) && isMultipleItemsSelectionAllowed
         case .none:
             return false
         }
@@ -227,10 +235,10 @@ extension DocumentPickerCoordinator: UIDropInteractionDelegate {
         }
     }
     
-    fileprivate func loadDocuments<T: NSItemProviderReading>(ofClass classs: T.Type,
-                                                             from session: UIDropSession,
-                                                             in group: DispatchGroup,
-                                                             completion: @escaping (([T]?) -> Void)) {
+    private func loadDocuments<T: NSItemProviderReading>(ofClass classs: T.Type,
+                                                         from session: UIDropSession,
+                                                         in group: DispatchGroup,
+                                                         completion: @escaping (([T]?) -> Void)) {
         group.enter()
         session.loadObjects(ofClass: classs.self) { items in
             if let items = items as? [T], items.isNotEmpty {
@@ -240,5 +248,18 @@ extension DocumentPickerCoordinator: UIDropInteractionDelegate {
             }
             group.leave()
         }
+    }
+    
+    private func isPDFDropSelectionAllowed(forSession session: UIDropSession) -> Bool {
+        if session.hasItemsConforming(toTypeIdentifiers: GiniPDFDocument.acceptedPDFTypes) {
+            let pdfIdentifier = GiniPDFDocument.acceptedPDFTypes[0]
+            let pdfItems = session.items.filter { $0.itemProvider.hasItemConformingToTypeIdentifier(pdfIdentifier) }
+            
+            if pdfItems.count > 1 || !isPDFSelectionAllowed {
+                return false
+            }
+        }
+        
+        return true
     }
 }


### PR DESCRIPTION
PDF file import should be disabled if there is already an image imported/taken

### How to test
Run the app, take a picture and try to import a PDF from the Files explorer.

### Merging
Automatic
  