### PR TITLE
Fixed QR code and PDF documents analysis

### DIFF
--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -37,7 +37,7 @@ final class ComponentAPICoordinator: NSObject, Coordinator {
         navBarViewController.navigationBar.barTintColor = self.giniColor
         navBarViewController.navigationBar.tintColor = .white
         navBarViewController.view.backgroundColor = .black
-
+        
         return navBarViewController
     }()
     
@@ -74,7 +74,7 @@ final class ComponentAPICoordinator: NSObject, Coordinator {
     fileprivate(set) var reviewScreen: ReviewViewController?
     fileprivate(set) lazy var documentPickerCoordinator =
         DocumentPickerCoordinator(giniConfiguration: giniConfiguration)
-
+    
     init(documentRequests: [DocumentRequest],
          configuration: GiniConfiguration,
          client: GiniClient) {
@@ -213,13 +213,13 @@ extension ComponentAPICoordinator {
         
         push(viewController: vc, removingViewControllerOfType: AnalysisViewController.self)
         analysisScreen = nil
-
+        
     }
     
     fileprivate func showNextScreenAfterPicking() {
         if let documentsType = documentRequests.type {
             switch documentsType {
-            case .image:
+            case .image:                
                 if giniConfiguration.multipageEnabled {
                     refreshMultipageReview(with: self.documentRequests)
                     showMultipageReviewScreen()
@@ -354,7 +354,7 @@ extension ComponentAPICoordinator {
             closeComponentAPI()
             return
         }
-
+        
         navigationController.popToRootViewController(animated: true)
     }
 }
@@ -409,15 +409,25 @@ extension ComponentAPICoordinator: CameraViewControllerDelegate {
         validate([document]) { result in
             switch result {
             case .success(let documentRequests):
-                self.documentRequests.append(contentsOf: documentRequests)
-                self.upload(documentRequests: documentRequests)
-                
-                if self.giniConfiguration.multipageEnabled, self.documentRequests.count > 1 {
-                    if let imageDocument = document as? GiniImageDocument {
-                        viewController.animateToControlsView(imageDocument: imageDocument)
+                switch document {
+                case let qrCodeDocument as GiniQRCodeDocument:
+                    viewController.showPopup(forQRDetected: qrCodeDocument) {
+                        self.documentRequests.removeAll()
+                        self.documentRequests.append(contentsOf: documentRequests)
+                        self.upload(documentRequests: documentRequests)
+                        self.showNextScreenAfterPicking()
                     }
-                } else {
-                    self.showNextScreenAfterPicking()
+                case let imageDocument as GiniImageDocument:
+                    self.documentRequests.append(contentsOf: documentRequests)
+                    self.upload(documentRequests: documentRequests)
+                    
+                    if self.documentRequests.count > 1 {
+                        viewController.animateToControlsView(imageDocument: imageDocument)
+                    } else {
+                        self.showNextScreenAfterPicking()
+                    }
+                    
+                default: break
                 }
             case .failure(let error):
                 if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {
@@ -480,13 +490,13 @@ extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
                         break
                     }
                 }
-
+                
                 if coordinator.currentPickerDismissesAutomatically {
                     self.cameraScreen?.showErrorDialog(for: error,
                                                        positiveAction: positiveAction)
                 } else {
                     coordinator.currentPickerViewController?.showErrorDialog(for: error,
-                                                                    positiveAction: positiveAction)
+                                                                             positiveAction: positiveAction)
                 }
             }
             
@@ -520,6 +530,7 @@ extension ComponentAPICoordinator: MultipageReviewViewControllerDelegate {
             
             if self.giniConfiguration.multipageEnabled, self.documentRequests.type == .image {
                 self.refreshMultipageReview(with: self.documentRequests)
+
             }
             
             upload(documentRequests: [documentRequests[index]])
@@ -607,7 +618,7 @@ extension ComponentAPICoordinator {
                 } catch let error {
                     documentError = error
                 }
-            
+                
                 documentRequests.append(DocumentRequest(value: document, error: documentError))
             }
             

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -409,15 +409,14 @@ extension ComponentAPICoordinator: CameraViewControllerDelegate {
         validate([document]) { result in
             switch result {
             case .success(let documentRequests):
-                switch document {
-                case let qrCodeDocument as GiniQRCodeDocument:
+                if let qrCodeDocument = document as? GiniQRCodeDocument {
                     viewController.showPopup(forQRDetected: qrCodeDocument) {
                         self.documentRequests.removeAll()
                         self.documentRequests.append(contentsOf: documentRequests)
                         self.upload(documentRequests: documentRequests)
                         self.showNextScreenAfterPicking()
                     }
-                case let imageDocument as GiniImageDocument:
+                } else if let imageDocument = document as? GiniImageDocument {
                     self.documentRequests.append(contentsOf: documentRequests)
                     self.upload(documentRequests: documentRequests)
                     
@@ -426,8 +425,6 @@ extension ComponentAPICoordinator: CameraViewControllerDelegate {
                     } else {
                         self.showNextScreenAfterPicking()
                     }
-                    
-                default: break
                 }
             case .failure(let error):
                 if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {
@@ -530,7 +527,6 @@ extension ComponentAPICoordinator: MultipageReviewViewControllerDelegate {
             
             if self.giniConfiguration.multipageEnabled, self.documentRequests.type == .image {
                 self.refreshMultipageReview(with: self.documentRequests)
-
             }
             
             upload(documentRequests: [documentRequests[index]])

--- a/Example/Example Swift/MultipageDocumentService.swift
+++ b/Example/Example Swift/MultipageDocumentService.swift
@@ -30,7 +30,7 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
         
         // When a PDF/QrCode document is imported the analysis screen is shown right away, and therefore the analysis
         // is triggered. There could be the case where the document hadn't been analyzed when this happens,
-        // that's why a reference to the completion block ahs to be kept. Once the document is uploaded,
+        // that's why a reference to the completion block has to be kept. Once the document is uploaded,
         // the completion block is called (see below).
         guard !partialDocumentsInfoSorted.isEmpty else {
             pendingAnalysisHandler = completion

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -487,7 +487,7 @@ extension CameraViewController {
      - parameter qrDocument: A validated `GiniQRCodeDocument`.
      - parameter didTapDone: Block executed when the user taps the _Done_ button to proceed with the `GiniQRCodeDocument`.
      */
-    func showPopup(forQRDetected qrDocument: GiniQRCodeDocument, didTapDone: @escaping () -> Void) {
+    public func showPopup(forQRDetected qrDocument: GiniQRCodeDocument, didTapDone: @escaping () -> Void) {
         DispatchQueue.main.async { [weak self] in
             guard let `self` = self else { return }
             

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -25,18 +25,23 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
             switch result {
             case .success(let validatedDocuments):
                 let validatedDocument = validatedDocuments[0]
-                self.addToDocuments(new: [validatedDocument])
-                self.didCaptureAndValidate(document)
                 
-                if let imageDocument = document as? GiniImageDocument {
-                    if self.documentRequests.count > 1 {
-                        viewController.animateToControlsView(imageDocument: imageDocument)
-                    } else {
-                        self.showNextScreenAfterPicking(documentRequests: [validatedDocument])
-                    }
-                } else if let qrDocument = document as? GiniQRCodeDocument {
-                    viewController.showPopup(forQRDetected: qrDocument) {
+                if let qrCodeDocument = document as? GiniQRCodeDocument {
+                    viewController.showPopup(forQRDetected: qrCodeDocument) {
+                        self.addToDocuments(new: [validatedDocument])
+                        self.didCaptureAndValidate(document)
                         self.showNextScreenAfterPicking(documentRequests: self.documentRequests)
+                    }
+                } else {
+                    self.addToDocuments(new: [validatedDocument])
+                    self.didCaptureAndValidate(document)
+                    
+                    if let imageDocument = document as? GiniImageDocument {
+                        if self.documentRequests.count > 1 {
+                            viewController.animateToControlsView(imageDocument: imageDocument)
+                        } else {
+                            self.showNextScreenAfterPicking(documentRequests: [validatedDocument])
+                        }
                     }
                 }
             case .failure(let error):

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -25,28 +25,25 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
             switch result {
             case .success(let validatedDocuments):
                 let validatedDocument = validatedDocuments[0]
-                switch document {
-                case let qrCodeDocument as GiniQRCodeDocument:
+                if let qrCodeDocument = document as? GiniQRCodeDocument {
                     viewController.showPopup(forQRDetected: qrCodeDocument) {
                         self.clearDocuments()
                         self.addToDocuments(new: [validatedDocument])
                         self.didCaptureAndValidate(document)
                         self.showNextScreenAfterPicking(documentRequests: self.documentRequests)
                     }
-                case let imageDocument as GiniImageDocument:
+                } else if let imageDocument = document as? GiniImageDocument {
                     self.addToDocuments(new: [validatedDocument])
                     self.didCaptureAndValidate(document)
-                        
+                    
                     // In case that there is more than one image already captured, an animation is shown instead of
                     // going to next screen
                     if self.documentRequests.count > 1 {
                         viewController.animateToControlsView(imageDocument: imageDocument)
-                        return
                     } else {
                         self.showNextScreenAfterPicking(documentRequests: [validatedDocument])
                     }
-                default: break
-            }
+                }
             case .failure(let error):
                 if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {
                     viewController.showErrorDialog(for: error) {

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -137,12 +137,6 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
 
 extension GiniScreenAPICoordinator {
     func addToDocuments(new documentRequests: [DocumentRequest]) {
-        // Since there could not be more than one PDF document and more than one QRCode document
-        // at the same time, the collection should be cleared up before adding the new document
-        if self.documentRequests.type == .qrcode || self.documentRequests.type == .pdf {
-            self.clearDocuments()
-        }
-        
         self.documentRequests.append(contentsOf: documentRequests)
         
         if giniConfiguration.multipageEnabled, documentRequests.type == .image {


### PR DESCRIPTION
When a user tried to analyze a PDF/QRCode document, it wasn't analyzed because the analysis wasn't triggered after the document was uploaded.
Also when scanning a QR code, this wasn't processed properly, being uploaded twice when it was validated (tap on the popup button triggered the upload again).

### How to test
Run the Example app, scan a QR code and check that you obtain results afterwards.

### Merging
Automatic

### Issue
#223
