### PR TITLE
Fix gallery issues

### DIFF
--- a/Example/Tests/GalleryCoordinatorDelegateMock.swift
+++ b/Example/Tests/GalleryCoordinatorDelegateMock.swift
@@ -22,5 +22,6 @@ final class GalleryCoordinatorDelegateMock: GalleryCoordinatorDelegate {
     func gallery(_ coordinator: GalleryCoordinator, didSelectImageDocuments imageDocuments: [GiniImageDocument]) {
         didOpenImages = true
         openedImageDocuments = imageDocuments
+        coordinator.dismissGallery()
     }
 }

--- a/Example/Tests/GalleryCoordinatorTests.swift
+++ b/Example/Tests/GalleryCoordinatorTests.swift
@@ -38,18 +38,10 @@ final class GalleryCoordinatorTests: XCTestCase {
                                          giniConfiguration: giniConfiguration)
     }
     
-    func testGalleryCoordinatorStart() {
-        coordinator.start()
-        
-        XCTAssertTrue(galleryManager.isCaching, "gallery manager should have started caching")
-        XCTAssertEqual(coordinator.galleryNavigator.viewControllers.count, 2,
-                       "there should be 2 view controllers in the navigator when the gallery coordinator starts")
-    }
-    
     func testCloseGallery() {
         let delegate = GalleryCoordinatorDelegateMock()
         coordinator.delegate = delegate
-        selectImage(at: 0, in: galleryManager.albums[2]) { _ in
+        selectImage(at: IndexPath(row: 0, section: 0), in: galleryManager.albums[2]) { _ in
             _ = self.coordinator.cancelButton.target?.perform(self.coordinator.cancelButton.action)
             
             XCTAssertTrue(delegate.didCancelGallery,
@@ -63,8 +55,8 @@ final class GalleryCoordinatorTests: XCTestCase {
         let delegate = GalleryCoordinatorDelegateMock()
         coordinator.delegate = delegate
         
-        selectImage(at: 0, in: galleryManager.albums[2]) { _ in
-            self.selectImage(at: 1, in: self.galleryManager.albums[2]) { _ in
+        selectImage(at: IndexPath(row: 0, section: 0), in: galleryManager.albums[2]) { _ in
+            self.selectImage(at: IndexPath(row: 1, section: 0), in: self.galleryManager.albums[2]) { _ in
                 let innerButton = self.coordinator.openImagesButton.customView as? UIButton
                 innerButton?.sendActions(for: .touchUpInside)
                 
@@ -81,7 +73,7 @@ final class GalleryCoordinatorTests: XCTestCase {
     func testNavigateBackToAlbumsTable() {
         coordinator.start()
         
-        selectImage(at: 0, in: galleryManager.albums[2]) { _ in
+        selectImage(at: IndexPath(row: 0, section: 0), in: galleryManager.albums[2]) { _ in
             _ = self.coordinator.navigationController(self.coordinator.galleryNavigator,
                                                       animationControllerFor: .pop,
                                                       from: self.dummyImagePicker,
@@ -94,7 +86,7 @@ final class GalleryCoordinatorTests: XCTestCase {
     }
     
     func testImagePickerDelegateDidSelect() {
-        selectImage(at: 0, in: galleryManager.albums[2]) { imagePicker in
+        selectImage(at: IndexPath(row: 0, section: 0), in: galleryManager.albums[2]) { imagePicker in
             XCTAssertEqual(imagePicker.navigationItem.rightBarButtonItem,
                            self.coordinator.openImagesButton,
                            "once that an image has been selected, the right bar button should be Open and not Cancel")
@@ -105,10 +97,11 @@ final class GalleryCoordinatorTests: XCTestCase {
     
     func testImagePickerDelegateDidDeselect() {
         let album = galleryManager.albums[1]
-        let deselectionIndex = 0
+        let deselectionIndex = IndexPath(row: 0, section: 0)
         selectImage(at: deselectionIndex, in: album) { imagePicker in
             self.coordinator.imagePicker(imagePicker,
-                                         didDeselectAsset: album.assets[deselectionIndex])
+                                         didDeselectAsset: album.assets[deselectionIndex.row],
+                                         at: deselectionIndex)
             XCTAssertTrue(self.coordinator.selectedImageDocuments.isEmpty,
                           "selected documents array should be 0 after removing all selected items.")
             XCTAssertEqual(imagePicker.navigationItem.rightBarButtonItem,
@@ -117,12 +110,13 @@ final class GalleryCoordinatorTests: XCTestCase {
         }
     }
     
-    fileprivate func selectImage(at index: Int, in album: Album, handler: @escaping ((ImagePickerViewController) -> Void)) {
+    fileprivate func selectImage(at index: IndexPath, in album: Album, handler: @escaping ((ImagePickerViewController) -> Void)) {
         let imagePicker = ImagePickerViewController(album: album,
                                                     galleryManager: galleryManager,
                                                     giniConfiguration: GiniConfiguration.sharedConfiguration)
         coordinator.imagePicker(imagePicker,
-                                didSelectAsset: album.assets[index])
+                                didSelectAsset: album.assets[index.row],
+                                at: index)
 
         _ = expectation(for: NSPredicate(format: "count != 0"),
                         evaluatedWith: coordinator.selectedImageDocuments, handler: nil)

--- a/Example/Tests/GalleryManagerMock.swift
+++ b/Example/Tests/GalleryManagerMock.swift
@@ -23,6 +23,10 @@ final class GalleryManagerMock: GalleryManagerProtocol {
     
     var isCaching = false
     
+    func reloadAlbums() {
+        
+    }
+    
     func startCachingImages(for album: Album) {
         isCaching = true
     }

--- a/Example/Tests/GalleryManagerMock.swift
+++ b/Example/Tests/GalleryManagerMock.swift
@@ -11,6 +11,8 @@ import Photos
 @testable import GiniVision
 
 final class GalleryManagerMock: GalleryManagerProtocol {
+
+    
     var albums: [Album] = [Album(assets: [Asset(identifier: "Asset 1")],
                                  title: "Album 1",
                                  identifier: "Album 1"),
@@ -35,7 +37,7 @@ final class GalleryManagerMock: GalleryManagerProtocol {
         isCaching = false
     }
     
-    func fetchImageData(from asset: Asset, completion: @escaping ((Data) -> Void)) {
+    func fetchImageData(from asset: Asset, isRemote: Bool, completion: @escaping ((Data?) -> Void)) {
         completion(Data(count: 10))
     }
     

--- a/Example/Tests/ImagePickerViewControllerDelegateMock.swift
+++ b/Example/Tests/ImagePickerViewControllerDelegateMock.swift
@@ -18,8 +18,8 @@ final class ImagePickerViewControllerDelegateMock: ImagePickerViewControllerDele
     }
     
     func imagePicker(_ viewController: ImagePickerViewController, didDeselectAsset asset: Asset, at index: IndexPath) {
-        if let index = selectedAssets.index(where: { $0.identifier == asset.identifier}) {
-            selectedAssets.remove(at: index)
+        if let selectedIndex = selectedAssets.index(where: { $0.identifier == asset.identifier}) {
+            selectedAssets.remove(at: selectedIndex)
         }
         viewController.deselectCell(at: index)
     }

--- a/Example/Tests/ImagePickerViewControllerDelegateMock.swift
+++ b/Example/Tests/ImagePickerViewControllerDelegateMock.swift
@@ -12,14 +12,16 @@ import Foundation
 final class ImagePickerViewControllerDelegateMock: ImagePickerViewControllerDelegate {
     var selectedAssets: [Asset] = []
 
-    func imagePicker(_ viewController: ImagePickerViewController, didSelectAsset asset: Asset) {
+    func imagePicker(_ viewController: ImagePickerViewController, didSelectAsset asset: Asset, at index: IndexPath) {
         selectedAssets.append(asset)
+        viewController.selectCell(at: index)
     }
     
-    func imagePicker(_ viewController: ImagePickerViewController, didDeselectAsset asset: Asset) {
+    func imagePicker(_ viewController: ImagePickerViewController, didDeselectAsset asset: Asset, at index: IndexPath) {
         if let index = selectedAssets.index(where: { $0.identifier == asset.identifier}) {
             selectedAssets.remove(at: index)
         }
+        viewController.deselectCell(at: index)
     }
     
 }

--- a/Example/Tests/ImagePickerViewControllerTests.swift
+++ b/Example/Tests/ImagePickerViewControllerTests.swift
@@ -64,7 +64,7 @@ final class ImagePickerViewControllerTests: XCTestCase {
         
         vc.collectionView(vc.collectionView, didSelectItemAt: selectedCellIndex)
         vc.collectionView(vc.collectionView, didSelectItemAt: selectedCellIndex2)
-        vc.collectionView(vc.collectionView, didDeselectItemAt: selectedCellIndex2)
+        vc.collectionView(vc.collectionView, didSelectItemAt: selectedCellIndex2)
         
         XCTAssertEqual(delegate.selectedAssets.count, 1,
                        "the selected indexes count should match thet ones delivered to the delegate")

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -703,6 +703,10 @@ extension CameraViewController {
         // Configure file picker
         documentPickerCoordinator.startCaching()
         documentPickerCoordinator.delegate = self
+
+        if documentPickerCoordinator.isGalleryPermissionGranted {
+            documentPickerCoordinator.startCaching()
+        }
         
         // Configure import file button
         controlsView.addSubview(importFileButton)

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -701,7 +701,6 @@ extension CameraViewController: DocumentPickerCoordinatorDelegate {
 extension CameraViewController {
     fileprivate func enableFileImport() {
         // Configure file picker
-        documentPickerCoordinator.startCaching()
         documentPickerCoordinator.delegate = self
 
         if documentPickerCoordinator.isGalleryPermissionGranted {

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -157,11 +157,9 @@ internal final class DocumentPickerCoordinator: NSObject {
 
 extension DocumentPickerCoordinator: GalleryCoordinatorDelegate {
     func gallery(_ coordinator: GalleryCoordinator,
-                 didSelectImageDocuments imageDocuments: [GiniImageDocument],
-                 completion: @escaping () -> Void) {
+                 didSelectImageDocuments imageDocuments: [GiniImageDocument]) {
         delegate?.documentPicker(self, didPick: imageDocuments, from: .gallery) { [weak self] error, didDismiss in
             guard let error = error else {
-                completion()
                 coordinator.dismissGallery(completion: didDismiss)
                 return
             }

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import MobileCoreServices
-import Photos
 
 protocol DocumentPickerCoordinatorDelegate: class {
     /**
@@ -44,6 +43,10 @@ internal final class DocumentPickerCoordinator: NSObject {
     let galleryCoordinator: GalleryCoordinator
     let giniConfiguration: GiniConfiguration
     var isPDFSelectionAllowed: Bool = true
+    
+    var isGalleryPermissionGranted: Bool {
+        return galleryCoordinator.isGalleryPermissionGranted
+    }
     
     fileprivate var acceptedDocumentTypes: [String] {
         switch giniConfiguration.fileImportSupportedTypes {

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -156,9 +156,12 @@ internal final class DocumentPickerCoordinator: NSObject {
 // MARK: GalleryCoordinatorDelegate
 
 extension DocumentPickerCoordinator: GalleryCoordinatorDelegate {
-    func gallery(_ coordinator: GalleryCoordinator, didSelectImageDocuments imageDocuments: [GiniImageDocument]) {
+    func gallery(_ coordinator: GalleryCoordinator,
+                 didSelectImageDocuments imageDocuments: [GiniImageDocument],
+                 completion: @escaping () -> Void) {
         delegate?.documentPicker(self, didPick: imageDocuments, from: .gallery) { [weak self] error, didDismiss in
             guard let error = error else {
+                completion()
                 coordinator.dismissGallery(completion: didDismiss)
                 return
             }

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -71,9 +71,7 @@ internal final class DocumentPickerCoordinator: NSObject {
     // MARK: - Start caching
     
     func startCaching() {
-        DispatchQueue.global().async {
-            self.galleryCoordinator.start()
-        }
+        galleryCoordinator.start()
     }
     
     // MARK: Picker presentation

--- a/GiniVision/Classes/Core/Gallery/AlbumsPickerViewController.swift
+++ b/GiniVision/Classes/Core/Gallery/AlbumsPickerViewController.swift
@@ -55,6 +55,10 @@ final class AlbumsPickerViewController: UIViewController {
         Constraints.pin(view: albumsTableView, toSuperView: view)
     }
     
+    func reloadAlbums() {
+        albumsTableView.reloadData()
+    }
+    
 }
 
 // MARK: UITableViewDataSource

--- a/GiniVision/Classes/Core/Gallery/Asset.swift
+++ b/GiniVision/Classes/Core/Gallery/Asset.swift
@@ -17,3 +17,9 @@ struct Asset {
         self.identifier = value.localIdentifier
     }
 }
+
+extension Asset: Equatable {
+    static func ==(lhs: Asset, rhs: Asset) -> Bool {
+        return lhs.identifier == rhs.identifier
+    }
+}

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -204,8 +204,8 @@ extension GalleryCoordinator: ImagePickerViewControllerDelegate {
                         if let data = data {
                             DispatchQueue.main.async {
                                 viewController.removeFromDownloadingItems(index: index)
+                                viewController.selectCell(at: index)
                             }
-                            viewController.selectCell(at: index)
                             self.addSelected(asset, withData: data)
                         }
                     }
@@ -216,9 +216,11 @@ extension GalleryCoordinator: ImagePickerViewControllerDelegate {
     }
     
     func imagePicker(_ viewController: ImagePickerViewController,
-                     didDeselectAsset asset: Asset) {
-        if let index = selectedImageDocuments.index(forKey: asset.identifier) {
-            selectedImageDocuments.remove(at: index)
+                     didDeselectAsset asset: Asset,
+                     at index: IndexPath) {
+        if let documentIndex = selectedImageDocuments.index(forKey: asset.identifier) {
+            viewController.deselectCell(at: index)
+            selectedImageDocuments.remove(at: documentIndex)
         }
         
         if let selectedItems = viewController.collectionView.indexPathsForSelectedItems, selectedItems.isEmpty {

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -10,8 +10,7 @@ import Photos
 
 protocol GalleryCoordinatorDelegate: class {
     func gallery(_ coordinator: GalleryCoordinator,
-                 didSelectImageDocuments imageDocuments: [GiniImageDocument],
-                 completion: @escaping () -> Void)
+                 didSelectImageDocuments imageDocuments: [GiniImageDocument])
     func gallery(_ coordinator: GalleryCoordinator, didCancel: Void)
 }
 
@@ -103,6 +102,13 @@ final class GalleryCoordinator: NSObject, Coordinator {
     
     func dismissGallery(completion: (() -> Void)? = nil) {
         rootViewController.dismiss(animated: true, completion: completion)
+        resetToInitialState()
+    }
+    
+    private func resetToInitialState() {
+        self.selectedImageDocuments.removeAll()
+        self.currentImagePickerViewController?.deselectAllCells()
+        self.currentImagePickerViewController?.navigationItem.setRightBarButton(cancelButton, animated: true)
     }
     
     // MARK: - Bar button actions
@@ -114,13 +120,7 @@ final class GalleryCoordinator: NSObject, Coordinator {
     
     @objc fileprivate func openImages() {
         let imageDocuments: [GiniImageDocument] = selectedImageDocuments.map { $0.value }
-        delegate?.gallery(self, didSelectImageDocuments: imageDocuments) { [weak self] in
-            self?.selectedImageDocuments.removeAll()
-            self?.currentImagePickerViewController?.deselectAllCells()
-            self?.currentImagePickerViewController?.navigationItem.setRightBarButton(self?.cancelButton,
-                                                                                     animated: true)
-        }
-
+        delegate?.gallery(self, didSelectImageDocuments: imageDocuments)
     }
     
     // MARK: - Image picker generation.

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -19,6 +19,7 @@ final class GalleryCoordinator: NSObject, Coordinator {
     fileprivate let giniConfiguration: GiniConfiguration
     fileprivate let galleryManager: GalleryManagerProtocol
     fileprivate(set) var selectedImageDocuments: [String: GiniImageDocument] = [:]
+    fileprivate var currentImagePickerViewController: ImagePickerViewController?
     
     var isGalleryPermissionGranted: Bool {
         return PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.authorized
@@ -88,9 +89,9 @@ final class GalleryCoordinator: NSObject, Coordinator {
     
     func start() {
         if let firstAlbum = galleryManager.albums.first {
-            let imagePicker = createImagePicker(with: firstAlbum)
+            currentImagePickerViewController = createImagePicker(with: firstAlbum)
             galleryManager.startCachingImages(for: firstAlbum)
-            galleryNavigator.pushViewController(imagePicker, animated: false)
+            galleryNavigator.pushViewController(currentImagePickerViewController!, animated: false)
         }
     }
     
@@ -109,7 +110,7 @@ final class GalleryCoordinator: NSObject, Coordinator {
         let imageDocuments: [GiniImageDocument] = selectedImageDocuments.map { $0.value }
         delegate?.gallery(self, didSelectImageDocuments: imageDocuments)
         selectedImageDocuments.removeAll()
-        galleryNavigator.popViewController(animated: true)
+        currentImagePickerViewController?.deselectAllCells()
     }
     
     // MARK: - Image picker generation.
@@ -161,6 +162,7 @@ extension GalleryCoordinator: UINavigationControllerDelegate {
         if let imagePicker = fromVC as? ImagePickerViewController {
             galleryManager.stopCachingImages(for: imagePicker.currentAlbum)
             selectedImageDocuments.removeAll()
+            currentImagePickerViewController = nil
         }
         return nil
     }
@@ -170,8 +172,8 @@ extension GalleryCoordinator: UINavigationControllerDelegate {
 
 extension GalleryCoordinator: AlbumsPickerViewControllerDelegate {
     func albumsPicker(_ viewController: AlbumsPickerViewController, didSelectAlbum album: Album) {
-        let imagePicker = createImagePicker(with: album)
-        galleryNavigator.pushViewController(imagePicker, animated: true)
+        currentImagePickerViewController = createImagePicker(with: album)
+        galleryNavigator.pushViewController(currentImagePickerViewController!, animated: true)
     }
 }
 

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -9,7 +9,9 @@ import Foundation
 import Photos
 
 protocol GalleryCoordinatorDelegate: class {
-    func gallery(_ coordinator: GalleryCoordinator, didSelectImageDocuments imageDocuments: [GiniImageDocument])
+    func gallery(_ coordinator: GalleryCoordinator,
+                 didSelectImageDocuments imageDocuments: [GiniImageDocument],
+                 completion: @escaping () -> Void)
     func gallery(_ coordinator: GalleryCoordinator, didCancel: Void)
 }
 
@@ -112,9 +114,13 @@ final class GalleryCoordinator: NSObject, Coordinator {
     
     @objc fileprivate func openImages() {
         let imageDocuments: [GiniImageDocument] = selectedImageDocuments.map { $0.value }
-        delegate?.gallery(self, didSelectImageDocuments: imageDocuments)
-        selectedImageDocuments.removeAll()
-        currentImagePickerViewController?.deselectAllCells()
+        delegate?.gallery(self, didSelectImageDocuments: imageDocuments) { [weak self] in
+            self?.selectedImageDocuments.removeAll()
+            self?.currentImagePickerViewController?.deselectAllCells()
+            self?.currentImagePickerViewController?.navigationItem.setRightBarButton(self?.cancelButton,
+                                                                                     animated: true)
+        }
+
     }
     
     // MARK: - Image picker generation.
@@ -227,7 +233,7 @@ extension GalleryCoordinator: ImagePickerViewControllerDelegate {
             selectedImageDocuments.remove(at: documentIndex)
         }
         
-        if let selectedItems = viewController.collectionView.indexPathsForSelectedItems, selectedItems.isEmpty {
+        if selectedImageDocuments.isEmpty {
             viewController.navigationItem.setRightBarButton(cancelButton, animated: true)
         }
     }

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -23,7 +23,7 @@ final class GalleryCoordinator: NSObject, Coordinator {
     fileprivate var currentImagePickerViewController: ImagePickerViewController?
     
     var isGalleryPermissionGranted: Bool {
-        return PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.authorized
+        return PHPhotoLibrary.authorizationStatus() == .authorized
     }
     
     // MARK: - View controllers

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -88,10 +88,14 @@ final class GalleryCoordinator: NSObject, Coordinator {
     // MARK: - Coordinator lifecycle
     
     func start() {
-        if let firstAlbum = galleryManager.albums.first {
-            currentImagePickerViewController = createImagePicker(with: firstAlbum)
-            galleryManager.startCachingImages(for: firstAlbum)
-            galleryNavigator.pushViewController(currentImagePickerViewController!, animated: false)
+        DispatchQueue.global().async {
+            if let firstAlbum = self.galleryManager.albums.first {                
+                DispatchQueue.main.async {
+                    self.galleryManager.startCachingImages(for: firstAlbum)
+                    self.currentImagePickerViewController = self.createImagePicker(with: firstAlbum)
+                    self.galleryNavigator.pushViewController(self.currentImagePickerViewController!, animated: false)
+                }
+            }
         }
     }
     

--- a/GiniVision/Classes/Core/Gallery/GalleryManager.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryManager.swift
@@ -13,11 +13,17 @@ protocol GalleryManagerProtocol: class {
     func fetchImage(from asset: Asset,
                     imageQuality: ImageQuality,
                     completion: @escaping ((UIImage) -> Void))
-    func fetchImageData(from asset: Asset,
-                        completion: @escaping ((Data) -> Void))
+    func fetchImageData(from asset: Asset, isRemote: Bool, completion: @escaping ((Data?) -> Void))
     func reloadAlbums()
     func startCachingImages(for album: Album)
     func stopCachingImages(for album: Album)
+}
+
+extension GalleryManagerProtocol {
+    func fetchImageData(from asset: Asset, completion: @escaping ((Data?) -> Void)) {
+        self.fetchImageData(from: asset, isRemote: false, completion: completion)
+    }
+
 }
 
 enum ImageQuality {
@@ -44,11 +50,14 @@ final class GalleryManager: GalleryManagerProtocol {
         }
     }
     
-    func fetchImageData(from asset: Asset, completion: @escaping ((Data) -> Void)) {
-        cachingImageManager.requestImageData(for: asset.value, options: nil) { data, _, _, _ in
-            if let data = data {
-                completion(data)
-            }
+    func fetchImageData(from asset: Asset, isRemote: Bool, completion: @escaping ((Data?) -> Void)) {
+        var options: PHImageRequestOptions?
+        if isRemote {
+            options = PHImageRequestOptions()
+            options?.isNetworkAccessAllowed = true
+        }
+        cachingImageManager.requestImageData(for: asset.value, options: options) { data, _, _, _ in
+            completion(data)
         }
     }
     

--- a/GiniVision/Classes/Core/Gallery/GalleryManager.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryManager.swift
@@ -13,17 +13,11 @@ protocol GalleryManagerProtocol: class {
     func fetchImage(from asset: Asset,
                     imageQuality: ImageQuality,
                     completion: @escaping ((UIImage) -> Void))
-    func fetchImageData(from asset: Asset, isRemote: Bool, completion: @escaping ((Data?) -> Void))
+    func fetchImageData(from asset: Asset, completion: @escaping ((Data?) -> Void))
+    func fetchRemoteImageData(from asset: Asset,completion: @escaping ((Data?) -> Void))
     func reloadAlbums()
     func startCachingImages(for album: Album)
     func stopCachingImages(for album: Album)
-}
-
-extension GalleryManagerProtocol {
-    func fetchImageData(from asset: Asset, completion: @escaping ((Data?) -> Void)) {
-        self.fetchImageData(from: asset, isRemote: false, completion: completion)
-    }
-
 }
 
 enum ImageQuality {
@@ -50,12 +44,17 @@ final class GalleryManager: GalleryManagerProtocol {
         }
     }
     
-    func fetchImageData(from asset: Asset, isRemote: Bool, completion: @escaping ((Data?) -> Void)) {
-        var options: PHImageRequestOptions?
-        if isRemote {
-            options = PHImageRequestOptions()
-            options?.isNetworkAccessAllowed = true
+    func fetchImageData(from asset: Asset, completion: @escaping ((Data?) -> Void)) {
+        cachingImageManager.requestImageData(for: asset.value, options: nil) { data, _, _, _ in
+            completion(data)
         }
+    }
+    
+    func fetchRemoteImageData(from asset: Asset, completion: @escaping ((Data?) -> Void)) {
+        var options: PHImageRequestOptions
+        options = PHImageRequestOptions()
+        options.isNetworkAccessAllowed = true
+        
         cachingImageManager.requestImageData(for: asset.value, options: options) { data, _, _, _ in
             completion(data)
         }

--- a/GiniVision/Classes/Core/Gallery/GalleryManager.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryManager.swift
@@ -15,6 +15,7 @@ protocol GalleryManagerProtocol: class {
                     completion: @escaping ((UIImage) -> Void))
     func fetchImageData(from asset: Asset,
                         completion: @escaping ((Data) -> Void))
+    func reloadAlbums()
     func startCachingImages(for album: Album)
     func stopCachingImages(for album: Album)
 }
@@ -25,11 +26,9 @@ enum ImageQuality {
 
 final class GalleryManager: GalleryManagerProtocol {
     
-    fileprivate let cachingImageManager = PHCachingImageManager()
+    private lazy var cachingImageManager = PHCachingImageManager()
     fileprivate let thumbnailSize = CGSize(width: 250, height: 250)
-    lazy var albums: [Album] = self.fetchAlbums().sorted(by: {
-        return $0.count > $1.count
-    })
+    lazy var albums: [Album] = self.fetchSortedAlbums()
         
     func fetchImage(from asset: Asset,
                     imageQuality: ImageQuality,
@@ -51,6 +50,10 @@ final class GalleryManager: GalleryManagerProtocol {
                 completion(data)
             }
         }
+    }
+    
+    func reloadAlbums() {
+        self.albums = fetchSortedAlbums()
     }
     
     func startCachingImages(for album: Album) {
@@ -90,7 +93,7 @@ extension GalleryManager {
         return assets
     }
     
-    fileprivate func fetchAlbums() -> [Album] {
+    fileprivate func fetchSortedAlbums() -> [Album] {
         var albums: [Album] = []
         let userAlbumsCollection = PHAssetCollection.fetchAssetCollections(with: PHAssetCollectionType.smartAlbum,
                                                                            subtype: PHAssetCollectionSubtype.any,
@@ -112,6 +115,8 @@ extension GalleryManager {
             })
         }
 
-        return albums
+        return albums.sorted(by: {
+            return $0.count > $1.count
+        })
     }
 }

--- a/GiniVision/Classes/Core/Gallery/ImagePickerCollectionViewCell.swift
+++ b/GiniVision/Classes/Core/Gallery/ImagePickerCollectionViewCell.swift
@@ -12,6 +12,13 @@ final class ImagePickerCollectionViewCell: UICollectionViewCell {
     
     let selectedCircleSize = CGSize(width: 25, height: 25)
     
+    lazy var activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.alpha = 0
+        return indicator
+    }()
+    
     fileprivate lazy var galleryImage: UIImageView = {
         let galleryImage: UIImageView = UIImageView(frame: .zero)
         galleryImage.translatesAutoresizingMaskIntoConstraints = false
@@ -45,10 +52,10 @@ final class ImagePickerCollectionViewCell: UICollectionViewCell {
         return circleView
     }()
     
-    override var isSelected: Bool {
+    var isProgramaticallySelected: Bool = false {
         didSet {
-            selectedForegroundView.alpha = isSelected ? 1 : 0
-            changeCheckCircle(to: isSelected)
+            selectedForegroundView.alpha = isProgramaticallySelected ? 1 : 0
+            changeCheckCircle(to: isProgramaticallySelected)
         }
     }
     
@@ -63,8 +70,10 @@ final class ImagePickerCollectionViewCell: UICollectionViewCell {
         addSubview(galleryImage)
         addSubview(selectedForegroundView)
         addSubview(checkCircleBackground)
+        addSubview(activityIndicator)
         checkCircleBackground.addSubview(checkImage)
         
+        Constraints.center(view: activityIndicator, with: self)
         Constraints.pin(view: galleryImage, toSuperView: self)
         Constraints.pin(view: selectedForegroundView, toSuperView: self)
         Constraints.active(item: checkCircleBackground, attr: .bottom, relatedBy: .equal, to: self, attr: .bottom,
@@ -85,8 +94,18 @@ final class ImagePickerCollectionViewCell: UICollectionViewCell {
     
     func fill(withAsset asset: Asset,
               multipleSelectionEnabled: Bool,
-              galleryManager: GalleryManagerProtocol) {
-        checkCircleBackground.alpha = multipleSelectionEnabled ? 1 : 0
+              galleryManager: GalleryManagerProtocol,
+              isDownloading: Bool,
+              isSelected: Bool) {
+        checkCircleBackground.alpha = multipleSelectionEnabled && !isDownloading ? 1 : 0
+        activityIndicator.alpha = isDownloading ? 1 : 0
+        isProgramaticallySelected = isSelected
+        selectedForegroundView.alpha = isSelected || isDownloading ? 1 : 0
+
+        if isDownloading {
+            activityIndicator.startAnimating()
+        }
+
         galleryManager.fetchImage(from: asset, imageQuality: .thumbnail) { [weak self] image in
             self?.galleryImage.image = image
         }

--- a/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
+++ b/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
@@ -9,13 +9,15 @@ import Foundation
 import Photos
 
 protocol ImagePickerViewControllerDelegate: class {
-    func imagePicker(_ viewController: ImagePickerViewController, didSelectAsset asset: Asset)
+    func imagePicker(_ viewController: ImagePickerViewController, didSelectAsset asset: Asset, at index: IndexPath)
     func imagePicker(_ viewController: ImagePickerViewController, didDeselectAsset  asset: Asset)
 }
 
 final class ImagePickerViewController: UIViewController {
     
     let currentAlbum: Album
+    var indexesForAssetsBeingDownloaded: [IndexPath] = []
+    var indexesForSelectedCells: [IndexPath] = []
     weak var delegate: ImagePickerViewControllerDelegate?
     fileprivate let galleryManager: GalleryManagerProtocol
     fileprivate let giniConfiguration: GiniConfiguration
@@ -79,6 +81,30 @@ final class ImagePickerViewController: UIViewController {
             self.collectionView.deselectItem(at: index, animated: false)
         }
     }
+    
+    func addToDownloadingItems(index: IndexPath) {
+        indexesForAssetsBeingDownloaded.append(index)
+        collectionView.reloadItems(at: [index])
+    }
+    
+    func removeFromDownloadingItems(index: IndexPath) {
+        if let assetIndex = indexesForAssetsBeingDownloaded.index(of: index) {
+            indexesForAssetsBeingDownloaded.remove(at: assetIndex)
+            collectionView.reloadItems(at: [index])
+        }
+    }
+    
+    func selectCell(at indexPath: IndexPath) {
+        indexesForSelectedCells.append(indexPath)
+        collectionView.reloadItems(at: [indexPath])
+    }
+    
+    func deselectCell(at indexPath: IndexPath) {
+        if let deselectCellIndex = indexesForSelectedCells.index(of: indexPath) {
+            indexesForSelectedCells.remove(at: deselectCellIndex)
+            collectionView.reloadItems(at: [indexPath])
+        }
+    }
  
     fileprivate func scrollToBottomOnStartup() {
         // This tweak is needed to fix an issue with the UICollectionView. UICollectionView doesn't
@@ -105,7 +131,9 @@ extension ImagePickerViewController: UICollectionViewDataSource {
         let asset = currentAlbum.assets[indexPath.row]
         cell?.fill(withAsset: asset,
                    multipleSelectionEnabled: giniConfiguration.multipageEnabled,
-                   galleryManager: galleryManager)
+                   galleryManager: galleryManager,
+                   isDownloading: indexesForAssetsBeingDownloaded.contains(indexPath),
+                   isSelected: indexesForSelectedCells.contains(indexPath))
         
         return cell!
     }
@@ -134,12 +162,13 @@ extension ImagePickerViewController: UICollectionViewDelegateFlowLayout {
             collectionView.deselectItem(at: indexPath, animated: false)
         } else {
             let asset = currentAlbum.assets[indexPath.row]
-            delegate?.imagePicker(self, didSelectAsset: asset)
+            delegate?.imagePicker(self, didSelectAsset: asset, at: indexPath)
         }
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         let asset = currentAlbum.assets[indexPath.row]
+        deselectCell(at: indexPath)
         delegate?.imagePicker(self, didDeselectAsset: asset)
     }
 }

--- a/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
+++ b/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
@@ -9,8 +9,12 @@ import Foundation
 import Photos
 
 protocol ImagePickerViewControllerDelegate: class {
-    func imagePicker(_ viewController: ImagePickerViewController, didSelectAsset asset: Asset, at index: IndexPath)
-    func imagePicker(_ viewController: ImagePickerViewController, didDeselectAsset  asset: Asset)
+    func imagePicker(_ viewController: ImagePickerViewController,
+                     didSelectAsset asset: Asset,
+                     at index: IndexPath)
+    func imagePicker(_ viewController: ImagePickerViewController,
+                     didDeselectAsset  asset: Asset,
+                     at index: IndexPath)
 }
 
 final class ImagePickerViewController: UIViewController {
@@ -77,9 +81,11 @@ final class ImagePickerViewController: UIViewController {
     // MARK: - Others
     
     func deselectAllCells() {
-        collectionView.indexPathsForSelectedItems?.forEach { index in
-            self.collectionView.deselectItem(at: index, animated: false)
-        }
+        var indexesToDeselect: [IndexPath] = []
+        indexesToDeselect.append(contentsOf: indexesForSelectedCells)
+        
+        indexesForSelectedCells.removeAll()
+        self.collectionView.reloadItems(at: indexesToDeselect)
     }
     
     func addToDownloadingItems(index: IndexPath) {
@@ -158,17 +164,12 @@ extension ImagePickerViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        if let selectedIndexes = collectionView.indexPathsForSelectedItems, selectedIndexes.count > 10 {
-            collectionView.deselectItem(at: indexPath, animated: false)
+        let asset = currentAlbum.assets[indexPath.row]
+
+        if indexesForSelectedCells.contains(indexPath) {
+            delegate?.imagePicker(self, didDeselectAsset: asset, at: indexPath)
         } else {
-            let asset = currentAlbum.assets[indexPath.row]
             delegate?.imagePicker(self, didSelectAsset: asset, at: indexPath)
         }
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        let asset = currentAlbum.assets[indexPath.row]
-        deselectCell(at: indexPath)
-        delegate?.imagePicker(self, didDeselectAsset: asset)
     }
 }

--- a/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
+++ b/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
@@ -20,13 +20,12 @@ protocol ImagePickerViewControllerDelegate: class {
 final class ImagePickerViewController: UIViewController {
     
     let currentAlbum: Album
-    var indexesForAssetsBeingDownloaded: [IndexPath] = []
-    var indexesForSelectedCells: [IndexPath] = []
     weak var delegate: ImagePickerViewControllerDelegate?
+    fileprivate var indexesForAssetsBeingDownloaded: [IndexPath] = []
+    fileprivate var indexesForSelectedCells: [IndexPath] = []
     fileprivate let galleryManager: GalleryManagerProtocol
     fileprivate let giniConfiguration: GiniConfiguration
     private var isInitialized: Bool = false
-    private let multipleSelectionLimit: Int = 10
     
     // MARK: - Views
     

--- a/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
+++ b/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
@@ -79,14 +79,6 @@ final class ImagePickerViewController: UIViewController {
     
     // MARK: - Others
     
-    func deselectAllCells() {
-        var indexesToDeselect: [IndexPath] = []
-        indexesToDeselect.append(contentsOf: indexesForSelectedCells)
-        
-        indexesForSelectedCells.removeAll()
-        self.collectionView.reloadItems(at: indexesToDeselect)
-    }
-    
     func addToDownloadingItems(index: IndexPath) {
         indexesForAssetsBeingDownloaded.append(index)
         collectionView.reloadItems(at: [index])
@@ -109,6 +101,14 @@ final class ImagePickerViewController: UIViewController {
             indexesForSelectedCells.remove(at: deselectCellIndex)
             collectionView.reloadItems(at: [indexPath])
         }
+    }
+    
+    func deselectAllCells() {
+        var indexesToDeselect: [IndexPath] = []
+        indexesToDeselect.append(contentsOf: indexesForSelectedCells)
+        
+        indexesForSelectedCells.removeAll()
+        self.collectionView.reloadItems(at: indexesToDeselect)
     }
  
     fileprivate func scrollToBottomOnStartup() {

--- a/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
+++ b/GiniVision/Classes/Core/Gallery/ImagePickerViewController.swift
@@ -73,6 +73,12 @@ final class ImagePickerViewController: UIViewController {
     }
     
     // MARK: - Others
+    
+    func deselectAllCells() {
+        collectionView.indexPathsForSelectedItems?.forEach { index in
+            self.collectionView.deselectItem(at: index, animated: false)
+        }
+    }
  
     fileprivate func scrollToBottomOnStartup() {
         // This tweak is needed to fix an issue with the UICollectionView. UICollectionView doesn't

--- a/GiniVision/Classes/Core/GiniVisionUtils.swift
+++ b/GiniVision/Classes/Core/GiniVisionUtils.swift
@@ -70,7 +70,9 @@ internal func UIFontPreferred(_ weight: FontWeight, andSize size: CGFloat) -> UI
 
 internal struct AnimationDuration {
     static var slow = 1.0
+    static var mediumSlow = 0.7
     static var medium = 0.5
+    static var mediumFast = 0.3
     static var fast = 0.2
 }
 

--- a/GiniVision/Classes/Core/GiniVisionUtils.swift
+++ b/GiniVision/Classes/Core/GiniVisionUtils.swift
@@ -70,10 +70,8 @@ internal func UIFontPreferred(_ weight: FontWeight, andSize size: CGFloat) -> UI
 
 internal struct AnimationDuration {
     static var slow = 1.0
-    static var mediumSlow = 0.7
-    static var medium = 0.5
-    static var mediumFast = 0.3
-    static var fast = 0.2
+    static var medium = 0.6
+    static var fast = 0.3
 }
 
 internal enum FontWeight {

--- a/GiniVision/Classes/Core/MultipageReviewTransitionAnimator.swift
+++ b/GiniVision/Classes/Core/MultipageReviewTransitionAnimator.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class MultipageReviewTransitionAnimator: NSObject {
     
-    let animationDuration = AnimationDuration.medium
+    let animationDuration = AnimationDuration.mediumFast
     var operation: UINavigationControllerOperation = .push
     var originFrame: CGRect = .zero
     var popImage: UIImage?

--- a/GiniVision/Classes/Core/MultipageReviewTransitionAnimator.swift
+++ b/GiniVision/Classes/Core/MultipageReviewTransitionAnimator.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class MultipageReviewTransitionAnimator: NSObject {
     
-    let animationDuration = AnimationDuration.mediumFast
+    let animationDuration = AnimationDuration.fast
     var operation: UINavigationControllerOperation = .push
     var originFrame: CGRect = .zero
     var popImage: UIImage?


### PR DESCRIPTION
There was a couple of issues related to gallery:

- Opening the gallery before giving access to it resulted in a blank collection since images weren't cached after that.
- When fetching assets from the OS, if the asset was in iCloud it returned `nil`.

### How to test
Make a clean install of the app and try to open the gallery after granting permissions to it. Also select an asset from iCloud.

### Merging
Automatic
  