### PR TITLE
Refactor document validation

### DIFF
--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -44,9 +44,9 @@
 		1F62FA3A1FA2207800CEA828 /* GINIImageNoResultsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F62FA351FA2207200CEA828 /* GINIImageNoResultsViewControllerTests.swift */; };
 		1F62FA3B1FA2207800CEA828 /* GINIOpenWithTutorialViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F62FA341FA2207100CEA828 /* GINIOpenWithTutorialViewControllerTests.swift */; };
 		1F62FA3C1FA2207800CEA828 /* GINISupportedFormatsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F62FA361FA2207200CEA828 /* GINISupportedFormatsViewControllerTests.swift */; };
+		1F6515AC2080CC44004502B0 /* GiniVisionDocumentValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6515AB2080CC44004502B0 /* GiniVisionDocumentValidatorTests.swift */; };
 		1F66D9892020A3180093771C /* GINIMultipageReviewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66D9882020A3180093771C /* GINIMultipageReviewControllerTests.swift */; };
 		1F79630A2068DF5C005CB2CA /* MultipageReviewViewControllerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7963082068DEA8005CB2CA /* MultipageReviewViewControllerDelegateMock.swift */; };
-		1F8547641F56E44700B1CAC6 /* GINIVisionDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8547631F56E44700B1CAC6 /* GINIVisionDocumentTests.swift */; };
 		1F8FAC422020AA1C00F586EF /* invoice2.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 1F8FAC412020AA1C00F586EF /* invoice2.jpg */; };
 		1F8FAC442020AA6200F586EF /* invoice3.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 1F8FAC432020AA6200F586EF /* invoice3.jpg */; };
 		1F9411881FB9F4AE0019DECD /* GINIComponentAPICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9411871FB9F4AE0019DECD /* GINIComponentAPICoordinatorTests.swift */; };
@@ -133,9 +133,9 @@
 		1F62FA341FA2207100CEA828 /* GINIOpenWithTutorialViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GINIOpenWithTutorialViewControllerTests.swift; sourceTree = "<group>"; };
 		1F62FA351FA2207200CEA828 /* GINIImageNoResultsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GINIImageNoResultsViewControllerTests.swift; sourceTree = "<group>"; };
 		1F62FA361FA2207200CEA828 /* GINISupportedFormatsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GINISupportedFormatsViewControllerTests.swift; sourceTree = "<group>"; };
+		1F6515AB2080CC44004502B0 /* GiniVisionDocumentValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiniVisionDocumentValidatorTests.swift; sourceTree = "<group>"; };
 		1F66D9882020A3180093771C /* GINIMultipageReviewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GINIMultipageReviewControllerTests.swift; sourceTree = "<group>"; };
 		1F7963082068DEA8005CB2CA /* MultipageReviewViewControllerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipageReviewViewControllerDelegateMock.swift; sourceTree = "<group>"; };
-		1F8547631F56E44700B1CAC6 /* GINIVisionDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GINIVisionDocumentTests.swift; sourceTree = "<group>"; };
 		1F8FAC412020AA1C00F586EF /* invoice2.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = invoice2.jpg; sourceTree = "<group>"; };
 		1F8FAC432020AA6200F586EF /* invoice3.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = invoice3.jpg; sourceTree = "<group>"; };
 		1F9411871FB9F4AE0019DECD /* GINIComponentAPICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GINIComponentAPICoordinatorTests.swift; sourceTree = "<group>"; };
@@ -328,6 +328,7 @@
 				1F3B5EA92049542F0052204A /* GalleryCoordinatorTests.swift */,
 				1F3F5A0A2044400F0037755F /* GalleryManagerMock.swift */,
 				1FB0C66B1F866B9F00AFE9F9 /* GINIAnalysisViewControllerTests.swift */,
+				1F6515AB2080CC44004502B0 /* GiniVisionDocumentValidatorTests.swift */,
 				1F7963082068DEA8005CB2CA /* MultipageReviewViewControllerDelegateMock.swift */,
 				0A6A78A71E1412E000AEB328 /* GINICameraViewControllerTests.swift */,
 				1F9411871FB9F4AE0019DECD /* GINIComponentAPICoordinatorTests.swift */,
@@ -342,7 +343,6 @@
 				1F94118A1FBAEB7D0019DECD /* ScreenAPICoordinatorTests.swift */,
 				1F578E121FBD81A300C17F62 /* GINISettingsViewControllerTests.swift */,
 				1F62FA361FA2207200CEA828 /* GINISupportedFormatsViewControllerTests.swift */,
-				1F8547631F56E44700B1CAC6 /* GINIVisionDocumentTests.swift */,
 				1F3B5EA620494FEB0052204A /* ImagePickerViewControllerDelegateMock.swift */,
 				1F3F5A0620443AEA0037755F /* ImagePickerViewControllerTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
@@ -777,10 +777,10 @@
 				1FD55CBE1F66BF9000A1F9C7 /* Extensions.swift in Sources */,
 				1F62FA3B1FA2207800CEA828 /* GINIOpenWithTutorialViewControllerTests.swift in Sources */,
 				1FA85EFA1FD6B569005C0C24 /* GINIQRCodeDocumentTests.swift in Sources */,
-				1F8547641F56E44700B1CAC6 /* GINIVisionDocumentTests.swift in Sources */,
 				1F3B5EA520494A1D0052204A /* AlbumsPickerViewControllerDelegateMock.swift in Sources */,
 				1FFC9E6A20513388007D505D /* GiniVisionDelegateMock.swift in Sources */,
 				0A6A78A61E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift in Sources */,
+				1F6515AC2080CC44004502B0 /* GiniVisionDocumentValidatorTests.swift in Sources */,
 				0A6A78A81E1412E000AEB328 /* GINICameraViewControllerTests.swift in Sources */,
 				1F62FA3C1FA2207800CEA828 /* GINISupportedFormatsViewControllerTests.swift in Sources */,
 				1F79630A2068DF5C005CB2CA /* MultipageReviewViewControllerDelegateMock.swift in Sources */,

--- a/Example/GiniVision.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/GiniVision.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/GiniVision/AppCoordinator.swift
+++ b/Example/GiniVision/AppCoordinator.swift
@@ -77,7 +77,7 @@ final class AppCoordinator: Coordinator {
         
         // 3. Validate document
         do {
-            try document?.validate()
+            try document?.validate(giniConfiguration: self.giniConfiguration)
             showOpenWithSwitchDialog(forDocuments: [document!])
         } catch {
             showExternalDocumentNotValidDialog()

--- a/Example/GiniVision/AppCoordinator.swift
+++ b/Example/GiniVision/AppCoordinator.swift
@@ -76,11 +76,14 @@ final class AppCoordinator: Coordinator {
         popToRootViewControllerIfNeeded()
         
         // 3. Validate document
-        do {
-            try document?.validate(giniConfiguration: self.giniConfiguration)
-            showOpenWithSwitchDialog(forDocuments: [document!])
-        } catch {
-            showExternalDocumentNotValidDialog()
+        if let document = document {
+            do {
+                try GiniVisionDocumentValidator.validate(document,
+                                                         withConfig: self.giniConfiguration)
+                showOpenWithSwitchDialog(forDocuments: [document])
+            } catch {
+                showExternalDocumentNotValidDialog()
+            }
         }
     }
     

--- a/Example/GiniVision/AppCoordinator.swift
+++ b/Example/GiniVision/AppCoordinator.swift
@@ -78,8 +78,8 @@ final class AppCoordinator: Coordinator {
         // 3. Validate document
         if let document = document {
             do {
-                try GiniVisionDocumentValidator.validate(document,
-                                                         withConfig: self.giniConfiguration)
+                try GiniVision.validate(document,
+                                        withConfig: self.giniConfiguration)
                 showOpenWithSwitchDialog(forDocuments: [document])
             } catch {
                 showExternalDocumentNotValidDialog()

--- a/Example/Tests/GINICameraViewControllerTests.swift
+++ b/Example/Tests/GINICameraViewControllerTests.swift
@@ -7,6 +7,7 @@ final class CameraViewControllerTests: XCTestCase {
     var cameraViewController: CameraViewController!
     var giniConfiguration: GiniConfiguration!
     var screenAPICoordinator: GiniScreenAPICoordinator!
+    let visionDelegate = GiniVisionDelegateMock()
     lazy var imageData: Data = {
         let image = self.loadImage(withName: "invoice.jpg")
         let imageData = UIImageJPEGRepresentation(image!, 0.9)!
@@ -19,7 +20,7 @@ final class CameraViewControllerTests: XCTestCase {
         giniConfiguration = GiniConfiguration.sharedConfiguration
         giniConfiguration.multipageEnabled = true
         cameraViewController = CameraViewController(giniConfiguration: giniConfiguration)
-        screenAPICoordinator = GiniScreenAPICoordinator(withDelegate: nil,
+        screenAPICoordinator = GiniScreenAPICoordinator(withDelegate: visionDelegate,
                                                         giniConfiguration: self.giniConfiguration)
         cameraViewController.delegate = screenAPICoordinator
     }
@@ -78,49 +79,7 @@ final class CameraViewControllerTests: XCTestCase {
         XCTAssertTrue(cameraViewController.multipageReviewBackgroundView.isHidden,
                       "multipageReviewBackgroundView should not be hidden after capture the second picture")
         
-    }
-    
-    func testPickerCompletionBlockWhenNoErrorsOccurred() {
-        let documents = [GiniImageDocument(data: imageData, imageSource: .external)]
-        let expect = expectation(description: "Document validation finishes")
-
-        cameraViewController.documentPicker(DocumentPickerCoordinator(), didPick: documents, from: .gallery) { error, _ in
-            expect.fulfill()
-            XCTAssertNil(error, "Completion block should not return an error when pciking one image")
-        }
-        
-        waitForExpectations(timeout: 2, handler: nil)
-    }
-    
-    func testPickerCompletionBlockWhenNoErrorsOccurredWithDeprecatedInit() {
-        let documents = [loadImageDocument(withName: "invoice")]
-        let expect = expectation(description: "Document validation finishes")
-        cameraViewController = CameraViewController(success: {_ in}, failure: {_ in})
-        cameraViewController.documentPicker(DocumentPickerCoordinator(), didPick: documents, from: .gallery) { error, _ in
-            expect.fulfill()
-            XCTAssertNil(error, "Completion block should not return an error when using the deprecated initializer")
-        }
-        
-        waitForExpectations(timeout: 2, handler: nil)
-    }
-    
-    func testPickerCompletionBlockWhenTooManyPages() {
-        var documents: [GiniVisionDocument] = []
-        for _ in 0...GiniPDFDocument.maxPagesCount {
-            documents.append(loadImageDocument(withName: "invoice"))
-        }
-
-        let expect = expectation(description: "Document validation finishes")
-        cameraViewController.documentPicker(DocumentPickerCoordinator(), didPick: documents, from: .gallery) { error, _ in
-            expect.fulfill()
-            let error = error as? FilePickerError
-            XCTAssertTrue(error == FilePickerError.maxFilesPickedCountExceeded,
-                          "Completion block should return the FilePickerError.maxFilesPickedCountExceeded error from outside of the camera screen")
-        }
-        
-        waitForExpectations(timeout: 2, handler: nil)
-    }
-    
+    }    
     
 }
 

--- a/Example/Tests/GINIQRCodeDocumentTests.swift
+++ b/Example/Tests/GINIQRCodeDocumentTests.swift
@@ -11,10 +11,14 @@ import XCTest
 
 final class GINIQRCodeDocumentTests: XCTestCase {
     
+    let giniConfiguration: GiniConfiguration = GiniConfiguration()
+    
     func testBezahlQRCodeExtractions() {
         let qrDocument = GiniQRCodeDocument(scannedString: "bank://singlepaymentsepa?name=Gini%20Online%20Shop" +
             "&reason=A12345-6789&iban=DE89370400440532013000&bic=GINIBICXXX&amount=47%2C65&currency=EUR")
-        XCTAssertNoThrow(try qrDocument.validate(), "should throw an error since is valid")
+        XCTAssertNoThrow(try GiniVisionDocumentValidator.validate(qrDocument,
+                                                                  withConfig: giniConfiguration),
+                         "should throw an error since is valid")
         XCTAssertEqual(qrDocument.extractedParameters["amountToPay"], "47,65:EUR",
                        "amountToPay should match")
         XCTAssertEqual(qrDocument.extractedParameters["paymentRecipient"], "Gini Online Shop",
@@ -31,7 +35,9 @@ final class GINIQRCodeDocumentTests: XCTestCase {
         let scannedString = "BCD\n001\n2\nSCT\nGENODEF1KIL\nMax Mustermann\nDE52210900070088299309\n" +
             "EUR1456.89\n\n457845789452\n\nDiverse Autoteile, Re 789452 KN 457845"
         let qrDocument = GiniQRCodeDocument(scannedString: scannedString)
-        XCTAssertNoThrow(try qrDocument.validate(), "should throw an error since is valid")
+        XCTAssertNoThrow(try GiniVisionDocumentValidator.validate(qrDocument,
+                                                                  withConfig: giniConfiguration),
+                         "should throw an error since is valid")
         XCTAssertEqual(qrDocument.extractedParameters["amountToPay"], "1456.89:EUR",
                        "amountToPay should match")
         XCTAssertEqual(qrDocument.extractedParameters["paymentRecipient"], "Max Mustermann",
@@ -47,7 +53,8 @@ final class GINIQRCodeDocumentTests: XCTestCase {
     
     func testNotValidQRCodeFormat() {
         let qrDocument = GiniQRCodeDocument(scannedString: "invalidQRCodeFormat")
-        XCTAssertThrowsError(try qrDocument.validate()) { error in
+        XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(qrDocument,
+                                                                      withConfig: giniConfiguration)) { error in
             XCTAssertTrue(error as? DocumentValidationError == DocumentValidationError.qrCodeFormatNotValid,
                           "validation should throw a DocumentaValidationError")
         }
@@ -56,7 +63,8 @@ final class GINIQRCodeDocumentTests: XCTestCase {
     func testNotValidEPC06912QRCodeFormat() {
         let scannedString = "1\n003\n3\nSCT\n5\n6\n7\n8\n9\n10\n11"
         let qrDocument = GiniQRCodeDocument(scannedString: scannedString)
-        XCTAssertThrowsError(try qrDocument.validate(),
+        XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(qrDocument,
+                                                                      withConfig: giniConfiguration),
                              "validation should throw a DocumentaValidationError")
     }
 }

--- a/Example/Tests/GINIVisionDocumentTests.swift
+++ b/Example/Tests/GINIVisionDocumentTests.swift
@@ -11,6 +11,7 @@ import XCTest
 
 class GINIVisionDocumentTests: XCTestCase {
     
+    let giniConfiguration: GiniConfiguration = GiniConfiguration()
     var filePickerManager: DocumentPickerCoordinator {
         return DocumentPickerCoordinator()
     }
@@ -18,9 +19,10 @@ class GINIVisionDocumentTests: XCTestCase {
     func testExcedeedMaxFileSize() {
         let higherThan10MBData = generateFakeData(megaBytes: 12)
         
-        let fakeDocument = GiniPDFDocument(data: higherThan10MBData)
+        let pdfDocument = GiniPDFDocument(data: higherThan10MBData)
         
-        XCTAssertThrowsError(try fakeDocument.validate(),
+        XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(pdfDocument,
+                                                                      withConfig: giniConfiguration),
                              "Files with a size lower than 10MB should be valid") { error in
             XCTAssert(error as? DocumentValidationError == DocumentValidationError.exceededMaxFileSize,
                       "should indicate that max file size has been exceeded")
@@ -30,9 +32,10 @@ class GINIVisionDocumentTests: XCTestCase {
     func testNotExcedeedMaxFileSize() {
         let lowerThanOrEqualTo10MBData = generateFakeData(megaBytes: 10)
         
-        let fakeDocument = GiniPDFDocument(data: lowerThanOrEqualTo10MBData)
+        let pdfDocument = GiniPDFDocument(data: lowerThanOrEqualTo10MBData)
 
-        XCTAssertThrowsError(try fakeDocument.validate(),
+        XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(pdfDocument,
+                                                                      withConfig: giniConfiguration),
                              "Files with a size greater than 10MB should not be valid") { error in
             XCTAssert(error as? DocumentValidationError != DocumentValidationError.exceededMaxFileSize,
                       "should indicate that max file size has been exceeded")
@@ -43,7 +46,9 @@ class GINIVisionDocumentTests: XCTestCase {
         let image = loadImage(withName: "tabBarIconHelp")
         let imageDocument = GiniImageDocument(data: UIImagePNGRepresentation(image!)!, imageSource: .camera)
         
-        XCTAssertNoThrow(try imageDocument.validate(), "Valid images should validate without throwing an exception")
+        XCTAssertNoThrow(try GiniVisionDocumentValidator.validate(imageDocument,
+                                                                  withConfig: giniConfiguration),
+                         "Valid images should validate without throwing an exception")
     }
     
     fileprivate func generateFakeData(megaBytes lengthInMB: Int) -> Data {

--- a/Example/Tests/GalleryManagerMock.swift
+++ b/Example/Tests/GalleryManagerMock.swift
@@ -28,10 +28,6 @@ final class GalleryManagerMock: GalleryManagerProtocol {
         
     }
     
-    func reloadAlbums() {
-        
-    }
-    
     func startCachingImages(for album: Album) {
         isCaching = true
     }

--- a/Example/Tests/GalleryManagerMock.swift
+++ b/Example/Tests/GalleryManagerMock.swift
@@ -28,6 +28,10 @@ final class GalleryManagerMock: GalleryManagerProtocol {
         
     }
     
+    func reloadAlbums() {
+        
+    }
+    
     func startCachingImages(for album: Album) {
         isCaching = true
     }

--- a/Example/Tests/GiniScreenAPICoordinatorTests.swift
+++ b/Example/Tests/GiniScreenAPICoordinatorTests.swift
@@ -92,41 +92,5 @@ final class GiniScreenAPICoordinatorTests: XCTestCase {
         
         XCTAssertNotNil(screenNavigator?.viewControllers.last as? ReviewViewController,
                         "first view controller is not a ReviewViewController")
-    }
-    
-    func testCameraDidCaptureImagesWithEmptyArray(){
-        let capturedImages = [loadImageDocument(withName: "invoice"), loadImageDocument(withName: "invoice2")]
-        coordinator.camera(CameraViewController(giniConfiguration: giniConfiguration), didCaptureDocuments: capturedImages, validationHandler: nil)
-        
-        XCTAssertEqual(coordinator.visionDocuments.count, 2,
-                       "vision documents count should match the number of images captured")
-    }
-    
-    func testCameraDidCaptureImagesWithNotEmptyArray(){
-        let capturedImages = [loadImageDocument(withName: "invoice"), loadImageDocument(withName: "invoice2")]
-        coordinator.camera(CameraViewController(giniConfiguration: giniConfiguration), didCaptureDocuments: capturedImages, validationHandler: nil)
-        coordinator.camera(CameraViewController(giniConfiguration: giniConfiguration), didCaptureDocuments: capturedImages, validationHandler: nil)
-
-        XCTAssertEqual(coordinator.visionDocuments.count, 4,
-                       "vision documents count should match the number of images captured")
-    }
-    
-    func testCameraDidCapturePDFWithEmptyArray(){
-        let capturedPDFs = [loadPDFDocument(withName: "testPDF")]
-        coordinator.camera(CameraViewController(giniConfiguration: giniConfiguration), didCaptureDocuments: capturedPDFs, validationHandler: nil)
-        
-        XCTAssertEqual(coordinator.visionDocuments.count, 1,
-                       "vision documents count should match the number of PDF captured")
-    }
-    
-    func testCameraDidCapturePDFWithExistingImages(){
-        let capturedImages = [loadImageDocument(withName: "invoice"), loadImageDocument(withName: "invoice2")]
-        let capturedPDFs = [loadPDFDocument(withName: "testPDF")]
-        coordinator.camera(CameraViewController(giniConfiguration: giniConfiguration), didCaptureDocuments: capturedImages, validationHandler: nil)
-        coordinator.camera(CameraViewController(giniConfiguration: giniConfiguration), didCaptureDocuments: capturedPDFs, validationHandler: nil)
-        
-        XCTAssertEqual(coordinator.visionDocuments.count, 2,
-                       "vision documents count should be 2 since it can not be a mixed array")
-    }
-    
+    }   
 }

--- a/Example/Tests/GiniVisionDelegateMock.swift
+++ b/Example/Tests/GiniVisionDelegateMock.swift
@@ -14,7 +14,7 @@ final class GiniVisionDelegateMock: GiniVisionDelegate {
     func didCapture(document: GiniVisionDocument) {
         
     }
-    
+        
     func didCancelCapturing() {
         
     }

--- a/Example/Tests/GiniVisionDocumentValidatorTests.swift
+++ b/Example/Tests/GiniVisionDocumentValidatorTests.swift
@@ -1,20 +1,17 @@
 //
-//  GINIVisionDocumentTests.swift
+//  GiniVisionDocumentValidatorTests.swift
 //  GiniVision_Tests
 //
-//  Created by Enrique del Pozo Gómez on 8/30/17.
-//  Copyright © 2017 Gini GmbH. All rights reserved.
+//  Created by Enrique del Pozo Gómez on 4/13/18.
+//  Copyright © 2018 Gini GmbH. All rights reserved.
 //
 
 import XCTest
 @testable import GiniVision
 
-class GINIVisionDocumentTests: XCTestCase {
+final class GiniVisionDocumentValidatorTests: XCTestCase {
     
-    let giniConfiguration: GiniConfiguration = GiniConfiguration()
-    var filePickerManager: DocumentPickerCoordinator {
-        return DocumentPickerCoordinator()
-    }
+    let giniConfiguration = GiniConfiguration()
     
     func testExcedeedMaxFileSize() {
         let higherThan10MBData = generateFakeData(megaBytes: 12)
@@ -24,8 +21,8 @@ class GINIVisionDocumentTests: XCTestCase {
         XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(pdfDocument,
                                                                       withConfig: giniConfiguration),
                              "Files with a size lower than 10MB should be valid") { error in
-            XCTAssert(error as? DocumentValidationError == DocumentValidationError.exceededMaxFileSize,
-                      "should indicate that max file size has been exceeded")
+                                XCTAssert(error as? DocumentValidationError == DocumentValidationError.exceededMaxFileSize,
+                                          "should indicate that max file size has been exceeded")
         }
     }
     
@@ -33,12 +30,12 @@ class GINIVisionDocumentTests: XCTestCase {
         let lowerThanOrEqualTo10MBData = generateFakeData(megaBytes: 10)
         
         let pdfDocument = GiniPDFDocument(data: lowerThanOrEqualTo10MBData)
-
+        
         XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(pdfDocument,
                                                                       withConfig: giniConfiguration),
                              "Files with a size greater than 10MB should not be valid") { error in
-            XCTAssert(error as? DocumentValidationError != DocumentValidationError.exceededMaxFileSize,
-                      "should indicate that max file size has been exceeded")
+                                XCTAssert(error as? DocumentValidationError != DocumentValidationError.exceededMaxFileSize,
+                                          "should indicate that max file size has been exceeded")
         }
     }
     
@@ -55,4 +52,5 @@ class GINIVisionDocumentTests: XCTestCase {
         let length = lengthInMB * 1000000
         return Data(count: length)
     }
+    
 }

--- a/GiniVision/Classes/Core/Camera.swift
+++ b/GiniVision/Classes/Core/Camera.swift
@@ -177,7 +177,9 @@ extension Camera: AVCaptureMetadataOutputObjectsDelegate {
         if let metadataObj = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
             metadataObj.type == AVMetadataObjectTypeQRCode {
             let qrDocument = GiniQRCodeDocument(scannedString: metadataObj.stringValue)
-            didDetectQR?(qrDocument) 
+            DispatchQueue.main.async { [weak self] in
+                self?.didDetectQR?(qrDocument)
+            }
         }
     }
 }

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -480,7 +480,8 @@ extension CameraViewController {
         let imageDocument = GiniImageDocument(data: imageData,
                                               imageSource: .camera,
                                               deviceOrientation: UIApplication.shared.statusBarOrientation)
-        self.didPick(imageDocument)        
+        didPick(imageDocument)
+        animateToControlsView(imageDocument: imageDocument)
     }
     
     func animateToControlsView(imageDocument: GiniImageDocument, completion: (() -> Void)? = nil) {

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -444,12 +444,7 @@ extension CameraViewController {
             }
         }
         self.camera?.didDetectQR = {[weak self] qrDocument in
-            guard let `self` = self else { return }
-            do {
-                try qrDocument.validate()
-                self.showPopup(forQRDetected: qrDocument)
-            } catch {
-            }
+            self?.didPick(qrDocument)
         }
     }
     
@@ -481,7 +476,6 @@ extension CameraViewController {
                                               imageSource: .camera,
                                               deviceOrientation: UIApplication.shared.statusBarOrientation)
         didPick(imageDocument)
-        animateToControlsView(imageDocument: imageDocument)
     }
     
     func animateToControlsView(imageDocument: GiniImageDocument, completion: (() -> Void)? = nil) {
@@ -533,7 +527,7 @@ extension CameraViewController {
         previewLayer?.connection?.videoOrientation = orientation
     }
     
-    fileprivate func showPopup(forQRDetected qrDocument: GiniQRCodeDocument) {
+    func showPopup(forQRDetected qrDocument: GiniQRCodeDocument, didTapDone: @escaping () -> Void) {
         if self.detectedQRCodeDocument != qrDocument {
             DispatchQueue.main.async { [weak self] in
                 guard let `self` = self else { return }
@@ -544,7 +538,7 @@ extension CameraViewController {
                                                              document: qrDocument,
                                                              giniConfiguration: self.giniConfiguration)
                 newQRCodePopup.didTapDone = { [weak self] in
-                    self?.didPick(qrDocument)
+                    didTapDone()
                     self?.detectedQRCodeDocument = nil
                     self?.currentQRCodePopup?.hide()
                 }

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -693,49 +693,6 @@ extension CameraViewController {
             self.captureButton.isEnabled = true
         }
     }
-    
-    func showErrorDialog(for error: Error, possitiveAction: (() -> Void)? = nil) {
-        let message: String
-        var cancelActionTitle: String = NSLocalizedStringPreferred("ginivision.camera.errorPopup.cancelButton",
-                                                                   comment: "cancel button title")
-        var confirmActionTitle: String? = NSLocalizedStringPreferred("ginivision.camera.errorPopup.pickanotherfileButton",
-                                                                     comment: "pick another file button title")
-        var confirmAction: (() -> Void)?
-        
-        switch error {
-        case let validationError as DocumentValidationError:
-            message = validationError.message
-            confirmAction = self.showImportFileSheet
-        case let customValidationError as CustomDocumentValidationError:
-            message = customValidationError.message
-            confirmAction = self.showImportFileSheet
-        case let pickerError as FilePickerError:
-            message = pickerError.message
-            if pickerError == .maxFilesPickedCountExceeded {
-                confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.errorPopup.reviewPages",
-                                                                comment: "review pages button title")
-                confirmAction = { [weak self] in
-                    guard let `self` = self else { return }
-                    self.delegate?.cameraDidTapMultipageReviewButton(self)
-                }
-            } else if pickerError == .mixedDocumentsUnsupported {
-                cancelActionTitle = NSLocalizedStringPreferred("ginivision.camera.mixedarrayspopup.cancel",
-                                                        comment: "cancel button text for popup")
-                confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.mixedarrayspopup.usePhotos",
-                                                           comment: "use photos button text in popup")
-            }
-
-        default:
-            message = DocumentValidationError.unknown.message
-        }
-
-        let dialog = errorDialog(withMessage: message,
-                                 cancelActionTitle: cancelActionTitle,
-                                 confirmActionTitle: confirmActionTitle,
-                                 confirmAction: possitiveAction ?? confirmAction)
-        
-        present(dialog, animated: true, completion: nil)
-    }
 }
 
 // MARK: - Default and not authorized views

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -14,20 +14,13 @@ import AVFoundation
      Called when a user takes a picture, imports a PDF/QRCode or imports one or several images.
      Once the method has been implemented, it is necessary to check if the number of
      documents accumulated doesn't exceed the minimun (`GiniImageDocument.maxPagesCount`).
-     Afterwards, it is mandatory to call the `DocumentValidationHandler` block passing the error
-     `CameraError.maxFilesPickedCountExceeded` (if the page count limit was exceeded) and
-     the inner completion block that will be executed once the gallery dismissal animation completes.
      
      - parameter viewController: `CameraViewController` where the documents were taken.
      - parameter documents: One or several documents either captured or imported in
      the `CameraViewController`. They can contain an error produced in the validation process.
-     - parameter completion: `DocumentPickerCompletion` block used to check if there is an issue with
-     the captured documents. The completion block also has an inner block that is executed once the
-     picker has been dismissed when there are no errors.
      */
     @objc func camera(_ viewController: CameraViewController,
-                      didCaptureDocuments documents: [GiniVisionDocument],
-                      validationHandler: DocumentValidationHandler?)
+                      didCapture document: GiniVisionDocument)
     
     /**
      Called when the `CameraViewController` appears.
@@ -43,6 +36,9 @@ import AVFoundation
      - parameter viewController: Camera view controller where the button was tapped.
      */
     @objc func cameraDidTapMultipageReviewButton(_ viewController: CameraViewController)
+    
+    @objc func camera(_ viewController: CameraViewController, didSelect documentPicker: DocumentPickerType)
+
 }
 
 /**
@@ -185,9 +181,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     weak var delegate: CameraViewControllerDelegate?
     fileprivate var camera: Camera?
     fileprivate var cameraState = CameraState.notValid
-    fileprivate lazy var documentPickerCoordinator: DocumentPickerCoordinator = {
-        return DocumentPickerCoordinator()
-    }()
     fileprivate var currentQRCodePopup: QRCodeDetectedPopupView?
     fileprivate var detectedQRCodeDocument: GiniQRCodeDocument?
     
@@ -279,18 +272,11 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         NotificationCenter.default.removeObserver(self)
     }
     
-    fileprivate func didPick(validatedDocuments documents: [GiniVisionDocument],
-                             validationHandler: DocumentValidationHandler?) {
+    fileprivate func didPick(_ document: GiniVisionDocument) {
         if let delegate = delegate {
-            delegate.camera(self, didCaptureDocuments: documents, validationHandler: validationHandler)
-        } else if let firstDocument = documents.first {
-            validationHandler?(nil, nil)
-            successBlock?(firstDocument)
-            if documents.count > 1 {
-                // TODO: Show a warning in the logger
-            }
+            delegate.camera(self, didCapture: document)
         } else {
-            print("A CameraViewControllerDelegate has not been specified")
+            successBlock?(document)
         }
     }
     
@@ -494,20 +480,7 @@ extension CameraViewController {
         let imageDocument = GiniImageDocument(data: imageData,
                                               imageSource: .camera,
                                               deviceOrientation: UIApplication.shared.statusBarOrientation)
-        
-        if giniConfiguration.multipageEnabled {
-            self.didPick(validatedDocuments: [imageDocument]) { error, _ in
-                if let error = error {
-                    self.showErrorDialog(for: error)
-                    return
-                }
-                
-                self.animateToControlsView(imageDocument: imageDocument)
-            }
-        } else {
-            self.didPick(validatedDocuments: [imageDocument], validationHandler: nil)
-        }
-        
+        self.didPick(imageDocument)        
     }
     
     func animateToControlsView(imageDocument: GiniImageDocument, completion: (() -> Void)? = nil) {
@@ -570,7 +543,7 @@ extension CameraViewController {
                                                              document: qrDocument,
                                                              giniConfiguration: self.giniConfiguration)
                 newQRCodePopup.didTapDone = { [weak self] in
-                    self?.didPick(validatedDocuments: [qrDocument], validationHandler: nil)
+                    self?.didPick(qrDocument)
                     self?.detectedQRCodeDocument = nil
                     self?.currentQRCodePopup?.hide()
                 }
@@ -652,115 +625,16 @@ extension CameraViewController {
     }
 }
 
-// MARK: - DocumentPickerCoordinatorDelegate
-
-extension CameraViewController: DocumentPickerCoordinatorDelegate {
-
-    func documentPicker(_ coordinator: DocumentPickerCoordinator,
-                        didPick documents: [GiniVisionDocument],
-                        from: DocumentPickerType,
-                        validationHandler: DocumentValidationHandler?) {
-        let loadingView = addValidationLoadingView()
-        self.validate(importedDocuments: documents) { validatedDocuments in
-            loadingView.removeFromSuperview()
-            let elementsWithError = validatedDocuments.filter { $0.error != nil}
-            if elementsWithError.isNotEmpty && (!self.giniConfiguration.multipageEnabled ||
-                elementsWithError.first?.document.type != .image) {
-                guard let error = elementsWithError.first?.error else { return }
-                if let handler = validationHandler {
-                    handler(nil) {
-                        self.showErrorDialog(for: error)
-                    }
-                } else {
-                    self.showErrorDialog(for: error)
-                }
-            } else {
-                self.process(validatedImportedDocuments: validatedDocuments.map { $0.document }) { [weak self] error, didDismiss in
-                    guard let `self` = self else { return }
-                    // This is needed since the `UIDocumentPickerViewController` is automatically
-                    // dismissed and the drag&drop is done in this view controller.
-                    // For that reason the error must not be forwarded.
-                    if from != .gallery {
-                        guard let error = error else {
-                            didDismiss?()
-                            return
-                        }
-                        
-                        self.showErrorDialog(for: error)
-                    } else {
-                        validationHandler?(error, didDismiss)
-                    }
-                }
-            }
-        }
-    }
-}
-
 // MARK: - Document import
 
 extension CameraViewController {
-    fileprivate func enableFileImport() {
-        // Configure file picker
-        documentPickerCoordinator.delegate = self
-
-        if documentPickerCoordinator.isGalleryPermissionGranted {
-            documentPickerCoordinator.startCaching()
-        }
-        
+    fileprivate func enableFileImport() {        
         // Configure import file button
         controlsView.addSubview(importFileButton)
         addImportButtonConstraints()
-        
-        if #available(iOS 11.0, *) {
-            addDropInteraction()
-        }
     }
     
-    fileprivate func validate(importedDocuments documents: [GiniVisionDocument],
-                              completion: @escaping ([(document: GiniVisionDocument, error: Error?)]) -> Void) {
-        DispatchQueue.global().async {
-            var validatedDocuments: [(GiniVisionDocument, Error?)] = []
-            documents.forEach { document in
-                var visionError: Error?
-                do {
-                    try document.validate()
-                } catch let error {
-                    visionError = error
-                }
-                validatedDocuments.append((document, visionError))
-            }
-            
-            DispatchQueue.main.async {
-                completion(validatedDocuments)
-            }
-            
-        }
-    }
-    
-    fileprivate func process(validatedImportedDocuments documents: [GiniVisionDocument],
-                             validationHandler: DocumentValidationHandler?) {
-        let didValidate: DocumentValidationHandler
-        if !documents.containsDifferentTypes {
-            didValidate = { error, coordinatorCompletion in
-                validationHandler?(error, coordinatorCompletion)
-                if error == nil {
-                    if let firstImage = documents.first as? GiniImageDocument, self.giniConfiguration.multipageEnabled {
-                        self.updateMultipageReviewButton(withImage: firstImage.previewImage,
-                                                         showingStack: documents.count > 1)
-                    }
-                }
-            }
-            didPick(validatedDocuments: documents, validationHandler: didValidate)
-            
-        } else {
-            showErrorDialog(for: FilePickerError.mixedDocumentsUnsupported) {
-                let imageDocuments = documents.filter { $0.type == .image }
-                self.didPick(validatedDocuments: imageDocuments, validationHandler: validationHandler)
-            }
-        }
-    }
-    
-    fileprivate func addValidationLoadingView() -> UIView {
+    func addValidationLoadingView() -> UIView {
         let loadingIndicator = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
         let blurredView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
         blurredView.autoresizingMask = [.flexibleTopMargin, .flexibleBottomMargin]
@@ -781,14 +655,13 @@ extension CameraViewController {
         
         if giniConfiguration.fileImportSupportedTypes == .pdf_and_images {
             alertViewController.addAction(UIAlertAction(title: "Fotos", style: .default) { [unowned self] _ in
-                self.documentPickerCoordinator.showGalleryPicker(from: self)
+                self.delegate?.camera(self, didSelect: .gallery)
             })
             alertViewControllerMessage = "Fotos oder PDF importieren"
         }
         
         alertViewController.addAction(UIAlertAction(title: "Dokumente", style: .default) { [unowned self] _ in
-            self.documentPickerCoordinator.isPDFSelectionAllowed = !self.imagesAlreadyPicked()
-            self.documentPickerCoordinator.showDocumentPicker(from: self)
+            self.delegate?.camera(self, didSelect: .explorer)
         })
         
         alertViewController.addAction(UIAlertAction(title: "Abbrechen", style: .cancel, handler: nil))
@@ -797,16 +670,6 @@ extension CameraViewController {
         alertViewController.popoverPresentationController?.sourceView = importFileButton
         
         self.present(alertViewController, animated: true, completion: nil)
-    }
-    
-    fileprivate func imagesAlreadyPicked() -> Bool {
-        return self.multipageReviewButton.image(for: .normal) != nil
-    }
-    
-    @available(iOS 11.0, *)
-    fileprivate func addDropInteraction() {
-        let dropInteraction = UIDropInteraction(delegate: documentPickerCoordinator)
-        view.addInteraction(dropInteraction)
     }
     
     fileprivate func createFileImportTip(giniConfiguration: GiniConfiguration) {

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -26,14 +26,13 @@ protocol DocumentPickerCoordinatorDelegate: class {
      */
     func documentPicker(_ coordinator: DocumentPickerCoordinator,
                         didPick documents: [GiniVisionDocument],
-                        from picker: DocumentPickerType,
-                        validationHandler: DocumentValidationHandler?)
+                        from picker: UIViewController?)
 }
 
 public typealias DidDismissPickerCompletion = () -> Void
 public typealias DocumentValidationHandler = (Error?, DidDismissPickerCompletion?) -> Void
 
-enum DocumentPickerType {
+@objc public enum DocumentPickerType: Int {
     case gallery, explorer, dragndrop
 }
 
@@ -162,15 +161,9 @@ internal final class DocumentPickerCoordinator: NSObject {
 extension DocumentPickerCoordinator: GalleryCoordinatorDelegate {
     func gallery(_ coordinator: GalleryCoordinator,
                  didSelectImageDocuments imageDocuments: [GiniImageDocument]) {
-        delegate?.documentPicker(self, didPick: imageDocuments, from: .gallery) { [weak self] error, didDismiss in
-            guard let error = error else {
-                coordinator.dismissGallery(completion: didDismiss)
-                return
-            }
-            
-            self?.showErrorDialog(for: error, from: coordinator.rootViewController)
-        }
-        
+        delegate?.documentPicker(self,
+                                 didPick: imageDocuments,
+                                 from: coordinator.rootViewController)         
     }
     
     func gallery(_ coordinator: GalleryCoordinator, didCancel: Void) {
@@ -185,8 +178,7 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
         let documents: [GiniVisionDocument] = urls
             .flatMap(self.data)
             .flatMap(self.createDocument)
-        
-        delegate?.documentPicker(self, didPick: documents, from: .explorer, validationHandler: nil)
+        delegate?.documentPicker(self, didPick: documents, from: nil)
     }
     
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
@@ -236,7 +228,7 @@ extension DocumentPickerCoordinator: UIDropInteractionDelegate {
         }
         
         dispatchGroup.notify(queue: DispatchQueue.main) {
-            self.delegate?.documentPicker(self, didPick: documents, from: .dragndrop, validationHandler: nil)
+            self.delegate?.documentPicker(self, didPick: documents, from: nil)
         }
     }
     

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -73,9 +73,9 @@ internal final class DocumentPickerCoordinator: NSObject {
     // MARK: Picker presentation
     
     func showGalleryPicker(from viewController: UIViewController) {
-        galleryCoordinator.checkGalleryAccessPermission(deniedHandler: {[unowned self] error in
+        galleryCoordinator.checkGalleryAccessPermission(deniedHandler: { error in
             if let error = error as? FilePickerError, error == FilePickerError.photoLibraryAccessDenied {
-                self.showErrorDialog(for: error, from: viewController)
+                viewController.showErrorDialog(for: error, positiveAction: UIApplication.shared.openAppSettings)
             }
             }, authorizedHandler: {
                 self.galleryCoordinator.delegate = self
@@ -100,29 +100,6 @@ internal final class DocumentPickerCoordinator: NSObject {
         }
         
         viewController.present(documentPicker, animated: true, completion: nil)
-    }
-    
-    func showErrorDialog(for error: Error, from viewController: UIViewController) {
-        let dialog: UIAlertController
-        
-        switch error {
-        case let error as FilePickerError where error == .photoLibraryAccessDenied:
-            dialog = errorDialog(withMessage: error.message,
-                                 cancelActionTitle: NSLocalizedStringPreferred("ginivision.camera.filepicker.errorPopup.cancelButton",
-                                                                               comment: "cancel button title"),
-                                 confirmActionTitle: NSLocalizedStringPreferred("ginivision.camera.filepicker.errorPopup.grantAccessButton",
-                                                                                comment: "cancel button title"),
-                                 confirmAction: UIApplication.shared.openAppSettings)
-        case let error as FilePickerError where error == .maxFilesPickedCountExceeded:
-            dialog = errorDialog(withMessage: error.message,
-                                 cancelActionTitle: NSLocalizedStringPreferred("ginivision.camera.filepicker.errorPopup.confirmButton",
-                                                                               comment: "cancel button title"))
-            
-        default:
-            return
-        }
-        
-        viewController.present(dialog, animated: true, completion: nil)
     }
     
     // MARK: File data picked from gallery or document pickers

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -29,9 +29,6 @@ protocol DocumentPickerCoordinatorDelegate: class {
                         from picker: UIViewController?)
 }
 
-public typealias DidDismissPickerCompletion = () -> Void
-public typealias DocumentValidationHandler = (Error?, DidDismissPickerCompletion?) -> Void
-
 @objc public enum DocumentPickerType: Int {
     case gallery, explorer, dragndrop
 }
@@ -42,10 +39,6 @@ internal final class DocumentPickerCoordinator: NSObject {
     let galleryCoordinator: GalleryCoordinator
     let giniConfiguration: GiniConfiguration
     var isPDFSelectionAllowed: Bool = true
-    
-    var isGalleryPermissionGranted: Bool {
-        return galleryCoordinator.isGalleryPermissionGranted
-    }
     
     var isGalleryPermissionGranted: Bool {
         return galleryCoordinator.isGalleryPermissionGranted

--- a/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/DocumentPickerCoordinator.swift
@@ -48,6 +48,10 @@ internal final class DocumentPickerCoordinator: NSObject {
         return galleryCoordinator.isGalleryPermissionGranted
     }
     
+    var isGalleryPermissionGranted: Bool {
+        return galleryCoordinator.isGalleryPermissionGranted
+    }
+    
     fileprivate var acceptedDocumentTypes: [String] {
         switch giniConfiguration.fileImportSupportedTypes {
         case .pdf_and_images:

--- a/GiniVision/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniVision/Classes/Core/Extensions/UIViewController.swift
@@ -35,7 +35,7 @@ extension UIViewController {
         }
     }
     
-    func showErrorDialog(for error: Error, positiveAction: @escaping (() -> Void)) {
+    func showErrorDialog(for error: Error, positiveAction: (() -> Void)?) {
         let message: String
         var cancelActionTitle: String = NSLocalizedStringPreferred("ginivision.camera.errorPopup.cancelButton",
                                                                    comment: "cancel button title")
@@ -91,11 +91,11 @@ extension UIViewController {
                                                         alertViewController.dismiss(animated: true, completion: nil)
         }))
         
-        if let confirmActionTitle = confirmActionTitle {
+        if let confirmActionTitle = confirmActionTitle, let confirmAction = confirmAction {
             alertViewController.addAction(UIAlertAction(title: confirmActionTitle,
                                                         style: .default,
                                                         handler: { _ in
-                                                            confirmAction?()
+                                                            confirmAction()
             }))
         }
         

--- a/GiniVision/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniVision/Classes/Core/Extensions/UIViewController.swift
@@ -43,22 +43,29 @@ extension UIViewController {
                                                                      comment: "pick another file button title")
         
         switch error {
+            
         case let validationError as DocumentValidationError:
             message = validationError.message
         case let customValidationError as CustomDocumentValidationError:
             message = customValidationError.message
         case let pickerError as FilePickerError:
             message = pickerError.message
-            if pickerError == .maxFilesPickedCountExceeded {
+
+            switch pickerError {
+            case .maxFilesPickedCountExceeded:
                 confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.errorPopup.reviewPages",
                                                                 comment: "review pages button title")
-            } else if pickerError == .mixedDocumentsUnsupported {
+            case .photoLibraryAccessDenied:
+                cancelActionTitle = NSLocalizedStringPreferred("ginivision.camera.filepicker.errorPopup.cancelButton",
+                                                                comment: "cancel button title")
+                confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.filepicker.errorPopup.grantAccessButton",
+                                                                comment: "cancel button title")
+            case .mixedDocumentsUnsupported:
                 cancelActionTitle = NSLocalizedStringPreferred("ginivision.camera.mixedarrayspopup.cancel",
                                                                comment: "cancel button text for popup")
                 confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.mixedarrayspopup.usePhotos",
                                                                 comment: "use photos button text in popup")
             }
-            
         default:
             message = DocumentValidationError.unknown.message
         }
@@ -69,5 +76,29 @@ extension UIViewController {
                                  confirmAction: positiveAction)
         
         present(dialog, animated: true, completion: nil)
+    }
+
+    fileprivate func errorDialog(withMessage message: String,
+                                 title: String? = nil,
+                                 cancelActionTitle: String,
+                                 confirmActionTitle: String? = nil,
+                                 confirmAction: (() -> Void)? = nil) -> UIAlertController {
+        
+        let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertViewController.addAction(UIAlertAction(title: cancelActionTitle,
+                                                    style: .cancel,
+                                                    handler: { _ in
+                                                        alertViewController.dismiss(animated: true, completion: nil)
+        }))
+        
+        if let confirmActionTitle = confirmActionTitle {
+            alertViewController.addAction(UIAlertAction(title: confirmActionTitle,
+                                                        style: .default,
+                                                        handler: { _ in
+                                                            confirmAction?()
+            }))
+        }
+        
+        return alertViewController
     }
 }

--- a/GiniVision/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniVision/Classes/Core/Extensions/UIViewController.swift
@@ -34,4 +34,40 @@ extension UIViewController {
             }
         }
     }
+    
+    func showErrorDialog(for error: Error, positiveAction: @escaping (() -> Void)) {
+        let message: String
+        var cancelActionTitle: String = NSLocalizedStringPreferred("ginivision.camera.errorPopup.cancelButton",
+                                                                   comment: "cancel button title")
+        var confirmActionTitle: String? = NSLocalizedStringPreferred("ginivision.camera.errorPopup.pickanotherfileButton",
+                                                                     comment: "pick another file button title")
+        
+        switch error {
+        case let validationError as DocumentValidationError:
+            message = validationError.message
+        case let customValidationError as CustomDocumentValidationError:
+            message = customValidationError.message
+        case let pickerError as FilePickerError:
+            message = pickerError.message
+            if pickerError == .maxFilesPickedCountExceeded {
+                confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.errorPopup.reviewPages",
+                                                                comment: "review pages button title")
+            } else if pickerError == .mixedDocumentsUnsupported {
+                cancelActionTitle = NSLocalizedStringPreferred("ginivision.camera.mixedarrayspopup.cancel",
+                                                               comment: "cancel button text for popup")
+                confirmActionTitle = NSLocalizedStringPreferred("ginivision.camera.mixedarrayspopup.usePhotos",
+                                                                comment: "use photos button text in popup")
+            }
+            
+        default:
+            message = DocumentValidationError.unknown.message
+        }
+        
+        let dialog = errorDialog(withMessage: message,
+                                 cancelActionTitle: cancelActionTitle,
+                                 confirmActionTitle: confirmActionTitle,
+                                 confirmAction: positiveAction)
+        
+        present(dialog, animated: true, completion: nil)
+    }
 }

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -26,10 +26,6 @@ final class GalleryCoordinator: NSObject, Coordinator {
         return PHPhotoLibrary.authorizationStatus() == .authorized
     }
     
-    var isGalleryPermissionGranted: Bool {
-        return PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.authorized
-    }
-    
     // MARK: - View controllers
     
     var rootViewController: UIViewController {

--- a/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryCoordinator.swift
@@ -26,6 +26,10 @@ final class GalleryCoordinator: NSObject, Coordinator {
         return PHPhotoLibrary.authorizationStatus() == .authorized
     }
     
+    var isGalleryPermissionGranted: Bool {
+        return PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.authorized
+    }
+    
     // MARK: - View controllers
     
     var rootViewController: UIViewController {

--- a/GiniVision/Classes/Core/Gallery/GalleryManager.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryManager.swift
@@ -50,7 +50,6 @@ final class GalleryManager: GalleryManagerProtocol {
         }
     }
     
-<<<<<<< HEAD
     func fetchRemoteImageData(from asset: Asset, completion: @escaping ((Data?) -> Void)) {
         var options: PHImageRequestOptions
         options = PHImageRequestOptions()
@@ -60,9 +59,7 @@ final class GalleryManager: GalleryManagerProtocol {
             completion(data)
         }
     }
-    
-=======
->>>>>>> Fixed issue with gallery permission.
+
     func reloadAlbums() {
         self.albums = fetchSortedAlbums()
     }

--- a/GiniVision/Classes/Core/Gallery/GalleryManager.swift
+++ b/GiniVision/Classes/Core/Gallery/GalleryManager.swift
@@ -50,6 +50,7 @@ final class GalleryManager: GalleryManagerProtocol {
         }
     }
     
+<<<<<<< HEAD
     func fetchRemoteImageData(from asset: Asset, completion: @escaping ((Data?) -> Void)) {
         var options: PHImageRequestOptions
         options = PHImageRequestOptions()
@@ -60,6 +61,8 @@ final class GalleryManager: GalleryManagerProtocol {
         }
     }
     
+=======
+>>>>>>> Fixed issue with gallery permission.
     func reloadAlbums() {
         self.albums = fetchSortedAlbums()
     }

--- a/GiniVision/Classes/Core/GiniImageDocument.swift
+++ b/GiniVision/Classes/Core/GiniImageDocument.swift
@@ -52,23 +52,6 @@ final public class GiniImageDocument: NSObject, GiniVisionDocument {
         }
     }
     
-    /**
-     Check image document type. It should be a PNG, JPEG, GIF or TIFF.
-     
-     - Throws: `DocumentValidationError.imageFormatNotValid` if it is not a image valid format.
-     Also throws `DocumentValidationError.fileFormatNotValid` if it is not an image
-     
-     */
-    public func checkType() throws {
-        if self.data.isImage {
-            if !(self.data.isJPEG || self.data.isPNG || self.data.isGIF || self.data.isTIFF) {
-                throw DocumentValidationError.imageFormatNotValid
-            }
-        } else {
-            throw DocumentValidationError.fileFormatNotValid
-        }
-    }
-    
     func rotatePreviewImage90Degrees() {
         guard let rotatedImage = self.previewImage?.rotated90Degrees() else { return }
         metaInformationManager.rotate(degrees: 90, imageOrientation: rotatedImage.imageOrientation)

--- a/GiniVision/Classes/Core/GiniPDFDocument.swift
+++ b/GiniVision/Classes/Core/GiniPDFDocument.swift
@@ -53,26 +53,6 @@ final public class GiniPDFDocument: NSObject, GiniVisionDocument {
         return nil
     }
     
-    /**
-     Check pdf document type. It should have less than 10 pages.
-     
-     - Throws: `DocumentValidationError.pdfPageLengthExceeded` if page length is exceeded.
-     Also throws `DocumentValidationError.fileFormatNotValid` if it is not a pdf
-     
-     */
-    
-    public func checkType() throws {
-        if self.data.isPDF {
-            if case 1...GiniPDFDocument.maxPagesCount = self.numberPages {
-                return
-            } else {
-                throw DocumentValidationError.pdfPageLengthExceeded
-            }
-        } else {
-            throw DocumentValidationError.fileFormatNotValid
-        }
-    }
-    
     fileprivate func renderFirstPage(fromPdf pdf: CGPDFDocument) -> UIImage? {
         var pdfImage: UIImage?
         let pdfDoc = pdf

--- a/GiniVision/Classes/Core/GiniQRCodeDocument.swift
+++ b/GiniVision/Classes/Core/GiniQRCodeDocument.swift
@@ -27,7 +27,7 @@ import Foundation
     lazy var extractedParameters: [String: String] = QRCodesExtractor
         .extractParameters(from: self.scannedString, withFormat: self.qrCodeFormat)
     fileprivate let epc06912LinesCount = 12
-    fileprivate lazy var qrCodeFormat: QRCodesFormat? = {
+    lazy var qrCodeFormat: QRCodesFormat? = {
         if self.scannedString.starts(with: "bank://") {
             return .bezahlcode
         } else {
@@ -44,16 +44,7 @@ import Foundation
     init(scannedString: String) {
         self.scannedString = scannedString
         super.init()
-    }
-    
-    public func checkType() throws {
-        if self.qrCodeFormat == nil ||
-            self.extractedParameters.isEmpty ||
-            self.extractedParameters["iban"] == nil {
-            throw DocumentValidationError.qrCodeFormatNotValid
-        }
-    }
-    
+    }    
 }
 
 // MARK: Equatable

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
@@ -1,0 +1,105 @@
+//
+//  GiniScreenAPICoordinator+Analysis.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 4/4/18.
+//
+
+import Foundation
+
+// MARK: - Analysis Screen
+
+internal extension GiniScreenAPICoordinator {
+    func createAnalysisScreen(withDocument document: GiniVisionDocument) -> AnalysisViewController {
+        let viewController = AnalysisViewController(document: document)
+        viewController.view.backgroundColor = giniConfiguration.backgroundColor
+        viewController.didShowAnalysis = { [weak self] in
+            guard let `self` = self else { return }
+            self.visionDelegate?.didShowAnalysis?(self)
+        }
+        viewController.setupNavigationItem(usingResources: self.cancelButtonResource,
+                                           selector: #selector(back),
+                                           position: .left,
+                                           target: self)
+        return viewController
+    }
+}
+
+// MARK: - ImageAnalysisNoResults screen
+
+extension GiniScreenAPICoordinator {
+    func createImageAnalysisNoResultsScreen() -> ImageAnalysisNoResultsViewController {
+        let imageAnalysisNoResultsViewController: ImageAnalysisNoResultsViewController
+        let isCameraViewControllerLoaded: Bool = {
+            guard let cameraViewController = cameraViewController else {
+                return false
+            }
+            return screenAPINavigationController.viewControllers.contains(cameraViewController)
+        }()
+        
+        if isCameraViewControllerLoaded {
+            imageAnalysisNoResultsViewController = ImageAnalysisNoResultsViewController()
+            imageAnalysisNoResultsViewController.setupNavigationItem(usingResources: backButtonResource,
+                                                                     selector: #selector(backToCamera),
+                                                                     position: .left,
+                                                                     target: self)
+        } else {
+            imageAnalysisNoResultsViewController = ImageAnalysisNoResultsViewController(bottomButtonText: nil,
+                                                                                        bottomButtonIcon: nil)
+            imageAnalysisNoResultsViewController.setupNavigationItem(usingResources: closeButtonResource,
+                                                                     selector: #selector(closeScreenApi),
+                                                                     position: .left,
+                                                                     target: self)
+        }
+        
+        imageAnalysisNoResultsViewController.didTapBottomButton = { [weak self] in
+            self?.backToCamera()
+        }
+        
+        return imageAnalysisNoResultsViewController
+    }
+}
+
+// MARK: - AnalysisDelegate
+
+extension GiniScreenAPICoordinator: AnalysisDelegate {
+    func displayError(withMessage message: String?, andAction action: (() -> Void)?) {
+        DispatchQueue.main.async {
+            var noticeAction: NoticeAction?
+            if let action = action {
+                noticeAction = NoticeAction(title: NSLocalizedString("ginivision.analysis.error.actionTitle",
+                                                                     bundle: Bundle(for: GiniVision.self),
+                                                                     comment: "Action button title"),
+                                            action: action)
+            }
+            let notice = NoticeView(text: message ?? "", type: .error, noticeAction: noticeAction)
+            self.show(notice: notice)
+        }
+    }
+    
+    func tryDisplayNoResultsScreen() -> Bool {
+        if let visionDocument = visionDocuments.first, visionDocument.type == .image {
+            DispatchQueue.main.async { [weak self] in
+                guard let `self` = self else { return }
+                self.imageAnalysisNoResultsViewController = self.createImageAnalysisNoResultsScreen()
+                self.screenAPINavigationController.pushViewController(self.imageAnalysisNoResultsViewController!,
+                                                                      animated: true)
+            }
+            
+            return true
+        }
+        return false
+    }
+    
+    private func show(notice: NoticeView) {
+        let noticeView = analysisViewController?.view.subviews.flatMap { $0 as? NoticeView }.first
+        if let noticeView = noticeView {
+            noticeView.hide(completion: { [weak self] in
+                self?.show(notice: notice)
+            })
+        } else {
+            analysisViewController?.view.addSubview(notice)
+            notice.show()
+        }
+    }
+}

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -242,7 +242,11 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
         let dropInteraction = UIDropInteraction(delegate: delegate)
         view.addInteraction(dropInteraction)
     }
-    
+}
+
+// MARK: - Validation
+
+extension GiniScreenAPICoordinator {
     fileprivate func validate(_ documents: [GiniVisionDocument],
                               completion: @escaping (Result<[ValidatedDocument]>) -> Void) {
         
@@ -268,8 +272,8 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
         }
     }
     
-    fileprivate func validate(importedDocuments documents: [GiniVisionDocument],
-                              completion: @escaping ([ValidatedDocument]) -> Void) {
+    private func validate(importedDocuments documents: [GiniVisionDocument],
+                          completion: @escaping ([ValidatedDocument]) -> Void) {
         DispatchQueue.global().async {
             var validatedDocuments: [(GiniVisionDocument, Error?)] = []
             documents.forEach { document in
@@ -288,5 +292,4 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
             }
         }
     }
-    
 }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -251,7 +251,7 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
             return
         }
         
-        guard (documents.count + visionDocuments.count) <= GiniPDFDocument.maxPagesCount else {
+        guard (documents.count + visionDocuments.count) <= GiniVisionDocumentValidator.maxPagesCount else {
             completion(.failure(FilePickerError.maxFilesPickedCountExceeded))
             return
         }
@@ -275,7 +275,8 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
             documents.forEach { document in
                 var documentError: Error?
                 do {
-                    try document.validate(giniConfiguration: self.giniConfiguration)
+                    try GiniVisionDocumentValidator.validate(document,
+                                                             withConfig: self.giniConfiguration)
                 } catch let error {
                     documentError = error
                 }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -1,0 +1,286 @@
+//
+//  GiniScreenAPICoordinator+Camera.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 4/4/18.
+//
+
+import Foundation
+
+// MARK: - Camera Screen
+
+extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
+    func camera(_ viewController: CameraViewController, didCapture document: GiniVisionDocument) {
+        let loadingView = viewController.addValidationLoadingView()
+        
+        validate([document]) { result in
+            loadingView.removeFromSuperview()
+            switch result {
+            case .success:
+                self.visionDocuments.append(document)
+                if let imageDocument = document as? GiniImageDocument {
+                    if self.giniConfiguration.multipageEnabled {
+                        viewController.animateToControlsView(imageDocument: imageDocument)
+                    } else {
+                        self.showNextScreenAfterPicking(documents: [imageDocument])
+                    }
+                } else if let qrDocument = document as? GiniQRCodeDocument {
+                    viewController.showPopup(forQRDetected: qrDocument) {
+                        self.showNextScreenAfterPicking(documents: self.visionDocuments)
+                    }
+                }
+            case .failure(let error):
+                if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {
+                    viewController.showErrorDialog(for: error) {
+                        let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
+                        self.showMultipageReview(withImageDocuments: imageDocuments)
+                    }
+                }
+            }
+        }
+    }
+    
+    func camera(_ viewController: CameraViewController, didSelect documentPicker: DocumentPickerType) {
+        switch documentPicker {
+        case .gallery:
+            documentPickerCoordinator.showGalleryPicker(from: viewController)
+        case .explorer:
+            documentPickerCoordinator.isPDFSelectionAllowed = visionDocuments.isEmpty
+            documentPickerCoordinator.showDocumentPicker(from: viewController)
+        case .dragndrop: break
+        }
+    }
+    
+    func cameraDidAppear(_ viewController: CameraViewController) {
+        if shouldShowOnBoarding() {
+            showOnboardingScreen()
+        } else if AlertDialogController.shouldShowNewMultipageFeature {
+            showMultipageNewFeatureDialog()
+        }
+    }
+    
+    func cameraDidTapMultipageReviewButton(_ viewController: CameraViewController) {
+        if let imageDocuments = visionDocuments as? [GiniImageDocument] {
+            showMultipageReview(withImageDocuments: imageDocuments)
+        }
+    }
+    
+    func createCameraViewController() -> CameraViewController {
+        let cameraViewController = CameraViewController(giniConfiguration: giniConfiguration)
+        cameraViewController.delegate = self
+        cameraViewController.title = giniConfiguration.navigationBarCameraTitle
+        cameraViewController.view.backgroundColor = giniConfiguration.backgroundColor
+        
+        cameraViewController.setupNavigationItem(usingResources: closeButtonResource,
+                                                 selector: #selector(back),
+                                                 position: .left,
+                                                 target: self)
+        
+        cameraViewController.setupNavigationItem(usingResources: helpButtonResource,
+                                                 selector: #selector(showHelpMenuScreen),
+                                                 position: .right,
+                                                 target: self)
+        
+        if giniConfiguration.fileImportSupportedTypes != .none {
+            documentPickerCoordinator.delegate = self
+            
+            if documentPickerCoordinator.isGalleryPermissionGranted {
+                documentPickerCoordinator.startCaching()
+            }
+            
+            if #available(iOS 11.0, *) {
+                addDropInteraction(forView: cameraViewController.view, with: documentPickerCoordinator)
+            }
+        }
+        
+        return cameraViewController
+    }
+    
+    private func didCaptureAndValidate(_ document: GiniVisionDocument) {
+        if let didCapture = visionDelegate?.didCapture(document:) {
+            didCapture(document)
+        } else if let didCapture = visionDelegate?.didCapture(_:) {
+            didCapture(document.data)
+        } else {
+            fatalError("GiniVisionDelegate.didCapture(document: GiniVisionDocument) should be implemented")
+        }
+    }
+    
+    private func shouldShowOnBoarding() -> Bool {
+        if giniConfiguration.onboardingShowAtFirstLaunch &&
+            !UserDefaults.standard.bool(forKey: "ginivision.defaults.onboardingShowed") {
+            UserDefaults.standard.set(true, forKey: "ginivision.defaults.onboardingShowed")
+            return true
+        } else if giniConfiguration.onboardingShowAtLaunch {
+            return true
+        }
+        
+        return false
+    }
+    
+    private func showOnboardingScreen() {
+        cameraViewController?.hideCameraOverlay()
+        cameraViewController?.hideCaptureButton()
+        cameraViewController?.hideFileImportTip()
+        
+        let vc = OnboardingContainerViewController { [weak self] in
+            guard let `self` = self else { return }
+            self.cameraViewController?.showCameraOverlay()
+            self.cameraViewController?.showCaptureButton()
+            self.cameraViewController?.showFileImportTip()
+        }
+        
+        let navigationController = UINavigationController(rootViewController: vc)
+        navigationController.applyStyle(withConfiguration: giniConfiguration)
+        navigationController.modalPresentationStyle = .overCurrentContext
+        screenAPINavigationController.present(navigationController, animated: true, completion: nil)
+    }
+    
+    private func showMultipageNewFeatureDialog() {
+        let alertDialog = AlertDialogController(giniConfiguration: giniConfiguration,
+                                                title: "This is the title",
+                                                subTitle: "This is the subtitle",
+                                                image: UIImageNamedPreferred(named: "multipageIcon"),
+                                                buttonTitle: "Let's scan!",
+                                                buttonImage: UIImage(named: "cameraIcon",
+                                                                     in: Bundle(for: GiniVision.self),
+                                                                     compatibleWith: nil))
+        alertDialog.continueAction = {
+            alertDialog.dismiss(animated: true, completion: nil)
+            AlertDialogController.shouldShowNewMultipageFeature = false
+        }
+        alertDialog.cancelAction = alertDialog.continueAction
+        screenAPINavigationController.present(alertDialog,
+                                              animated: true,
+                                              completion: nil)
+    }
+    
+    func showNextScreenAfterPicking(documents: [GiniVisionDocument]) {
+        if let firstDocument = documents.first, let documentsType = documents.type {
+            switch documentsType {
+            case .image:
+                if let imageDocuments = self.visionDocuments as? [GiniImageDocument],
+                    let lastDocument = imageDocuments.last {
+                    if self.giniConfiguration.multipageEnabled {
+                        if let imageDocuments = self.visionDocuments as? [GiniImageDocument],
+                            lastDocument.isImported {
+                            self.showMultipageReview(withImageDocuments: imageDocuments)
+                        }
+                    } else {
+                        self.reviewViewController = self.createReviewScreen(withDocument: lastDocument)
+                        self.screenAPINavigationController.pushViewController(self.reviewViewController!,
+                                                                              animated: true)
+                        self.didCaptureAndValidate(firstDocument)
+                    }
+                }
+            case .qrcode, .pdf:
+                self.analysisViewController = self.createAnalysisScreen(withDocument: firstDocument)
+                self.screenAPINavigationController.pushViewController(self.analysisViewController!,
+                                                                      animated: true)
+                self.didCaptureAndValidate(firstDocument)
+            }
+        }
+    }
+    
+}
+
+// MARK: - DocumentPickerCoordinatorDelegate
+
+extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
+    
+    func documentPicker(_ coordinator: DocumentPickerCoordinator,
+                        didPick documents: [GiniVisionDocument]) {
+        
+        self.validate(documents) { result in
+            switch result {
+            case .success(let validatedDocuments):
+                coordinator.dismissCurrentPicker {
+                    self.visionDocuments.append(contentsOf: validatedDocuments.map { $0.document })
+                    self.showNextScreenAfterPicking(documents: validatedDocuments.map { $0.document })
+                }
+            case .failure(let error):
+                var positiveAction: (() -> Void)?
+                
+                if let error = error as? FilePickerError {
+                    switch error {
+                    case .maxFilesPickedCountExceeded, .mixedDocumentsUnsupported:
+                        let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
+                        
+                        if imageDocuments.isNotEmpty {
+                            positiveAction = {
+                                coordinator.dismissCurrentPicker {
+                                    let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
+                                    self.showMultipageReview(withImageDocuments: imageDocuments)
+                                }
+                            }
+                        }
+                        
+                    case .photoLibraryAccessDenied:
+                        break
+                    }
+                }
+                
+                if coordinator.currentPickerDismissesAutomatically {
+                    self.cameraViewController?.showErrorDialog(for: error,
+                                                               positiveAction: positiveAction)
+                } else {
+                    coordinator.rootViewController?.showErrorDialog(for: error,
+                                                                    positiveAction: positiveAction)
+                }
+            }
+            
+        }
+    }
+    
+    @available(iOS 11.0, *)
+    fileprivate func addDropInteraction(forView view: UIView, with delegate: UIDropInteractionDelegate) {
+        let dropInteraction = UIDropInteraction(delegate: delegate)
+        view.addInteraction(dropInteraction)
+    }
+    
+    fileprivate func validate(_ documents: [GiniVisionDocument],
+                              completion: @escaping (Result<[ValidatedDocument]>) -> Void) {
+        
+        guard !(documents + visionDocuments).containsDifferentTypes else {
+            completion(.failure(FilePickerError.mixedDocumentsUnsupported))
+            return
+        }
+        
+        guard (documents.count + visionDocuments.count) <= GiniPDFDocument.maxPagesCount else {
+            completion(.failure(FilePickerError.maxFilesPickedCountExceeded))
+            return
+        }
+        
+        self.validate(importedDocuments: documents) { validatedDocuments in
+            let elementsWithError = validatedDocuments.filter { $0.error != nil }
+            if let firstElement = elementsWithError.first,
+                let error = firstElement.1,
+                (!self.giniConfiguration.multipageEnabled || firstElement.document.type != .image) {
+                completion(.failure(error))
+            } else {
+                completion(.success(validatedDocuments))
+            }
+        }
+    }
+    
+    fileprivate func validate(importedDocuments documents: [GiniVisionDocument],
+                              completion: @escaping ([ValidatedDocument]) -> Void) {
+        DispatchQueue.global().async {
+            var validatedDocuments: [(GiniVisionDocument, Error?)] = []
+            documents.forEach { document in
+                var documentError: Error?
+                do {
+                    try document.validate(giniConfiguration: self.giniConfiguration)
+                } catch let error {
+                    documentError = error
+                }
+                validatedDocuments.append((document, documentError))
+            }
+            
+            DispatchQueue.main.async {
+                completion(validatedDocuments)
+            }
+        }
+    }
+    
+}

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -141,7 +141,7 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
     private func showMultipageNewFeatureDialog() {
         let alertDialog = AlertDialogController(giniConfiguration: giniConfiguration,
                                                 title: "This is the title",
-                                                subTitle: "This is the subtitle",
+                                                message: "This is the subtitle",
                                                 image: UIImageNamedPreferred(named: "multipageIcon"),
                                                 buttonTitle: "Let's scan!",
                                                 buttonImage: UIImage(named: "cameraIcon",

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Review.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Review.swift
@@ -1,0 +1,77 @@
+//
+//  GiniScreenAPICoordinator+Review.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 4/4/18.
+//
+
+import Foundation
+
+// MARK: - Review Screen
+
+internal extension GiniScreenAPICoordinator {
+    func createReviewScreen(withDocument document: GiniVisionDocument,
+                            isFirstScreen: Bool = false) -> ReviewViewController {
+        let reviewViewController = ReviewViewController(document, successBlock: { [weak self] document in
+            guard let `self` = self else { return }
+            self.visionDocuments[0] = document
+            self.changesOnReview = true
+            }, failureBlock: { _ in
+        })
+        
+        reviewViewController.title = giniConfiguration.navigationBarReviewTitle
+        reviewViewController.view.backgroundColor = giniConfiguration.backgroundColor
+        reviewViewController.setupNavigationItem(usingResources: nextButtonResource,
+                                                 selector: #selector(showAnalysisScreen),
+                                                 position: .right,
+                                                 target: self)
+        
+        let backResource = isFirstScreen ? closeButtonResource : backButtonResource
+        reviewViewController.setupNavigationItem(usingResources: backResource,
+                                                 selector: #selector(back),
+                                                 position: .left,
+                                                 target: self)
+        
+        return reviewViewController
+    }
+}
+
+// MARK: - Multipage Review screen
+
+extension GiniScreenAPICoordinator: MultipageReviewViewControllerDelegate {
+    
+    func multipageReview(_ controller: MultipageReviewViewController,
+                         didUpdateDocuments documents: [GiniImageDocument]) {
+        self.visionDocuments = documents
+        if self.visionDocuments.isEmpty {
+            self.closeMultipageScreen()
+        }
+    }
+    
+    func createMultipageReviewScreenContainer(withImageDocuments documents: [GiniImageDocument])
+        -> MultipageReviewViewController {
+            let vc = MultipageReviewViewController(imageDocuments: documents, giniConfiguration: giniConfiguration)
+            vc.delegate = self
+            vc.setupNavigationItem(usingResources: backButtonResource,
+                                   selector: #selector(closeMultipageScreen),
+                                   position: .left,
+                                   target: self)
+            
+            vc.setupNavigationItem(usingResources: nextButtonResource,
+                                   selector: #selector(showAnalysisScreen),
+                                   position: .right,
+                                   target: self)
+            return vc
+    }
+    
+    @objc fileprivate func closeMultipageScreen() {
+        self.screenAPINavigationController.popViewController(animated: true)
+        self.multiPageReviewController = nil
+    }
+    
+    func showMultipageReview(withImageDocuments imageDocuments: [GiniImageDocument]) {
+        multiPageReviewController = createMultipageReviewScreenContainer(withImageDocuments: imageDocuments)
+        screenAPINavigationController.pushViewController(multiPageReviewController!,
+                                                         animated: true)
+    }
+}

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -374,7 +374,9 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
 
 extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
     
-    func documentPicker(_ coordinator: DocumentPickerCoordinator, didPick documents: [GiniVisionDocument], from picker: UIViewController?) {
+    func documentPicker(_ coordinator: DocumentPickerCoordinator,
+                        didPick documents: [GiniVisionDocument],
+                        from picker: UIViewController?) {
         
         self.validateCollectionOf(documents: documents) { result in
             switch result {
@@ -382,7 +384,6 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
                 picker?.dismiss(animated: true, completion: nil)
                 self.visionDocuments.append(contentsOf: validatedDocuments)
                 self.showNextScreenAfterPicking(documents: validatedDocuments)
-                break
             case .failure(let error):
                 var positiveAction: () -> Void = {}
                 
@@ -392,12 +393,11 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
                         positiveAction = {
                             
                         }
-                        break
                     case .mixedDocumentsUnsupported:
                         positiveAction = {
-                            self.showMultipageReview(withImageDocuments: self.visionDocuments as! [GiniImageDocument])
+                            let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
+                            self.showMultipageReview(withImageDocuments: imageDocuments)
                         }
-                        break
                     case .photoLibraryAccessDenied:
                         break
                     }
@@ -428,7 +428,7 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
             return
         }
         
-        guard (documents + visionDocuments).containsDifferentTypes else {
+        guard !(documents + visionDocuments).containsDifferentTypes else {
             completion(.failure(FilePickerError.mixedDocumentsUnsupported))
             return
         }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -14,14 +14,13 @@ protocol Coordinator: class {
 
 typealias ValidatedDocument = (document: GiniVisionDocument, error: Error?)
 
-//swiftlint:disable file_length
 internal final class GiniScreenAPICoordinator: NSObject, Coordinator {
     
     var rootViewController: UIViewController {
         return screenAPINavigationController
     }
     
-    fileprivate lazy var screenAPINavigationController: UINavigationController = {
+    fileprivate(set) lazy var screenAPINavigationController: UINavigationController = {
         let navigationController = UINavigationController()
         navigationController.delegate = self
         navigationController.applyStyle(withConfiguration: self.giniConfiguration)
@@ -29,45 +28,45 @@ internal final class GiniScreenAPICoordinator: NSObject, Coordinator {
     }()
     
     // Screens
-    fileprivate var analysisViewController: AnalysisViewController?
-    fileprivate var cameraViewController: CameraViewController?
-    fileprivate var imageAnalysisNoResultsViewController: ImageAnalysisNoResultsViewController?
-    fileprivate var reviewViewController: ReviewViewController?
-    fileprivate var multiPageReviewController: MultipageReviewViewController?
-    fileprivate lazy var documentPickerCoordinator: DocumentPickerCoordinator = {
+    var analysisViewController: AnalysisViewController?
+    var cameraViewController: CameraViewController?
+    var imageAnalysisNoResultsViewController: ImageAnalysisNoResultsViewController?
+    var reviewViewController: ReviewViewController?
+    var multiPageReviewController: MultipageReviewViewController?
+    lazy var documentPickerCoordinator: DocumentPickerCoordinator = {
         return DocumentPickerCoordinator()
     }()
     
     // Properties
-    fileprivate var changesOnReview: Bool = false
-    fileprivate var giniConfiguration: GiniConfiguration
+    var changesOnReview: Bool = false
+    fileprivate(set) var giniConfiguration: GiniConfiguration
     fileprivate let multiPageTransition = MultipageReviewTransitionAnimator()
     weak var visionDelegate: GiniVisionDelegate?
-    fileprivate(set) var visionDocuments: [GiniVisionDocument] = []
+    var visionDocuments: [GiniVisionDocument] = []
     
     // Resources
-    fileprivate lazy var backButtonResource =
+    fileprivate(set) lazy var backButtonResource =
         PreferredButtonResource(image: "navigationReviewBack",
                                 title: "ginivision.navigationbar.review.back",
                                 comment: "Button title in the navigation bar for the back button on the review screen",
                                 configEntry: self.giniConfiguration.navigationBarReviewTitleBackButton)
-    fileprivate lazy var cancelButtonResource =
+    fileprivate(set) lazy var cancelButtonResource =
         PreferredButtonResource(image: "navigationAnalysisBack",
                                 title: "ginivision.navigationbar.analysis.back",
                                 comment: "Button title in the navigation bar for" +
             "the back button on the analysis screen",
                                 configEntry: self.giniConfiguration.navigationBarAnalysisTitleBackButton)
-    fileprivate lazy var closeButtonResource =
+    fileprivate(set) lazy var closeButtonResource =
         PreferredButtonResource(image: "navigationCameraClose",
                                 title: "ginivision.navigationbar.camera.close",
                                 comment: "Button title in the navigation bar for the close button on the camera screen",
                                 configEntry: self.giniConfiguration.navigationBarCameraTitleCloseButton)
-    fileprivate lazy var helpButtonResource =
+    fileprivate(set) lazy var helpButtonResource =
         PreferredButtonResource(image: "navigationCameraHelp",
                                 title: "ginivision.navigationbar.camera.help",
                                 comment: "Button title in the navigation bar for the help button on the camera screen",
                                 configEntry: self.giniConfiguration.navigationBarCameraTitleHelpButton)
-    fileprivate lazy var nextButtonResource =
+    fileprivate(set) lazy var nextButtonResource =
         PreferredButtonResource(image: "navigationReviewContinue",
                                 title: "ginivision.navigationbar.review.continue",
                                 comment: "Button title in the navigation bar for " +
@@ -137,7 +136,7 @@ internal final class GiniScreenAPICoordinator: NSObject, Coordinator {
 
 extension GiniScreenAPICoordinator {
     
-    @objc fileprivate func back() {
+    @objc func back() {
         if self.screenAPINavigationController.viewControllers.count == 1 {
             self.closeScreenApi()
         } else {
@@ -145,15 +144,15 @@ extension GiniScreenAPICoordinator {
         }
     }
     
-    @objc fileprivate func closeScreenApi() {
+    @objc func closeScreenApi() {
         self.visionDelegate?.didCancelCapturing()
     }
     
-    @objc fileprivate func showHelpMenuScreen() {
+    @objc func showHelpMenuScreen() {
         self.screenAPINavigationController.pushViewController(HelpMenuViewController(), animated: true)
     }
     
-    @objc fileprivate func showAnalysisScreen() {
+    @objc func showAnalysisScreen() {
         let documentToShow = visionDocuments[0]
         if let didReview = visionDelegate?.didReview(document:withChanges:) {
             didReview(documentToShow, changesOnReview)
@@ -168,7 +167,7 @@ extension GiniScreenAPICoordinator {
         self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)
     }
     
-    @objc fileprivate func backToCamera() {
+    @objc func backToCamera() {
         if let cameraViewController = cameraViewController {
             screenAPINavigationController.popToViewController(cameraViewController, animated: true)
         }
@@ -234,449 +233,5 @@ extension GiniScreenAPICoordinator: UINavigationControllerDelegate {
         }
         
         return multiPageTransition
-    }
-}
-
-// MARK: - Camera Screen
-
-extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
-
-    func camera(_ viewController: CameraViewController, didCapture document: GiniVisionDocument) {
-        let loadingView = viewController.addValidationLoadingView()
-
-        validate([document]) { result in
-            loadingView.removeFromSuperview()
-            switch result {
-            case .success:
-                self.visionDocuments.append(document)
-                if let imageDocument = document as? GiniImageDocument {
-                    if self.giniConfiguration.multipageEnabled {
-                        viewController.animateToControlsView(imageDocument: imageDocument)
-                    } else {
-                        self.showNextScreenAfterPicking(documents: [imageDocument])
-                    }
-                } else if let qrDocument = document as? GiniQRCodeDocument {
-                    viewController.showPopup(forQRDetected: qrDocument) {
-                        self.showNextScreenAfterPicking(documents: self.visionDocuments)
-                    }
-                }
-            case .failure(let error):
-                if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {
-                    viewController.showErrorDialog(for: error) {
-                        let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
-                        self.showMultipageReview(withImageDocuments: imageDocuments)
-                    }
-                }
-            }
-        }
-    }
-    
-    func camera(_ viewController: CameraViewController, didSelect documentPicker: DocumentPickerType) {
-        switch documentPicker {
-        case .gallery:
-            documentPickerCoordinator.showGalleryPicker(from: viewController)
-        case .explorer:
-            documentPickerCoordinator.isPDFSelectionAllowed = visionDocuments.isEmpty
-            documentPickerCoordinator.showDocumentPicker(from: viewController)
-        case .dragndrop: break
-        }
-    }
-    
-    func cameraDidAppear(_ viewController: CameraViewController) {
-        if shouldShowOnBoarding() {
-            showOnboardingScreen()
-        } else if AlertDialogController.shouldShowNewMultipageFeature {
-            showMultipageNewFeatureDialog()
-        }
-    }
-    
-    func cameraDidTapMultipageReviewButton(_ viewController: CameraViewController) {
-        if let imageDocuments = visionDocuments as? [GiniImageDocument] {
-            showMultipageReview(withImageDocuments: imageDocuments)
-        }
-    }
-    
-    func createCameraViewController() -> CameraViewController {
-        let cameraViewController = CameraViewController(giniConfiguration: giniConfiguration)
-        cameraViewController.delegate = self
-        cameraViewController.title = giniConfiguration.navigationBarCameraTitle
-        cameraViewController.view.backgroundColor = giniConfiguration.backgroundColor
-        
-        cameraViewController.setupNavigationItem(usingResources: closeButtonResource,
-                                                 selector: #selector(back),
-                                                 position: .left,
-                                                 target: self)
-        
-        cameraViewController.setupNavigationItem(usingResources: helpButtonResource,
-                                                 selector: #selector(showHelpMenuScreen),
-                                                 position: .right,
-                                                 target: self)
-        
-        if giniConfiguration.fileImportSupportedTypes != .none {
-            documentPickerCoordinator.delegate = self
-            
-            if documentPickerCoordinator.isGalleryPermissionGranted {
-                documentPickerCoordinator.startCaching()
-            }
-            
-            if #available(iOS 11.0, *) {
-                addDropInteraction(forView: cameraViewController.view, with: documentPickerCoordinator)
-            }
-        }
-        
-        return cameraViewController
-    }
-    
-    fileprivate func didCapture(withDocument document: GiniVisionDocument) {
-        if let didCapture = visionDelegate?.didCapture(document:) {
-            didCapture(document)
-        } else if let didCapture = visionDelegate?.didCapture(_:) {
-            didCapture(document.data)
-        } else {
-            fatalError("GiniVisionDelegate.didCapture(document: GiniVisionDocument) should be implemented")
-        }
-    }
-    
-    fileprivate func shouldShowOnBoarding() -> Bool {
-        if giniConfiguration.onboardingShowAtFirstLaunch &&
-            !UserDefaults.standard.bool(forKey: "ginivision.defaults.onboardingShowed") {
-            UserDefaults.standard.set(true, forKey: "ginivision.defaults.onboardingShowed")
-            return true
-        } else if giniConfiguration.onboardingShowAtLaunch {
-            return true
-        }
-        
-        return false
-    }
-    
-    private func showOnboardingScreen() {
-        cameraViewController?.hideCameraOverlay()
-        cameraViewController?.hideCaptureButton()
-        cameraViewController?.hideFileImportTip()
-        
-        let vc = OnboardingContainerViewController { [weak self] in
-            guard let `self` = self else { return }
-            self.cameraViewController?.showCameraOverlay()
-            self.cameraViewController?.showCaptureButton()
-            self.cameraViewController?.showFileImportTip()
-        }
-        
-        let navigationController = UINavigationController(rootViewController: vc)
-        navigationController.applyStyle(withConfiguration: giniConfiguration)
-        navigationController.modalPresentationStyle = .overCurrentContext
-        screenAPINavigationController.present(navigationController, animated: true, completion: nil)
-    }
-    
-    private func showMultipageNewFeatureDialog() {
-        let alertDialog = AlertDialogController(giniConfiguration: giniConfiguration,
-                                                title: "This is the title",
-                                                message: "This is the message",
-                                                image: UIImageNamedPreferred(named: "multipageIcon"),
-                                                buttonTitle: "Let's scan!",
-                                                buttonImage: UIImage(named: "cameraIcon",
-                                                                     in: Bundle(for: GiniVision.self),
-                                                                     compatibleWith: nil))
-        alertDialog.continueAction = {
-            alertDialog.dismiss(animated: true, completion: nil)
-            AlertDialogController.shouldShowNewMultipageFeature = false
-        }
-        alertDialog.cancelAction = alertDialog.continueAction
-        screenAPINavigationController.present(alertDialog,
-                                              animated: true,
-                                              completion: nil)
-    }
-    
-}
-
-// MARK: - DocumentPickerCoordinatorDelegate
-
-extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
-    
-    func documentPicker(_ coordinator: DocumentPickerCoordinator,
-                        didPick documents: [GiniVisionDocument]) {
-        
-        self.validate(documents) { result in
-            switch result {
-            case .success(let validatedDocuments):
-                coordinator.dismissCurrentPicker {
-                    self.visionDocuments.append(contentsOf: validatedDocuments.map { $0.document })
-                    self.showNextScreenAfterPicking(documents: validatedDocuments.map { $0.document })
-                }
-            case .failure(let error):
-                var positiveAction: (() -> Void)?
-                
-                if let error = error as? FilePickerError {
-                    switch error {
-                    case .maxFilesPickedCountExceeded, .mixedDocumentsUnsupported:
-                        let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
-
-                        if imageDocuments.isNotEmpty {
-                            positiveAction = {
-                                coordinator.dismissCurrentPicker {
-                                    let imageDocuments = self.visionDocuments.flatMap { $0 as? GiniImageDocument }
-                                    self.showMultipageReview(withImageDocuments: imageDocuments)
-                                }
-                            }
-                        }
-
-                    case .photoLibraryAccessDenied:
-                        break
-                    }
-                }
-                
-                if coordinator.currentPickerDismissesAutomatically {
-                    self.cameraViewController?.showErrorDialog(for: error,
-                                                               positiveAction: positiveAction)
-                } else {
-                    coordinator.rootViewController?.showErrorDialog(for: error,
-                                                                    positiveAction: positiveAction)
-                }
-            }
-            
-        }
-    }
-    
-    @available(iOS 11.0, *)
-    fileprivate func addDropInteraction(forView view: UIView, with delegate: UIDropInteractionDelegate) {
-        let dropInteraction = UIDropInteraction(delegate: delegate)
-        view.addInteraction(dropInteraction)
-    }
-    
-    fileprivate func validate(_ documents: [GiniVisionDocument],
-                              completion: @escaping (Result<[ValidatedDocument]>) -> Void) {
-        
-        guard !(documents + visionDocuments).containsDifferentTypes else {
-            completion(.failure(FilePickerError.mixedDocumentsUnsupported))
-            return
-        }
-        
-        guard (documents.count + visionDocuments.count) <= GiniPDFDocument.maxPagesCount else {
-            completion(.failure(FilePickerError.maxFilesPickedCountExceeded))
-            return
-        }
-        
-        self.validate(importedDocuments: documents) { validatedDocuments in
-            let elementsWithError = validatedDocuments.filter { $0.error != nil }
-            if let firstElement = elementsWithError.first,
-                let error = firstElement.1,
-                (!self.giniConfiguration.multipageEnabled || firstElement.document.type != .image) {
-                completion(.failure(error))
-            } else {
-                completion(.success(validatedDocuments))
-            }
-        }
-    }
-    
-    fileprivate func validate(importedDocuments documents: [GiniVisionDocument],
-                              completion: @escaping ([ValidatedDocument]) -> Void) {
-        DispatchQueue.global().async {
-            var validatedDocuments: [(GiniVisionDocument, Error?)] = []
-            documents.forEach { document in
-                var documentError: Error?
-                do {
-                    try document.validate(giniConfiguration: self.giniConfiguration)
-                } catch let error {
-                    documentError = error
-                }
-                validatedDocuments.append((document, documentError))
-            }
-            
-            DispatchQueue.main.async {
-                completion(validatedDocuments)
-            }
-        }
-    }
-    
-    func showNextScreenAfterPicking(documents: [GiniVisionDocument]) {
-        if let firstDocument = documents.first, let documentsType = documents.type {
-            switch documentsType {
-            case .image:
-                if let imageDocuments = self.visionDocuments as? [GiniImageDocument],
-                    let lastDocument = imageDocuments.last {
-                    if self.giniConfiguration.multipageEnabled {
-                        if let imageDocuments = self.visionDocuments as? [GiniImageDocument],
-                            lastDocument.isImported {
-                            self.showMultipageReview(withImageDocuments: imageDocuments)
-                        }
-                    } else {
-                        self.reviewViewController = self.createReviewScreen(withDocument: lastDocument)
-                        self.screenAPINavigationController.pushViewController(self.reviewViewController!,
-                                                                              animated: true)
-                        self.didCapture(withDocument: firstDocument)
-                    }
-                }
-            case .qrcode, .pdf:
-                self.analysisViewController = self.createAnalysisScreen(withDocument: firstDocument)
-                self.screenAPINavigationController.pushViewController(self.analysisViewController!,
-                                                                      animated: true)
-                self.didCapture(withDocument: firstDocument)
-            }
-        }
-    }
-}
-
-// MARK: - Review Screen
-
-internal extension GiniScreenAPICoordinator {
-    fileprivate func createReviewScreen(withDocument document: GiniVisionDocument,
-                                        isFirstScreen: Bool = false) -> ReviewViewController {
-        let reviewViewController = ReviewViewController(document, successBlock: { [weak self] document in
-            guard let `self` = self else { return }
-            self.visionDocuments[0] = document
-            self.changesOnReview = true
-            }, failureBlock: { _ in
-        })
-        
-        reviewViewController.title = giniConfiguration.navigationBarReviewTitle
-        reviewViewController.view.backgroundColor = giniConfiguration.backgroundColor
-        reviewViewController.setupNavigationItem(usingResources: nextButtonResource,
-                                                 selector: #selector(showAnalysisScreen),
-                                                 position: .right,
-                                                 target: self)
-        
-        let backResource = isFirstScreen ? closeButtonResource : backButtonResource
-        reviewViewController.setupNavigationItem(usingResources: backResource,
-                                                 selector: #selector(back),
-                                                 position: .left,
-                                                 target: self)
-        
-        return reviewViewController
-    }
-}
-
-// MARK: - Multipage Review screen
-
-extension GiniScreenAPICoordinator: MultipageReviewViewControllerDelegate {
-    
-    func multipageReview(_ controller: MultipageReviewViewController,
-                         didUpdateDocuments documents: [GiniImageDocument]) {
-        self.visionDocuments = documents
-        if self.visionDocuments.isEmpty {
-            self.closeMultipageScreen()
-        }
-    }
-    
-    fileprivate func createMultipageReviewScreenContainer(withImageDocuments documents: [GiniImageDocument])
-        -> MultipageReviewViewController {
-            let vc = MultipageReviewViewController(imageDocuments: documents, giniConfiguration: giniConfiguration)
-            vc.delegate = self
-            vc.setupNavigationItem(usingResources: backButtonResource,
-                                   selector: #selector(closeMultipageScreen),
-                                   position: .left,
-                                   target: self)
-            
-            vc.setupNavigationItem(usingResources: nextButtonResource,
-                                   selector: #selector(showAnalysisScreen),
-                                   position: .right,
-                                   target: self)
-            return vc
-    }
-    
-    @objc fileprivate func closeMultipageScreen() {
-        self.screenAPINavigationController.popViewController(animated: true)
-        self.multiPageReviewController = nil
-    }
-    
-    fileprivate func showMultipageReview(withImageDocuments imageDocuments: [GiniImageDocument]) {
-        multiPageReviewController = createMultipageReviewScreenContainer(withImageDocuments: imageDocuments)
-        screenAPINavigationController.pushViewController(multiPageReviewController!,
-                                                         animated: true)
-    }
-}
-
-// MARK: - Analysis Screen
-
-internal extension GiniScreenAPICoordinator {
-    fileprivate func createAnalysisScreen(withDocument document: GiniVisionDocument) -> AnalysisViewController {
-        let viewController = AnalysisViewController(document: document)
-        viewController.view.backgroundColor = giniConfiguration.backgroundColor
-        viewController.didShowAnalysis = { [weak self] in
-            guard let `self` = self else { return }
-            self.visionDelegate?.didShowAnalysis?(self)
-        }
-        viewController.setupNavigationItem(usingResources: self.cancelButtonResource,
-                                           selector: #selector(back),
-                                           position: .left,
-                                           target: self)
-        return viewController
-    }
-}
-
-// MARK: - ImageAnalysisNoResults screen
-
-extension GiniScreenAPICoordinator {
-    fileprivate func createImageAnalysisNoResultsScreen() -> ImageAnalysisNoResultsViewController {
-        let imageAnalysisNoResultsViewController: ImageAnalysisNoResultsViewController
-        let isCameraViewControllerLoaded: Bool = {
-            guard let cameraViewController = cameraViewController else {
-                return false
-            }
-            return screenAPINavigationController.viewControllers.contains(cameraViewController)
-        }()
-        
-        if isCameraViewControllerLoaded {
-            imageAnalysisNoResultsViewController = ImageAnalysisNoResultsViewController()
-            imageAnalysisNoResultsViewController.setupNavigationItem(usingResources: backButtonResource,
-                                                                     selector: #selector(backToCamera),
-                                                                     position: .left,
-                                                                     target: self)
-        } else {
-            imageAnalysisNoResultsViewController = ImageAnalysisNoResultsViewController(bottomButtonText: nil,
-                                                                                        bottomButtonIcon: nil)
-            imageAnalysisNoResultsViewController.setupNavigationItem(usingResources: closeButtonResource,
-                                                                     selector: #selector(closeScreenApi),
-                                                                     position: .left,
-                                                                     target: self)
-        }
-        
-        imageAnalysisNoResultsViewController.didTapBottomButton = { [weak self] in
-            self?.backToCamera()
-        }
-        
-        return imageAnalysisNoResultsViewController
-    }
-}
-
-// MARK: - AnalysisDelegate
-
-extension GiniScreenAPICoordinator: AnalysisDelegate {
-    func displayError(withMessage message: String?, andAction action: (() -> Void)?) {
-        DispatchQueue.main.async {
-            var noticeAction: NoticeAction?
-            if let action = action {
-                noticeAction = NoticeAction(title: NSLocalizedString("ginivision.analysis.error.actionTitle",
-                                                                     bundle: Bundle(for: GiniVision.self),
-                                                                     comment: "Action button title"),
-                                            action: action)
-            }
-            let notice = NoticeView(text: message ?? "", type: .error, noticeAction: noticeAction)
-            self.show(notice: notice)
-        }
-    }
-    
-    func tryDisplayNoResultsScreen() -> Bool {
-        if let visionDocument = visionDocuments.first, visionDocument.type == .image {
-            DispatchQueue.main.async { [weak self] in
-                guard let `self` = self else { return }
-                self.imageAnalysisNoResultsViewController = self.createImageAnalysisNoResultsScreen()
-                self.screenAPINavigationController.pushViewController(self.imageAnalysisNoResultsViewController!,
-                                                                      animated: true)
-            }
-            
-            return true
-        }
-        return false
-    }
-    
-    private func show(notice: NoticeView) {
-        let noticeView = analysisViewController?.view.subviews.flatMap { $0 as? NoticeView }.first
-        if let noticeView = noticeView {
-            noticeView.hide(completion: { [weak self] in
-                self?.show(notice: notice)
-            })
-        } else {
-            analysisViewController?.view.addSubview(notice)
-            notice.show()
-        }
     }
 }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -38,11 +38,11 @@ internal final class GiniScreenAPICoordinator: NSObject, Coordinator {
     }()
     
     // Properties
-    var changesOnReview: Bool = false
     fileprivate(set) var giniConfiguration: GiniConfiguration
     fileprivate let multiPageTransition = MultipageReviewTransitionAnimator()
-    weak var visionDelegate: GiniVisionDelegate?
+    var changesOnReview: Bool = false
     var visionDocuments: [GiniVisionDocument] = []
+    weak var visionDelegate: GiniVisionDelegate?
     
     // Resources
     fileprivate(set) lazy var backButtonResource =

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -408,7 +408,7 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
                                                        positiveAction: positiveAction)
                 } else {
                     self.cameraViewController?.showErrorDialog(for: error,
-                                                               possitiveAction: positiveAction)
+                                                               positiveAction: positiveAction)
                 }
             }
             

--- a/GiniVision/Classes/Core/GiniVision.swift
+++ b/GiniVision/Classes/Core/GiniVision.swift
@@ -179,4 +179,14 @@ import UIKit
     public static var versionString: String {
         return GiniVisionVersion
     }
+    
+    /**
+     Validates a `GiniVisionDocument` with a given `GiniConfiguration`.
+     
+     - Throws: `DocumentValidationError` if there was an error during the validation.
+     
+     */
+    public class func validate(_ document: GiniVisionDocument, withConfig giniConfiguration: GiniConfiguration) throws {
+        try GiniVisionDocumentValidator.validate(document, withConfig: giniConfiguration)
+    }
 }

--- a/GiniVision/Classes/Core/GiniVisionDocument.swift
+++ b/GiniVision/Classes/Core/GiniVisionDocument.swift
@@ -18,8 +18,6 @@ import Foundation
     var previewImage: UIImage? { get }
     var isReviewable: Bool { get }
     var isImported: Bool { get }
-    
-    func checkType() throws
 }
 
 // MARK: GiniVisionDocumentType
@@ -101,15 +99,13 @@ public class GiniVisionDocumentBuilder: NSObject {
     }
 }
 
-// MARK: GiniVisionDocument extension
-
-extension GiniVisionDocument {
+public final class GiniVisionDocumentValidator {
     
     public static var maxPagesCount: Int {
         return 10
     }
     
-    fileprivate var MAX_FILE_SIZE: Int { // Bytes
+    fileprivate static var maxFileSize: Int { // Bytes
         return 10 * 1024 * 1024
     }
     
@@ -122,11 +118,10 @@ extension GiniVisionDocument {
      - Throws: `DocumentValidationError.exceededMaxFileSize` is thrown if the document is not valid.
      
      */
-    public func validate(giniConfiguration: GiniConfiguration) throws {
-        let document = self
+    public class func validate(_ document: GiniVisionDocument, withConfig giniConfiguration: GiniConfiguration) throws {
         if !maxFileSizeExceeded(forData: document.data) {
-            try checkType()
-            let customValidationResult = giniConfiguration.customDocumentValidations(self)
+            try validateType(for: document)
+            let customValidationResult = giniConfiguration.customDocumentValidations(document)
             if let error = customValidationResult.error, !customValidationResult.isSuccess {
                 throw error
             }
@@ -137,10 +132,44 @@ extension GiniVisionDocument {
     
     // MARK: File size check
     
-    fileprivate func maxFileSizeExceeded(forData data: Data) -> Bool {
-        if data.count > MAX_FILE_SIZE {
+    fileprivate class func maxFileSizeExceeded(forData data: Data) -> Bool {
+        if data.count > maxFileSize {
             return true
         }
         return false
+    }
+    
+    fileprivate class func validateType(for document: GiniVisionDocument) throws {
+        switch document {
+        case let qrDocument as GiniQRCodeDocument:
+            if qrDocument.qrCodeFormat == nil ||
+                qrDocument.extractedParameters.isEmpty ||
+                qrDocument.extractedParameters["iban"] == nil {
+                throw DocumentValidationError.qrCodeFormatNotValid
+            }
+        case let pdfDocument as GiniPDFDocument:
+            if pdfDocument.data.isPDF {
+                if case 1...maxPagesCount = pdfDocument.numberPages {
+                    return
+                } else {
+                    throw DocumentValidationError.pdfPageLengthExceeded
+                }
+            } else {
+                throw DocumentValidationError.fileFormatNotValid
+            }
+        case let imageDocument as GiniImageDocument:
+            if imageDocument.data.isImage {
+                if !(imageDocument.data.isJPEG ||
+                    imageDocument.data.isPNG ||
+                    imageDocument.data.isGIF ||
+                    imageDocument.data.isTIFF) {
+                    throw DocumentValidationError.imageFormatNotValid
+                }
+            } else {
+                throw DocumentValidationError.fileFormatNotValid
+            }
+        default:
+            break
+        }
     }
 }

--- a/GiniVision/Classes/Core/GiniVisionDocument.swift
+++ b/GiniVision/Classes/Core/GiniVisionDocument.swift
@@ -22,7 +22,7 @@ import Foundation
 
 extension GiniVisionDocument {
     @available(*, deprecated)
-    func validate() throws {
+    public func validate() throws {
         try GiniVisionDocumentValidator.validate(self,
                                                  withConfig: GiniConfiguration.sharedConfiguration)
     }

--- a/GiniVision/Classes/Core/GiniVisionDocument.swift
+++ b/GiniVision/Classes/Core/GiniVisionDocument.swift
@@ -20,6 +20,14 @@ import Foundation
     var isImported: Bool { get }
 }
 
+extension GiniVisionDocument {
+    @available(*, deprecated)
+    func validate() throws {
+        try GiniVisionDocumentValidator.validate(self,
+                                                 withConfig: GiniConfiguration.sharedConfiguration)
+    }
+}
+
 // MARK: GiniVisionDocumentType
 
 @objc public enum GiniVisionDocumentType: Int {
@@ -96,80 +104,5 @@ public class GiniVisionDocumentBuilder: NSObject {
             }
         }
         return nil
-    }
-}
-
-public final class GiniVisionDocumentValidator {
-    
-    public static var maxPagesCount: Int {
-        return 10
-    }
-    
-    fileprivate static var maxFileSize: Int { // Bytes
-        return 10 * 1024 * 1024
-    }
-    
-    // MARK: File validation
-    /**
-     Validates a document. The validation process is done in the _global_ `DispatchQueue`.
-     Also it is possible to add custom validations in the `GiniConfiguration.customDocumentValidations`
-     closure.
-     
-     - Throws: `DocumentValidationError.exceededMaxFileSize` is thrown if the document is not valid.
-     
-     */
-    public class func validate(_ document: GiniVisionDocument, withConfig giniConfiguration: GiniConfiguration) throws {
-        if !maxFileSizeExceeded(forData: document.data) {
-            try validateType(for: document)
-            let customValidationResult = giniConfiguration.customDocumentValidations(document)
-            if let error = customValidationResult.error, !customValidationResult.isSuccess {
-                throw error
-            }
-        } else {
-            throw DocumentValidationError.exceededMaxFileSize
-        }
-    }
-    
-    // MARK: File size check
-    
-    fileprivate class func maxFileSizeExceeded(forData data: Data) -> Bool {
-        if data.count > maxFileSize {
-            return true
-        }
-        return false
-    }
-    
-    fileprivate class func validateType(for document: GiniVisionDocument) throws {
-        switch document {
-        case let qrDocument as GiniQRCodeDocument:
-            if qrDocument.qrCodeFormat == nil ||
-                qrDocument.extractedParameters.isEmpty ||
-                qrDocument.extractedParameters["iban"] == nil {
-                throw DocumentValidationError.qrCodeFormatNotValid
-            }
-        case let pdfDocument as GiniPDFDocument:
-            if pdfDocument.data.isPDF {
-                if case 1...maxPagesCount = pdfDocument.numberPages {
-                    return
-                } else {
-                    throw DocumentValidationError.pdfPageLengthExceeded
-                }
-            } else {
-                throw DocumentValidationError.fileFormatNotValid
-            }
-        case let imageDocument as GiniImageDocument:
-            if imageDocument.data.isImage {
-                if !(imageDocument.data.isJPEG ||
-                    imageDocument.data.isPNG ||
-                    imageDocument.data.isGIF ||
-                    imageDocument.data.isTIFF) {
-                    throw DocumentValidationError.imageFormatNotValid
-                }
-            } else {
-                throw DocumentValidationError.fileFormatNotValid
-            }
-        default:
-            break
-        }
     }
 }

--- a/GiniVision/Classes/Core/GiniVisionDocument.swift
+++ b/GiniVision/Classes/Core/GiniVisionDocument.swift
@@ -112,10 +112,6 @@ extension GiniVisionDocument {
     fileprivate var MAX_FILE_SIZE: Int { // Bytes
         return 10 * 1024 * 1024
     }
-
-    fileprivate var customDocumentValidations: ((GiniVisionDocument) -> CustomDocumentValidationResult) {
-        return GiniConfiguration.sharedConfiguration.customDocumentValidations
-    }
     
     // MARK: File validation
     /**

--- a/GiniVision/Classes/Core/GiniVisionDocument.swift
+++ b/GiniVision/Classes/Core/GiniVisionDocument.swift
@@ -126,11 +126,11 @@ extension GiniVisionDocument {
      - Throws: `DocumentValidationError.exceededMaxFileSize` is thrown if the document is not valid.
      
      */
-    public func validate() throws {
+    public func validate(giniConfiguration: GiniConfiguration) throws {
         let document = self
         if !maxFileSizeExceeded(forData: document.data) {
             try checkType()
-            let customValidationResult = customDocumentValidations(self)
+            let customValidationResult = giniConfiguration.customDocumentValidations(self)
             if let error = customValidationResult.error, !customValidationResult.isSuccess {
                 throw error
             }

--- a/GiniVision/Classes/Core/GiniVisionDocumentValidator.swift
+++ b/GiniVision/Classes/Core/GiniVisionDocumentValidator.swift
@@ -1,0 +1,83 @@
+//
+//  GiniVisionDocumentValidator.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 4/13/18.
+//
+
+import Foundation
+
+final class GiniVisionDocumentValidator {
+    
+    static var maxPagesCount: Int {
+        return 10
+    }
+    
+    fileprivate static var maxFileSize: Int { // Bytes
+        return 10 * 1024 * 1024
+    }
+    
+    // MARK: File validation
+    /**
+     Validates a document. The validation process is done in the _global_ `DispatchQueue`.
+     Also it is possible to add custom validations in the `GiniConfiguration.customDocumentValidations`
+     closure.
+     
+     - Throws: `DocumentValidationError.exceededMaxFileSize` is thrown if the document is not valid.
+     
+     */
+    class func validate(_ document: GiniVisionDocument, withConfig giniConfiguration: GiniConfiguration) throws {
+        if !maxFileSizeExceeded(forData: document.data) {
+            try validateType(for: document)
+            let customValidationResult = giniConfiguration.customDocumentValidations(document)
+            if let error = customValidationResult.error, !customValidationResult.isSuccess {
+                throw error
+            }
+        } else {
+            throw DocumentValidationError.exceededMaxFileSize
+        }
+    }
+    
+    // MARK: File size check
+    
+    fileprivate class func maxFileSizeExceeded(forData data: Data) -> Bool {
+        if data.count > maxFileSize {
+            return true
+        }
+        return false
+    }
+    
+    fileprivate class func validateType(for document: GiniVisionDocument) throws {
+        switch document {
+        case let qrDocument as GiniQRCodeDocument:
+            if qrDocument.qrCodeFormat == nil ||
+                qrDocument.extractedParameters.isEmpty ||
+                qrDocument.extractedParameters["iban"] == nil {
+                throw DocumentValidationError.qrCodeFormatNotValid
+            }
+        case let pdfDocument as GiniPDFDocument:
+            if pdfDocument.data.isPDF {
+                if case 1...maxPagesCount = pdfDocument.numberPages {
+                    return
+                } else {
+                    throw DocumentValidationError.pdfPageLengthExceeded
+                }
+            } else {
+                throw DocumentValidationError.fileFormatNotValid
+            }
+        case let imageDocument as GiniImageDocument:
+            if imageDocument.data.isImage {
+                if !(imageDocument.data.isJPEG ||
+                    imageDocument.data.isPNG ||
+                    imageDocument.data.isGIF ||
+                    imageDocument.data.isTIFF) {
+                    throw DocumentValidationError.imageFormatNotValid
+                }
+            } else {
+                throw DocumentValidationError.fileFormatNotValid
+            }
+        default:
+            break
+        }
+    }
+}

--- a/GiniVision/Classes/Core/GiniVisionUtils.swift
+++ b/GiniVision/Classes/Core/GiniVisionUtils.swift
@@ -184,32 +184,7 @@ internal func setStatusBarStyle(to statusBarStyle: UIStatusBarStyle,
     application.setStatusBarStyle(statusBarStyle, animated: true)
 }
 
-/**
-    Create an alert view controller.
- */
-func errorDialog(withMessage message: String,
-                 title: String? = nil,
-                 cancelActionTitle: String,
-                 confirmActionTitle: String? = nil,
-                 confirmAction: (() -> Void)? = nil) -> UIAlertController {
-    
-    let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-    alertViewController.addAction(UIAlertAction(title: cancelActionTitle,
-                                                style: .cancel,
-                                                handler: { _ in
-        alertViewController.dismiss(animated: true, completion: nil)
-    }))
-    
-    if let confirmActionTitle = confirmActionTitle {
-        alertViewController.addAction(UIAlertAction(title: confirmActionTitle,
-                                                    style: .default,
-                                                    handler: { _ in
-            confirmAction?()
-        }))
-    }
 
-    return alertViewController
-}
 
 /**
     Measure the time spent executing a block


### PR DESCRIPTION
To avoid raveled and unreadable code between the components of the application, it has been decoupled the validation from the camera screen, being done outside of it. Also the pickers has been also decoupled from the camera so it is now more clear. This eases the validation and flow between different components, being easier to use with the Component API.


### How to test
Run the Example app in single page mode, disable internet connection in the device and try to analyze a document.

### Merging
Automatic
  