### PR TITLE
Added analysis screen error view

### DIFF
--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -302,7 +302,9 @@ extension ComponentAPICoordinator {
                     if self.documentRequests.type != .image || !self.giniConfiguration.multipageEnabled {
                         guard let visionError = error as? GiniVisionError,
                         let firstDocumentRequest = self.documentRequests.first else { return }
-                        self.showErrorInAnalysisScreen(with: visionError.message, for: firstDocumentRequest)
+                        self.showErrorInAnalysisScreen(with: visionError.message, for: firstDocumentRequest) {
+                            self.upload(documentRequest: firstDocumentRequest)
+                        }
                     }
                 }
                 
@@ -325,7 +327,9 @@ extension ComponentAPICoordinator {
                     guard let firstDocumentRequest = self.documentRequests.first else { return }
                     let visionError = CustomAnalysisError.analysisFailed
 
-                    self.showErrorInAnalysisScreen(with: visionError.message, for: firstDocumentRequest)
+                    self.showErrorInAnalysisScreen(with: visionError.message, for: firstDocumentRequest) {
+                        self.startAnalysis()
+                    }
                 }
             }
         })
@@ -335,14 +339,14 @@ extension ComponentAPICoordinator {
         documentService?.delete(document)
     }
     
-    private func showErrorInAnalysisScreen(with message: String, for documentRequest: DocumentRequest) {
+    private func showErrorInAnalysisScreen(with message: String,
+                                           for documentRequest: DocumentRequest,
+                                           action: @escaping () -> Void) {
         if self.analysisScreen == nil {
             self.analysisScreen = AnalysisViewController(document: documentRequest.document)
         }
         
-        self.analysisScreen?.showError(with: message, action: {
-            self.upload(documentRequest: documentRequest)
-        })
+        self.analysisScreen?.showError(with: message, action: action)
     }
 }
 

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -249,7 +249,12 @@ extension ComponentAPICoordinator {
     
     fileprivate func push<T: UIViewController>(viewController: UIViewController, removing viewControllers: [T?]) {
         var navigationStack = navigationController.viewControllers
-        let viewControllersToDelete = navigationStack.filter { return viewControllers.map { $0.self }.contains($0) }
+        let viewControllersToDelete = navigationStack.filter {
+            return viewControllers
+                .lazy
+                .compactMap { $0 }
+                .contains($0)
+        }
         
         viewControllersToDelete.forEach { viewControllerToDelete in
             if let index = navigationStack.index(of: viewControllerToDelete) {

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -197,7 +197,7 @@ extension ComponentAPICoordinator {
                                                       action: #selector(closeComponentAPIFromResults))
         }
         
-        push(viewController: resultsScreen!, removingViewControllerOfType: AnalysisViewController.self)
+        push(viewController: resultsScreen!, removing: [reviewScreen, analysisScreen])
     }
     
     fileprivate func showNoResultsScreen() {
@@ -215,7 +215,7 @@ extension ComponentAPICoordinator {
             vc = genericNoResults!
         }
         
-        push(viewController: vc, removingViewControllerOfType: AnalysisViewController.self)
+        push(viewController: vc, removing: [reviewScreen, analysisScreen])
         
     }
     
@@ -247,13 +247,16 @@ extension ComponentAPICoordinator {
         closeComponentAPI()
     }
     
-    fileprivate func push<T>(viewController: UIViewController, removingViewControllerOfType: T.Type) {
+    fileprivate func push<T: UIViewController>(viewController: UIViewController, removing viewControllers: [T?]) {
         var navigationStack = navigationController.viewControllers
+        let viewControllersToDelete = navigationStack.filter { return viewControllers.map { $0.self }.contains($0) }
         
-        if let deleteViewController = (navigationStack.compactMap { $0 as? T }.first) as? UIViewController,
-            let index = navigationStack.index(of: deleteViewController) {
-            navigationStack.remove(at: index)
+        viewControllersToDelete.forEach { viewControllerToDelete in
+            if let index = navigationStack.index(of: viewControllerToDelete) {
+                navigationStack.remove(at: index)
+            }
         }
+
         navigationStack.append(viewController)
         navigationController.setViewControllers(navigationStack, animated: true)
     }

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -24,8 +24,8 @@ final class ComponentAPICoordinator: NSObject, Coordinator {
     
     fileprivate var documentService: DocumentServiceProtocol?
     fileprivate var documentRequests: [DocumentRequest]
-    // When there was an error uploading a document or analyzing it and the analysis screen is not initialized yet,
-    // both the error message and action has to be saved to show in the analysis screen.
+    // When there was an error uploading a document or analyzing it and the analysis screen
+    // had not been initialized yet, both the error message and action has to be saved to show in the analysis screen.
     fileprivate var analysisErrorAndAction: (message: String, action: () -> Void)?
     
     fileprivate let giniColor = UIColor(red: 0, green: (157/255), blue: (220/255), alpha: 1)

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -175,8 +175,6 @@ extension ComponentAPICoordinator {
             analysisScreen = AnalysisViewController(document: document)
         }
         
-        analysisScreen = AnalysisViewController(document: document)
-
         startAnalysis()
         addCloseButtonIfNeeded(onViewController: analysisScreen!)
         
@@ -300,10 +298,9 @@ extension ComponentAPICoordinator {
                     self.documentRequests[index].error = error
                     
                     if self.documentRequests.type != .image || !self.giniConfiguration.multipageEnabled {
-                        guard let visionError = error as? GiniVisionError,
-                        let firstDocumentRequest = self.documentRequests.first else { return }
-                        self.showErrorInAnalysisScreen(with: visionError.message, for: firstDocumentRequest) {
-                            self.upload(documentRequest: firstDocumentRequest)
+                        guard let visionError = error as? GiniVisionError else { return }
+                        self.showErrorInAnalysisScreen(with: visionError.message, for: documentRequest) {
+                            self.upload(documentRequest: documentRequest)
                         }
                     }
                 }

--- a/Example/Example Swift/DocumentServiceProtocol.swift
+++ b/Example/Example Swift/DocumentServiceProtocol.swift
@@ -58,6 +58,8 @@ extension DocumentServiceProtocol {
                         docType: String = "",
                         cancellationToken: BFCancellationToken? = nil,
                         completion: @escaping UploadDocumentCompletion) {
+        print("📝 Creating document...")
+
         giniSDK.sessionManager
             .getSession()
             .continueWith(block: sessionBlock(cancellationToken: cancellationToken))
@@ -72,8 +74,12 @@ extension DocumentServiceProtocol {
                           "for vision document:", document.id)
                     completion(.success(createdDocument))
                 } else if task.isCancelled {
+                    print("❌ Document creation was cancelled")
+
                     completion(.failure(AnalysisError.cancelled))
                 } else {
+                    print("❌ Document creation failed")
+
                     completion(.failure(AnalysisError.documentCreation))
                 }
                 
@@ -102,6 +108,8 @@ extension DocumentServiceProtocol {
     
     func fetchExtractions(for documents: [GINIPartialDocumentInfo],
                           completion: @escaping AnalysisCompletion) {
+        print("🔎 Starting analysis...")
+
         analysisCancellationToken = BFCancellationTokenSource()
         let fileName = "Composite-\(NSDate().timeIntervalSince1970)"
         

--- a/Example/Example Swift/MultipageDocumentService.swift
+++ b/Example/Example Swift/MultipageDocumentService.swift
@@ -55,7 +55,7 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
         if let index = partialDocuments.index(forKey: document.id) {
             if let partialDocumentId = partialDocuments[document.id]?
                 .info
-                .documentUrl {
+                .documentId {
                 deletePartialDocument(with: partialDocumentId)
             }
             partialDocuments.remove(at: index)
@@ -72,7 +72,7 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
             })
             .continueWith(block: { task in
                 if task.isCancelled || task.error != nil {
-                    print("❌ Error deleting composite document with id:", id)
+                    print("❌ Error deleting partial document with id:", id)
                 } else {
                     print("🗑 Deleted partial document with id:", id)
                 }

--- a/Example/Example Swift/MultipageDocumentService.swift
+++ b/Example/Example Swift/MultipageDocumentService.swift
@@ -27,6 +27,7 @@ final class MultipageDocumentsService: DocumentServiceProtocol {
             .map { $0.value }
             .sorted()
             .map { $0.info }
+            .filter { $0.documentUrl != nil}
         
         // When a PDF/QrCode document is imported the analysis screen is shown right away, and therefore the analysis
         // is triggered. There could be the case where the document hadn't been analyzed when this happens,

--- a/Example/Example Swift/SinglePageDocumentService.swift
+++ b/Example/Example Swift/SinglePageDocumentService.swift
@@ -45,7 +45,7 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
     }
     
     func delete(_ document: GiniVisionDocument) {
-        if let documentId = partialDocumentInfo?.documentUrl {
+        if let documentId = partialDocumentInfo?.documentId {
             deletePartialDocument(with: documentId)
         }
         cancelAnalysis()
@@ -61,7 +61,7 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
             })
             .continueWith(block: { task in
                 if task.isCancelled || task.error != nil {
-                    print("❌ Error deleting composite document with id:", id)
+                    print("❌ Error deleting partial document with id:", id)
                 } else {
                     print("🗑 Deleted partial document with id:", id)
                 }

--- a/Example/Example Swift/SinglePageDocumentService.swift
+++ b/Example/Example Swift/SinglePageDocumentService.swift
@@ -23,7 +23,7 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
     }
     
     func startAnalysis(completion: @escaping AnalysisCompletion) {
-        guard let partialDocumentInfo = partialDocumentInfo else {
+        guard let partialDocumentInfo = partialDocumentInfo, partialDocumentInfo.documentUrl != nil  else {
             pendingAnalysisHandler = completion
             return
         }
@@ -87,9 +87,13 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
                             
                             if let handler = self.pendingAnalysisHandler {
                                 self.startAnalysis(completion: handler)
+                                self.pendingAnalysisHandler = nil
                             }
+                            
+                            completion?(.success(document))
                         case .failure(let error):
-                            print("❌ Partial document creation error: ", error)
+                            
+                            completion?(.failure(error))
                         }
         }
     }

--- a/Example/Example Swift/UIViewController.swift
+++ b/Example/Example Swift/UIViewController.swift
@@ -46,6 +46,11 @@ extension UIViewController {
                                                        bundle: Bundle(for: GiniVision.self),
                                                        comment: "use photos button text in popup")
             }
+        case let visionError as CustomAnalysisError:
+            message = visionError.message
+            confirmActionTitle = NSLocalizedString("ginivision.analysis.error.actionTitle",
+                                                   bundle: Bundle(for: GiniVision.self),
+                                                   comment: "Retry analysis")
         default:
             message = DocumentValidationError.unknown.message
         }

--- a/Example/Example Swift/UIViewController.swift
+++ b/Example/Example Swift/UIViewController.swift
@@ -48,7 +48,8 @@ extension UIViewController {
             }
         case let visionError as CustomAnalysisError:
             message = visionError.message
-            confirmActionTitle = NSLocalizedString("ginivision.analysis.error.actionTitle",
+            confirmActionTitle = nil
+            cancelActionTitle = NSLocalizedString("ginivision.analysis.error.actionTitle",
                                                    bundle: Bundle(for: GiniVision.self),
                                                    comment: "Retry analysis")
         default:

--- a/Example/Tests/GINIComponentAPICoordinatorTests.swift
+++ b/Example/Tests/GINIComponentAPICoordinatorTests.swift
@@ -35,8 +35,6 @@ class GINIComponentAPICoordinatorTests: XCTestCase {
                                                                              clientEmailDomain: ""))
         componentAPICoordinator?.start()
         
-        XCTAssertNil(componentAPICoordinator?.analysisScreen,
-                     "analysis screen should be nil when no document is imported")
         XCTAssertNil(componentAPICoordinator?.reviewScreen,
                      "review screen should be nil when no document is imported")
         XCTAssertNotNil(componentAPICoordinator?.cameraScreen,
@@ -56,8 +54,6 @@ class GINIComponentAPICoordinatorTests: XCTestCase {
                                                                              clientEmailDomain: ""))
         componentAPICoordinator?.start()
         
-        XCTAssertNil(componentAPICoordinator?.analysisScreen,
-                     "analysis screen should be nil when a image is imported")
         XCTAssertNotNil(componentAPICoordinator?.reviewScreen,
                         "review screen should not be nil when a image is imported")
         XCTAssertNil(componentAPICoordinator?.cameraScreen,
@@ -85,7 +81,7 @@ class GINIComponentAPICoordinatorTests: XCTestCase {
         XCTAssertNil(componentAPICoordinator?.cameraScreen,
                      "camera screen should be nil when a pdfpdf is imported")
         
-        XCTAssertEqual(componentAPICoordinator?.analysisScreen?.navigationItem.leftBarButtonItem?.title,
+        XCTAssertEqual(componentAPICoordinator?.analysisScreen.navigationItem.leftBarButtonItem?.title,
                        "Schließen")
     }
     

--- a/Example/Tests/GINIComponentAPICoordinatorTests.swift
+++ b/Example/Tests/GINIComponentAPICoordinatorTests.swift
@@ -35,6 +35,8 @@ class GINIComponentAPICoordinatorTests: XCTestCase {
                                                                              clientEmailDomain: ""))
         componentAPICoordinator?.start()
         
+        XCTAssertNil(componentAPICoordinator?.analysisScreen,
+                     "analysis screen should be nil when no document is imported")
         XCTAssertNil(componentAPICoordinator?.reviewScreen,
                      "review screen should be nil when no document is imported")
         XCTAssertNotNil(componentAPICoordinator?.cameraScreen,
@@ -81,7 +83,7 @@ class GINIComponentAPICoordinatorTests: XCTestCase {
         XCTAssertNil(componentAPICoordinator?.cameraScreen,
                      "camera screen should be nil when a pdfpdf is imported")
         
-        XCTAssertEqual(componentAPICoordinator?.analysisScreen.navigationItem.leftBarButtonItem?.title,
+        XCTAssertEqual(componentAPICoordinator?.analysisScreen?.navigationItem.leftBarButtonItem?.title,
                        "Schließen")
     }
     

--- a/Example/Tests/GINIComponentAPICoordinatorTests.swift
+++ b/Example/Tests/GINIComponentAPICoordinatorTests.swift
@@ -56,6 +56,8 @@ class GINIComponentAPICoordinatorTests: XCTestCase {
                                                                              clientEmailDomain: ""))
         componentAPICoordinator?.start()
         
+        XCTAssertNil(componentAPICoordinator?.analysisScreen,
+                     "analysis screen should be nil when no document is imported")
         XCTAssertNotNil(componentAPICoordinator?.reviewScreen,
                         "review screen should not be nil when a image is imported")
         XCTAssertNil(componentAPICoordinator?.cameraScreen,

--- a/GiniVision/Classes/Core/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/AnalysisViewController.swift
@@ -203,18 +203,20 @@ import UIKit
         loadingIndicatorView.stopAnimating()
     }
     
+    /**
+     Shows an error when there was an error with either during the analysis or uploading a document
+     */
     public func showError(with message: String, action: @escaping () -> Void ) {
         errorView.textLabel.text = message
         errorView.userAction = NoticeAction(title: NoticeActionType.retry.title, action: action)
         errorView.show()
     }
     
+    /**
+     Hide the error view if any.
+     */
     public func hideError(animated: Bool = false) {
         errorView.hide(animated, completion: nil)
-    }
-    
-    public func updateDocument(with document: GiniVisionDocument) {
-        imageView.image = document.previewImage
     }
     
     fileprivate func addImageView() {

--- a/GiniVision/Classes/Core/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/AnalysisViewController.swift
@@ -204,7 +204,7 @@ import UIKit
     }
     
     /**
-     Shows an error when there was an error with either during the analysis or uploading a document
+     Shows an error when there was an error with either the analysis or document upload
      */
     public func showError(with message: String, action: @escaping () -> Void ) {
         errorView.textLabel.text = message

--- a/GiniVision/Classes/Core/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/AnalysisViewController.swift
@@ -93,6 +93,13 @@ import UIKit
         overlayView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
         return overlayView
     }()
+    fileprivate lazy var errorView: NoticeView = {
+        let errorView = NoticeView(text: "",
+                                   type: .error,
+                                   noticeAction: NoticeAction(title: "", action: {}))
+        errorView.translatesAutoresizingMaskIntoConstraints = false
+        return errorView
+    }()
     
     fileprivate let document: GiniVisionDocument
     fileprivate let giniConfiguration: GiniConfiguration
@@ -169,6 +176,8 @@ import UIKit
                 showCaptureSuggestions(giniConfiguration: giniConfiguration)
             }
         }
+        
+        addErrorView()
     }
     
     override public func viewDidAppear(_ animated: Bool) {
@@ -192,6 +201,16 @@ import UIKit
      */
     public func hideAnimation() {
         loadingIndicatorView.stopAnimating()
+    }
+    
+    public func showError(with message: String, action: @escaping () -> Void ) {
+        errorView.textLabel.text = message
+        errorView.userAction = NoticeAction(title: NoticeActionType.retry.title, action: action)
+        errorView.show()
+    }
+    
+    public func hideError(animated: Bool = false) {
+        errorView.hide(animated, completion: nil)
     }
     
     fileprivate func addImageView() {
@@ -254,6 +273,13 @@ import UIKit
                               attr: .centerY)
         }
     }
+    
+    fileprivate func addErrorView() {
+        view.addSubview(errorView)
+        
+        Constraints.pin(view: errorView, toSuperView: view, positions: [.left, .right, .top])
+    }
+    
     fileprivate func showPDFInformationView(withDocument document: GiniPDFDocument,
                                             giniConfiguration: GiniConfiguration) {
         let pdfView = PDFInformationView(title: document.pdfTitle ?? "PDF Dokument",

--- a/GiniVision/Classes/Core/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/AnalysisViewController.swift
@@ -213,7 +213,7 @@ import UIKit
     }
     
     /**
-     Hide the error view if any.
+     Hide the error view
      */
     public func hideError(animated: Bool = false) {
         errorView.hide(animated, completion: nil)

--- a/GiniVision/Classes/Core/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/AnalysisViewController.swift
@@ -213,6 +213,10 @@ import UIKit
         errorView.hide(animated, completion: nil)
     }
     
+    public func updateDocument(with document: GiniVisionDocument) {
+        imageView.image = document.previewImage
+    }
+    
     fileprivate func addImageView() {
         self.view.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
@@ -66,7 +66,7 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
     func displayError(withMessage message: String?, andAction action: (() -> Void)?) {
         DispatchQueue.main.async { [weak self] in
             guard let `self` = self, let message = message, let action = action else { return }
-            self.analysisViewController.showError(with: message, action: action)
+            self.analysisViewController?.showError(with: message, action: action)
         }
     }
     

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
@@ -66,7 +66,7 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
     func displayError(withMessage message: String?, andAction action: (() -> Void)?) {
         DispatchQueue.main.async { [weak self] in
             guard let `self` = self, let message = message, let action = action else { return }
-            self.analysisViewController?.showError(with: message, action: action)
+            self.analysisViewController.showError(with: message, action: action)
         }
     }
     

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
@@ -67,13 +67,18 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let `self` = self,
                 let message = message,
-                let action = action,
-                let firstDocument = self.documentRequests.first?.document else { return }
-            if self.analysisViewController == nil {
-                self.analysisViewController = self.createAnalysisScreen(withDocument: firstDocument)
-            }
+                let action = action else { return }
             
-            self.analysisViewController?.showError(with: message, action: action)
+            if let analysisViewController = self.analysisViewController {
+                analysisViewController.showError(with: message, action: { [weak self] in
+                    guard let `self` = self else { return }
+                    self.analysisErrorAndAction = nil
+                    action()
+                })
+            } else {
+                self.analysisErrorAndAction = (message, action)
+            }
+
         }
     }
     

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
@@ -65,7 +65,14 @@ extension GiniScreenAPICoordinator {
 extension GiniScreenAPICoordinator: AnalysisDelegate {
     func displayError(withMessage message: String?, andAction action: (() -> Void)?) {
         DispatchQueue.main.async { [weak self] in
-            guard let `self` = self, let message = message, let action = action else { return }
+            guard let `self` = self,
+                let message = message,
+                let action = action,
+                let firstDocument = self.documentRequests.first?.document else { return }
+            if self.analysisViewController == nil {
+                self.analysisViewController = self.createAnalysisScreen(withDocument: firstDocument)
+            }
+            
             self.analysisViewController?.showError(with: message, action: action)
         }
     }
@@ -82,5 +89,5 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
             return true
         }
         return false
-    }
+    }    
 }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Analysis.swift
@@ -64,16 +64,9 @@ extension GiniScreenAPICoordinator {
 
 extension GiniScreenAPICoordinator: AnalysisDelegate {
     func displayError(withMessage message: String?, andAction action: (() -> Void)?) {
-        DispatchQueue.main.async {
-            var noticeAction: NoticeAction?
-            if let action = action {
-                noticeAction = NoticeAction(title: NSLocalizedString("ginivision.analysis.error.actionTitle",
-                                                                     bundle: Bundle(for: GiniVision.self),
-                                                                     comment: "Action button title"),
-                                            action: action)
-            }
-            let notice = NoticeView(text: message ?? "", type: .error, noticeAction: noticeAction)
-            self.show(notice: notice)
+        DispatchQueue.main.async { [weak self] in
+            guard let `self` = self, let message = message, let action = action else { return }
+            self.analysisViewController?.showError(with: message, action: action)
         }
     }
     
@@ -89,20 +82,5 @@ extension GiniScreenAPICoordinator: AnalysisDelegate {
             return true
         }
         return false
-    }
-    
-    private func show(notice: NoticeView) {
-        let noticeView = analysisViewController?.view.subviews.compactMap { $0 as? NoticeView }.first
-        if let noticeView = noticeView {
-            noticeView.hide(completion: { [weak self] in
-                self?.show(notice: notice)
-            })
-        } else {
-            guard let analysisView = analysisViewController?.view else { return }
-
-            analysisView.addSubview(notice)
-            Constraints.pin(view: notice, toSuperView: analysisView, positions: [.top, .left, .right])
-            notice.show()
-        }
     }
 }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -288,7 +288,8 @@ extension GiniScreenAPICoordinator: UploadDelegate {
 
             if document.type != .image || !self.giniConfiguration.multipageEnabled {
                 guard let error = error as? GiniVisionError else { return }
-                self.displayError(withMessage: error.message, andAction: {
+                self.displayError(withMessage: error.message, andAction: { [weak self] in
+                    guard let `self` = self else { return }
                     self.analysisViewController?.hideError()
                     self.didCaptureAndValidate(document)
                 })

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -288,7 +288,6 @@ extension GiniScreenAPICoordinator: UploadDelegate {
                 guard let error = error as? GiniVisionError else { return }
                 self.displayError(withMessage: error.message, andAction: { [weak self] in
                     guard let `self` = self else { return }
-                    self.analysisViewController?.hideError()
                     self.didCaptureAndValidate(document)
                 })
             }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -284,7 +284,16 @@ extension GiniScreenAPICoordinator: UploadDelegate {
     func uploadDidFail(for document: GiniVisionDocument, with error: Error) {
         DispatchQueue.main.async { [weak self] in
             guard let `self` = self else { return }
-            self.update(document, withError: error, isUploaded: false)
+            
+            if document.type != .image {
+                guard let error = error as? GiniVisionError else { return }
+                self.displayError(withMessage: error.message, andAction: {
+                    self.analysisViewController?.hideError()
+                    self.didCaptureAndValidate(document)
+                })
+            } else {
+                self.update(document, withError: error, isUploaded: false)
+            }
         }
     }
 }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -284,15 +284,14 @@ extension GiniScreenAPICoordinator: UploadDelegate {
     func uploadDidFail(for document: GiniVisionDocument, with error: Error) {
         DispatchQueue.main.async { [weak self] in
             guard let `self` = self else { return }
-            
-            if document.type != .image {
+            self.update(document, withError: error, isUploaded: false)
+
+            if document.type != .image || !self.giniConfiguration.multipageEnabled {
                 guard let error = error as? GiniVisionError else { return }
                 self.displayError(withMessage: error.message, andAction: {
                     self.analysisViewController?.hideError()
                     self.didCaptureAndValidate(document)
                 })
-            } else {
-                self.update(document, withError: error, isUploaded: false)
             }
         }
     }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -155,8 +155,7 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
                     }
                 }
             case .qrcode, .pdf:
-                analysisViewController = createAnalysisScreen(withDocument: firstDocument)
-                screenAPINavigationController.pushViewController(analysisViewController!,
+                screenAPINavigationController.pushViewController(analysisViewController,
                                                                  animated: true)
             }
         }
@@ -290,7 +289,7 @@ extension GiniScreenAPICoordinator: UploadDelegate {
                 guard let error = error as? GiniVisionError else { return }
                 self.displayError(withMessage: error.message, andAction: { [weak self] in
                     guard let `self` = self else { return }
-                    self.analysisViewController?.hideError()
+                    self.analysisViewController.hideError()
                     self.didCaptureAndValidate(document)
                 })
             }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -155,8 +155,7 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
                     }
                 }
             case .qrcode, .pdf:
-                screenAPINavigationController.pushViewController(analysisViewController,
-                                                                 animated: true)
+                showAnalysisScreen()
             }
         }
     }
@@ -289,7 +288,7 @@ extension GiniScreenAPICoordinator: UploadDelegate {
                 guard let error = error as? GiniVisionError else { return }
                 self.displayError(withMessage: error.message, andAction: { [weak self] in
                     guard let `self` = self else { return }
-                    self.analysisViewController.hideError()
+                    self.analysisViewController?.hideError()
                     self.didCaptureAndValidate(document)
                 })
             }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -42,6 +42,11 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
     fileprivate(set) var documentRequests: [DocumentRequest] = []
     fileprivate let multiPageTransition = MultipageReviewTransitionAnimator()
     weak var visionDelegate: GiniVisionDelegate?
+    
+    // When there was an error uploading a document or analyzing it and the analysis screen is not initialized yet,
+    // both the error message and action has to be saved to show in the analysis screen.
+    var analysisErrorAndAction: (message: String, action: () -> Void)?
+    
     // Resources
     fileprivate(set) lazy var backButtonResource =
         PreferredButtonResource(image: "navigationReviewBack",
@@ -206,9 +211,10 @@ extension GiniScreenAPICoordinator {
             return
         }
         visionDelegate?.didReview(documents: documentRequests.map { $0.document })
-
-        if analysisViewController == nil {
-            analysisViewController = createAnalysisScreen(withDocument: firstDocument)
+        analysisViewController = createAnalysisScreen(withDocument: firstDocument)
+        
+        if let (message, action) = analysisErrorAndAction {
+            displayError(withMessage: message, andAction: action)
         }
         
         self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -26,12 +26,7 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
     }()
     
     // Screens
-    lazy var analysisViewController: AnalysisViewController = {
-        guard let document = documentRequests.first?.document else {
-            fatalError("You are trying to access the analysis screen when there are not documents")
-        }
-        return createAnalysisScreen(withDocument: document)
-    }()
+    var analysisViewController: AnalysisViewController?
     var cameraViewController: CameraViewController?
     var imageAnalysisNoResultsViewController: ImageAnalysisNoResultsViewController?
     var reviewViewController: ReviewViewController?
@@ -132,7 +127,8 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
                 return [self.cameraViewController!, self.reviewViewController!]
             }
         } else {
-            return [self.analysisViewController]
+            self.analysisViewController = createAnalysisScreen(withDocument: documentRequests[0].document)
+            return [self.analysisViewController!]
         }
     }
 }
@@ -206,10 +202,19 @@ extension GiniScreenAPICoordinator {
     }
     
     @objc func showAnalysisScreen() {
+        guard let firstDocument = documentRequests.first?.document else {
+            return
+        }
         visionDelegate?.didReview(documents: documentRequests.map { $0.document })
-        analysisViewController.updateDocument(with: documentRequests[0].document)
+
+        // Check if analysis is already created, and in that case update with the first document
+        if analysisViewController == nil {
+            analysisViewController = createAnalysisScreen(withDocument: firstDocument)
+        } else {
+            analysisViewController?.updateDocument(with: firstDocument)
+        }
         
-        self.screenAPINavigationController.pushViewController(analysisViewController, animated: true)
+        self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)
     }
     
     @objc func backToCamera() {

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -207,11 +207,8 @@ extension GiniScreenAPICoordinator {
         }
         visionDelegate?.didReview(documents: documentRequests.map { $0.document })
 
-        // Check if analysis is already created, and in that case update with the first document
         if analysisViewController == nil {
             analysisViewController = createAnalysisScreen(withDocument: firstDocument)
-        } else {
-            analysisViewController?.updateDocument(with: firstDocument)
         }
         
         self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -237,6 +237,8 @@ extension GiniScreenAPICoordinator: UINavigationControllerDelegate {
             if toVC == cameraViewController {
                 documentRequests.removeAll()
             }
+            
+            analysisViewController = nil
             visionDelegate?.didCancelAnalysis()
         }
         

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -26,7 +26,12 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
     }()
     
     // Screens
-    var analysisViewController: AnalysisViewController?
+    lazy var analysisViewController: AnalysisViewController = {
+        guard let document = documentRequests.first?.document else {
+            fatalError("You are trying to access the analysis screen when there are not documents")
+        }
+        return createAnalysisScreen(withDocument: document)
+    }()
     var cameraViewController: CameraViewController?
     var imageAnalysisNoResultsViewController: ImageAnalysisNoResultsViewController?
     var reviewViewController: ReviewViewController?
@@ -127,8 +132,7 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
                 return [self.cameraViewController!, self.reviewViewController!]
             }
         } else {
-            self.analysisViewController = self.createAnalysisScreen(withDocument: documentRequests[0].document)
-            return [self.analysisViewController!]
+            return [self.analysisViewController]
         }
     }
 }
@@ -203,14 +207,9 @@ extension GiniScreenAPICoordinator {
     
     @objc func showAnalysisScreen() {
         visionDelegate?.didReview(documents: documentRequests.map { $0.document })
+        analysisViewController.updateDocument(with: documentRequests[0].document)
         
-        if analysisViewController == nil {
-            analysisViewController = createAnalysisScreen(withDocument: documentRequests[0].document)
-        } else {
-            analysisViewController?.updateDocument(with: documentRequests[0].document)
-        }
-        
-        self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)
+        self.screenAPINavigationController.pushViewController(analysisViewController, animated: true)
     }
     
     @objc func backToCamera() {

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -204,7 +204,12 @@ extension GiniScreenAPICoordinator {
     @objc func showAnalysisScreen() {
         visionDelegate?.didReview(documents: documentRequests.map { $0.document })
         
-        self.analysisViewController = createAnalysisScreen(withDocument: documentRequests[0].document)
+        if analysisViewController == nil {
+            analysisViewController = createAnalysisScreen(withDocument: documentRequests[0].document)
+        } else {
+            analysisViewController?.updateDocument(with: documentRequests[0].document)
+        }
+        
         self.screenAPINavigationController.pushViewController(analysisViewController!, animated: true)
     }
     
@@ -228,7 +233,6 @@ extension GiniScreenAPICoordinator: UINavigationControllerDelegate {
             if toVC == cameraViewController {
                 documentRequests.removeAll()
             }
-            analysisViewController = nil
             visionDelegate?.didCancelAnalysis()
         }
         

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -43,8 +43,8 @@ final class GiniScreenAPICoordinator: NSObject, Coordinator {
     fileprivate let multiPageTransition = MultipageReviewTransitionAnimator()
     weak var visionDelegate: GiniVisionDelegate?
     
-    // When there was an error uploading a document or analyzing it and the analysis screen is not initialized yet,
-    // both the error message and action has to be saved to show in the analysis screen.
+    // When there was an error uploading a document or analyzing it and the analysis screen
+    // had not been initialized yet, both the error message and action has to be saved to show in the analysis screen.
     var analysisErrorAndAction: (message: String, action: () -> Void)?
     
     // Resources

--- a/GiniVision/Classes/Core/GiniVision.swift
+++ b/GiniVision/Classes/Core/GiniVision.swift
@@ -135,10 +135,11 @@ import UIKit
      - parameter configuration: The configuration to set.
      */
     @objc public class func setConfiguration(_ configuration: GiniConfiguration) {
+        GiniConfiguration.shared = configuration
+
         if configuration.debugModeOn {
             Log(message: "DEBUG mode is ON. Never make a release in DEBUG mode!", event: .warning)
         }
-        GiniConfiguration.shared = configuration
     }
     
     /**

--- a/GiniVision/Classes/Core/Multipage Review/MultipageReviewPagesCollectionCell.swift
+++ b/GiniVision/Classes/Core/Multipage Review/MultipageReviewPagesCollectionCell.swift
@@ -223,9 +223,7 @@ final class MultipageReviewPagesCollectionCell: UICollectionViewCell {
         let collectionInset = UIEdgeInsets(top: 16, left: 0, bottom: 16, right: 0)
         let height = collection.frame.height -
             collectionInset.top -
-            collectionInset.bottom +
-            shadowHeight +
-            shadowRadius
+            collectionInset.bottom 
         let aspectRatio: CGFloat = 11 / 20
         let width = height * aspectRatio
         

--- a/GiniVision/Classes/Core/Multipage Review/MultipageReviewPagesCollectionFooter.swift
+++ b/GiniVision/Classes/Core/Multipage Review/MultipageReviewPagesCollectionFooter.swift
@@ -62,9 +62,7 @@ final class MultipageReviewPagesCollectionFooter: UICollectionReusableView {
     
     class func size(in collectionView: UICollectionView) -> CGSize {
         let padding = self.padding(in: collectionView)
-        let height = MultipageReviewPagesCollectionFooter.contentSize(in: collectionView).height +
-            padding.top +
-            padding.bottom
+        let height = MultipageReviewPagesCollectionFooter.contentSize(in: collectionView).height
         let width = MultipageReviewPagesCollectionFooter.contentSize(in: collectionView).width +
             padding.left +
             padding.right

--- a/GiniVision/Classes/Core/Multipage Review/MultipageReviewViewController.swift
+++ b/GiniVision/Classes/Core/Multipage Review/MultipageReviewViewController.swift
@@ -536,7 +536,8 @@ extension MultipageReviewViewController: UICollectionViewDataSource {
                 .dequeueReusableCell(withReuseIdentifier: MultipageReviewMainCollectionCell.identifier,
                                      for: indexPath) as? MultipageReviewMainCollectionCell
             let documentRequest = documentRequests[indexPath.row]
-            cell?.setUp(with: documentRequest) { action in
+            cell?.setUp(with: documentRequest) { [weak self] action in
+                guard let `self` = self else { return }
                 switch action {
                 case .retry:
                     self.delegate?.multipageReview(self, didTapRetryUploadFor: documentRequest)

--- a/GiniVision/Classes/Core/Multipage Review/MultipageReviewViewController.swift
+++ b/GiniVision/Classes/Core/Multipage Review/MultipageReviewViewController.swift
@@ -478,7 +478,8 @@ extension MultipageReviewViewController {
         let documentToDelete = documentRequests[indexPath.row]
         documentRequests.remove(at: indexPath.row)
         mainCollection.deleteItems(at: [indexPath])
-        
+        delegate?.multipageReview(self, didDelete: documentToDelete)
+
         pagesCollection.performBatchUpdates({
             self.pagesCollection.deleteItems(at: [indexPath])
         }, completion: { _ in
@@ -489,8 +490,6 @@ extension MultipageReviewViewController {
                 
                 self.selectItem(at: min(indexPath.row, self.documentRequests.count - 1))
             }
-            
-            self.delegate?.multipageReview(self, didDelete: documentToDelete)
         })
     }
     
@@ -542,8 +541,8 @@ extension MultipageReviewViewController: UICollectionViewDataSource {
                 case .retry:
                     self.delegate?.multipageReview(self, didTapRetryUploadFor: documentRequest)
                 case .retake:
-                    self.delegate?.multipageReviewDidTapAddImage(self)
                     self.deleteItem(at: indexPath)
+                    self.delegate?.multipageReviewDidTapAddImage(self)
                 }
             }
             

--- a/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
+++ b/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
@@ -42,6 +42,8 @@ extension DocumentServiceProtocol {
                         docType: String = "",
                         cancellationToken: BFCancellationToken? = nil,
                         completion: @escaping UploadDocumentCompletion) {
+        Log(message: "Creating document...", event: "📝")
+
         giniSDK.sessionManager
             .getSession()
             .continueWith(block: sessionBlock(cancellationToken: cancellationToken))
@@ -56,8 +58,10 @@ extension DocumentServiceProtocol {
                         "for vision document \(document.id)", event: "📄")
                     completion(.success(createdDocument))
                 } else if task.isCancelled {
+                    Log(message: "Document creation was cancelled", event: .error)
                     completion(.failure(AnalysisError.cancelled))
                 } else {
+                    Log(message: "Document creation failed", event: .error)
                     completion(.failure(AnalysisError.documentCreation))
                 }
                 
@@ -107,6 +111,8 @@ extension DocumentServiceProtocol {
     
     func fetchExtractions(for documents: [GINIPartialDocumentInfo],
                           completion: @escaping AnalysisCompletion) {
+        Log(message: "Starting analysis...", event: "🔎")
+
         analysisCancellationToken = BFCancellationTokenSource()
         let fileName = "Composite-\(NSDate().timeIntervalSince1970)"
         

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -137,12 +137,12 @@ extension GiniScreenAPICoordinator: GiniVisionDelegate {
     }
     
     func didCapture(document: GiniVisionDocument, uploadDelegate: UploadDelegate) {        
-        documentService?.upload(document: document) { result in
+        documentService?.upload(document: document) { [weak uploadDelegate] result in
             switch result {
             case .success:
-                uploadDelegate.uploadDidComplete(for: document)
+                uploadDelegate?.uploadDidComplete(for: document)
             case .failure(let error):
-                uploadDelegate.uploadDidFail(for: document, with: error)
+                uploadDelegate?.uploadDidFail(for: document, with: error)
             }
         }
     }

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -178,7 +178,10 @@ extension GiniScreenAPICoordinator: GiniVisionDelegate {
             case .success(let extractions):
                 self.present(result: extractions)
             case .failure(let error):
-                print(error)
+                guard let error = error as? GiniVisionError else { return }
+                self.displayError(withMessage: error.message, andAction: {
+                    self.didShowAnalysis(analysisDelegate)
+                })
             }
         }
     }

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -110,24 +110,6 @@ extension GiniScreenAPICoordinator {
         }
     }
     
-    func show(error: Error) {
-        let errorMessage = "Es ist ein Fehler aufgetreten. Wiederholen"
-        
-        // Display an error with a custom message and custom action on the analysis screen
-        displayError(withMessage: errorMessage, andAction: { [weak self] in
-            guard let `self` = self else { return }
-            
-            self.documentService?.startAnalysis { result in
-                switch result {
-                case .success(let extractions):
-                    self.present(result: extractions)
-                case .failure(let error):
-                    print(error)
-                }
-            }
-        })
-    }
-    
 }
 
 extension GiniScreenAPICoordinator: GiniVisionDelegate {

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -136,22 +136,15 @@ extension GiniScreenAPICoordinator: GiniVisionDelegate {
         resultsDelegate?.giniVisionDidCancelAnalysis()        
     }
     
-    func didCapture(document: GiniVisionDocument, uploadDelegate: UploadDelegate) {
-        var uploadDocumentCompletionHandler: UploadDocumentCompletion? = nil
-        
-        if giniConfiguration.multipageEnabled {
-            uploadDocumentCompletionHandler = { result in
-                switch result {
-                case .success:
-                    uploadDelegate.uploadDidComplete(for: document)
-                case .failure(let error): 
-                    uploadDelegate.uploadDidFail(for: document, with: error)
-                }
+    func didCapture(document: GiniVisionDocument, uploadDelegate: UploadDelegate) {        
+        documentService?.upload(document: document) { result in
+            switch result {
+            case .success:
+                uploadDelegate.uploadDidComplete(for: document)
+            case .failure(let error):
+                uploadDelegate.uploadDidFail(for: document, with: error)
             }
         }
-        
-        documentService?.upload(document: document,
-                                completion: uploadDocumentCompletionHandler)
     }
     
     func didReview(documents: [GiniVisionDocument]) {

--- a/GiniVision/Classes/Networking/SinglePageDocumentsService.swift
+++ b/GiniVision/Classes/Networking/SinglePageDocumentsService.swift
@@ -22,7 +22,7 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
     }
     
     func startAnalysis(completion: @escaping AnalysisCompletion) {
-        guard let partialDocumentInfo = partialDocumentInfo else {
+        guard let partialDocumentInfo = partialDocumentInfo, partialDocumentInfo.documentUrl != nil else {
             pendingAnalysisHandler = completion
             return
         }
@@ -58,15 +58,17 @@ final class SinglePageDocumentsService: DocumentServiceProtocol {
         createDocument(from: document,
                        fileName: fileName) { result in
             switch result {
-            case .success(let document):
-                self.partialDocumentInfo?.documentUrl = document.links.document
+            case .success(let createdDocument):
+                self.partialDocumentInfo?.documentUrl = createdDocument.links.document
                 
                 if let handler = self.pendingAnalysisHandler {
                     self.startAnalysis(completion: handler)
                     self.pendingAnalysisHandler = nil
                 }
+                
+                completion?(.success(createdDocument))
             case .failure(let error):
-                Log(message: "Partial document creation error: \(error)", event: .error)
+                completion?(.failure(error))
             }
         }
     }


### PR DESCRIPTION
When there is an error in the analysis or uploading a document, it has to be shown in the analysis screen. For the uploading doesn't apply for images when multipage is enabled, since the error will be shown in the multipage screen.
Also fixed minor issue with auto-layout in page cell.

### How to test
Run the Example app, disable the internet connection, scan a qr code and see that an error is shown in the analysis screen.

### Merging
Automatic

### Issue
#243


