### PR TITLE
Fixed open with and QRcode/PDF document upload

### DIFF
--- a/Documentation/source/Changelog.md
+++ b/Documentation/source/Changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+4.0.0-beta.1 (2018-05-15)
+------------------
+
+-   Added multipage mode
+-   Added network plugin
+-   Minor UX/UI improvements 
+
 3.3.2 (2018-03-08)
 ------------------
 

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -114,6 +114,8 @@ final class ComponentAPICoordinator: NSObject, Coordinator {
                 } else {
                     showReviewScreen()
                 }
+                
+                upload(documentRequests: documentRequests)
             } else {
                 showAnalysisScreen()
             }
@@ -287,7 +289,7 @@ extension ComponentAPICoordinator {
                     self.documentRequests[index].error = error
                 }
                 
-                // When multipage mode is used and documents are image, you have to refresh the multipage review screen
+                // When multipage mode is used and documents are images, you have to refresh the multipage review screen
                 if self.giniConfiguration.multipageEnabled, self.documentRequests.type == .image {
                     self.refreshMultipageReview(with: self.documentRequests)
                 }

--- a/Example/Example Swift/Info.plist
+++ b/Example/Example Swift/Info.plist
@@ -49,7 +49,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -93,8 +93,9 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
                     fatalError("You are trying to import a file from other app when the Open With feature is not " +
                         "enabled. To enable it just set `openWithEnabled` to `true` in the `GiniConfiguration`")
                 }
-                viewControllers = initialViewControllers(with: documentRequests)
                 
+                documentRequests.forEach { visionDelegate?.didCapture(document: $0.document, uploadDelegate: self) }
+                viewControllers = initialViewControllers(with: documentRequests)
             } else {
                 fatalError("You are trying to import both PDF and images at the same time. " +
                     "For now it is only possible to import either images or one PDF")

--- a/GiniVision/Classes/Core/GiniVisionVersion.swift
+++ b/GiniVision/Classes/Core/GiniVisionVersion.swift
@@ -1,1 +1,1 @@
-internal let GiniVisionVersion = "3.3.2"
+internal let GiniVisionVersion = "4.0.0-beta.1"

--- a/GiniVision/Classes/Networking/MultipageDocumentsService.swift
+++ b/GiniVision/Classes/Networking/MultipageDocumentsService.swift
@@ -14,6 +14,7 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
     var partialDocuments: [String: PartialDocumentInfo] = [:]
     var compositeDocument: GINIDocument?
     var analysisCancellationToken: BFCancellationTokenSource?
+    var pendingAnalysisHandler: AnalysisCompletion?
     
     init(sdk: GiniSDK) {
         self.giniSDK = sdk
@@ -21,9 +22,21 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
     
     func startAnalysis(completion: @escaping AnalysisCompletion) {
         let partialDocumentsInfoSorted = partialDocuments
+            .lazy
             .map { $0.value }
             .sorted()
             .map { $0.info }
+            .filter { $0.documentUrl != nil}
+        
+        // When a PDF is imported the analysis screen is shown right away, and therefore the analysis is triggered.
+        // There could be the case where the PDF document hadn't been analyzed when this happens, that's why a reference
+        // to the completion block ahs to be kept. Once the document is uploaded, the completion block is
+        // called (see below).
+        guard partialDocumentsInfoSorted.isNotEmpty else {
+            pendingAnalysisHandler = completion
+            return
+        }
+        
         self.fetchExtractions(for: partialDocumentsInfoSorted, completion: completion)
     }
     
@@ -73,6 +86,12 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
             switch result {
             case .success(let createdDocument):
                 self.partialDocuments[document.id]?.info.documentUrl = createdDocument.links.document
+                
+                if let handler = self.pendingAnalysisHandler {
+                    self.startAnalysis(completion: handler)
+                    self.pendingAnalysisHandler = nil
+                }
+                
                 completion?(.success(createdDocument))
             case .failure(let error):
                 completion?(.failure(error))

--- a/GiniVision/Classes/Networking/MultipageDocumentsService.swift
+++ b/GiniVision/Classes/Networking/MultipageDocumentsService.swift
@@ -28,10 +28,10 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
             .map { $0.info }
             .filter { $0.documentUrl != nil}
         
-        // When a PDF is imported the analysis screen is shown right away, and therefore the analysis is triggered.
-        // There could be the case where the PDF document hadn't been analyzed when this happens, that's why a reference
-        // to the completion block ahs to be kept. Once the document is uploaded, the completion block is
-        // called (see below).
+        // When a PDF/QrCode document is imported the analysis screen is shown right away, and therefore the analysis
+        // is triggered. There could be the case where the document hadn't been analyzed when this happens,
+        // that's why a reference to the completion block ahs to be kept. Once the document is uploaded,
+        // the completion block is called (see below).
         guard partialDocumentsInfoSorted.isNotEmpty else {
             pendingAnalysisHandler = completion
             return

--- a/GiniVision/Classes/Networking/MultipageDocumentsService.swift
+++ b/GiniVision/Classes/Networking/MultipageDocumentsService.swift
@@ -29,8 +29,8 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
             .filter { $0.documentUrl != nil}
         
         // When a PDF/QrCode document is imported the analysis screen is shown right away, and therefore the analysis
-        // is triggered. There could be the case where the document hadn't been analyzed when this happens,
-        // that's why a reference to the completion block ahs to be kept. Once the document is uploaded,
+        // is triggered. There could be the case in which the document hadn't been analyzed when this happens,
+        // that's why a reference to the completion block has to be kept. Once the document is uploaded,
         // the completion block is called (see below).
         guard partialDocumentsInfoSorted.isNotEmpty else {
             pendingAnalysisHandler = completion

--- a/GiniVision/Classes/Networking/SinglePageDocumentsService.swift
+++ b/GiniVision/Classes/Networking/SinglePageDocumentsService.swift
@@ -63,6 +63,7 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
                 
                 if let handler = self.pendingAnalysisHandler {
                     self.startAnalysis(completion: handler)
+                    self.pendingAnalysisHandler = nil
                 }
             case .failure(let error):
                 Log(message: "Partial document creation error: \(error)", event: .error)


### PR DESCRIPTION
When using open with, the documents were not being uploaded. Also there were problems with PDF and QR code document upload, since the analysis might start when the document wasn't uploaded.

### How to test
Open _Files_ app and open a file from there. Also try to analyze a QR code and check that you get results.

### Merging
Automatic
