### PR TITLE
Added customizable opaque background view style when the tool tip is shown 

### DIFF
--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		1FA85EFA1FD6B569005C0C24 /* GINIQRCodeDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA85EF81FD6B520005C0C24 /* GINIQRCodeDocumentTests.swift */; };
 		1FAC24DA1F97A39000861F60 /* GINIHelpMenuViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAC24D91F97A39000861F60 /* GINIHelpMenuViewControllerTests.swift */; };
 		1FB0C66C1F866B9F00AFE9F9 /* GINIAnalysisViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB0C66B1F866B9F00AFE9F9 /* GINIAnalysisViewControllerTests.swift */; };
+		1FD4DBDC20D1002300A87443 /* OpaqueViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD4DBDB20D1002300A87443 /* OpaqueViewTests.swift */; };
 		1FD55CBE1F66BF9000A1F9C7 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */; };
 		1FEEADA91F793F84005BA159 /* ComponentAPICoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEEADA81F793F84005BA159 /* ComponentAPICoordinator.swift */; };
 		1FEED28D1F6ABEA40068E8AB /* testPDF-rotated90.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1FEED2891F6ABEA40068E8AB /* testPDF-rotated90.pdf */; };
@@ -119,6 +120,7 @@
 		1FA85EF81FD6B520005C0C24 /* GINIQRCodeDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GINIQRCodeDocumentTests.swift; sourceTree = "<group>"; };
 		1FAC24D91F97A39000861F60 /* GINIHelpMenuViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GINIHelpMenuViewControllerTests.swift; sourceTree = "<group>"; };
 		1FB0C66B1F866B9F00AFE9F9 /* GINIAnalysisViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GINIAnalysisViewControllerTests.swift; sourceTree = "<group>"; };
+		1FD4DBDB20D1002300A87443 /* OpaqueViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpaqueViewTests.swift; sourceTree = "<group>"; };
 		1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		1FEEADA81F793F84005BA159 /* ComponentAPICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentAPICoordinator.swift; sourceTree = "<group>"; };
 		1FEED2891F6ABEA40068E8AB /* testPDF-rotated90.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "testPDF-rotated90.pdf"; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 			children = (
 				1FD55CBD1F66BF9000A1F9C7 /* Extensions.swift */,
 				1FB0C66B1F866B9F00AFE9F9 /* GINIAnalysisViewControllerTests.swift */,
+				1FD4DBDB20D1002300A87443 /* OpaqueViewTests.swift */,
 				0A6A78A71E1412E000AEB328 /* GINICameraViewControllerTests.swift */,
 				1F9411871FB9F4AE0019DECD /* GINIComponentAPICoordinatorTests.swift */,
 				1FAC24D91F97A39000861F60 /* GINIHelpMenuViewControllerTests.swift */,
@@ -633,6 +636,7 @@
 				1FA85EFA1FD6B569005C0C24 /* GINIQRCodeDocumentTests.swift in Sources */,
 				1F8547641F56E44700B1CAC6 /* GINIVisionDocumentTests.swift in Sources */,
 				0A6A78A61E140F8500AEB328 /* GINIOnboardingViewControllerTests.swift in Sources */,
+				1FD4DBDC20D1002300A87443 /* OpaqueViewTests.swift in Sources */,
 				0A6A78A81E1412E000AEB328 /* GINICameraViewControllerTests.swift in Sources */,
 				1F62FA3C1FA2207800CEA828 /* GINISupportedFormatsViewControllerTests.swift in Sources */,
 				1F62FA3A1FA2207800CEA828 /* GINIImageNoResultsViewControllerTests.swift in Sources */,

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - Gini-iOS-SDK/Core (= 0.6.0)
   - Gini-iOS-SDK/Core (0.6.0):
     - Bolts (~> 1.1.5)
-  - GiniVision (3.3.2)
+  - GiniVision (3.3.3)
 
 DEPENDENCIES:
   - Gini-iOS-SDK
@@ -28,7 +28,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
   Gini-iOS-SDK: 75c35076dbbdeff5b7ac8c90b8cbd63274dbc209
-  GiniVision: 26987ec36786b1d817eff51994a788199ee7f303
+  GiniVision: bac50dcc1c5c640e8481035ee825f2b6f0a27c17
 
 PODFILE CHECKSUM: 06f7834b2b47d77f0913939fdb40daff97ddd35b
 

--- a/Example/Tests/GINICameraViewControllerTests.swift
+++ b/Example/Tests/GINICameraViewControllerTests.swift
@@ -35,5 +35,20 @@ class CameraViewControllerTests: XCTestCase {
         XCTAssertFalse(vc.captureButton.isEnabled, "capture button should be disaled when tooltip is shown")
         
     }
+    
+    func testOpaqueViewWhenToolTipIsShown() {
+        ToolTipView.shouldShowFileImportToolTip = true
+        GiniConfiguration.sharedConfiguration.fileImportSupportedTypes = .pdf_and_images
+        GiniConfiguration.sharedConfiguration.toolTipOpaqueBackgroundStyle = .dark
+        
+        // Disable onboarding on launch
+        GiniConfiguration.sharedConfiguration.onboardingShowAtLaunch = false
+        GiniConfiguration.sharedConfiguration.onboardingShowAtFirstLaunch = false
+        
+        vc = CameraViewController(successBlock: { _ in }, failureBlock: { _ in })
+        _ = vc.view
+        
+        XCTAssertEqual(vc.opaqueView?.backgroundColor, UIColor.black.withAlphaComponent(0.8))
+    }
 }
 

--- a/Example/Tests/GINICameraViewControllerTests.swift
+++ b/Example/Tests/GINICameraViewControllerTests.swift
@@ -39,7 +39,7 @@ class CameraViewControllerTests: XCTestCase {
     func testOpaqueViewWhenToolTipIsShown() {
         ToolTipView.shouldShowFileImportToolTip = true
         GiniConfiguration.sharedConfiguration.fileImportSupportedTypes = .pdf_and_images
-        GiniConfiguration.sharedConfiguration.toolTipOpaqueBackgroundStyle = .dark
+        GiniConfiguration.sharedConfiguration.toolTipOpaqueBackgroundStyle = .dimmed
         
         // Disable onboarding on launch
         GiniConfiguration.sharedConfiguration.onboardingShowAtLaunch = false

--- a/Example/Tests/OpaqueViewTests.swift
+++ b/Example/Tests/OpaqueViewTests.swift
@@ -20,7 +20,7 @@ final class OpaqueViewFactoryTests: XCTestCase {
     }
     
     func testDarkStyle() {
-        let opaqueView = OpaqueViewFactory.create(with: .dark)
+        let opaqueView = OpaqueViewFactory.create(with: .dimmed)
         
         XCTAssertEqual(opaqueView.backgroundColor, UIColor.black.withAlphaComponent(0.8))
     }

--- a/Example/Tests/OpaqueViewTests.swift
+++ b/Example/Tests/OpaqueViewTests.swift
@@ -1,0 +1,28 @@
+//
+//  OpaqueViewFactoryTests.swift
+//  GiniVision_Tests
+//
+//  Created by Enrique del Pozo Gómez on 6/13/18.
+//  Copyright © 2018 Gini GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import GiniVision
+
+final class OpaqueViewFactoryTests: XCTestCase {
+    
+    func testBlurStyle() {
+        let opaqueView = OpaqueViewFactory.create(with: .blurred(style: .light)) as? UIVisualEffectView
+        let blurEffect = opaqueView?.effect as? UIBlurEffect
+        
+        XCTAssertNotNil(opaqueView)
+        XCTAssertNotNil(blurEffect)
+    }
+    
+    func testDarkStyle() {
+        let opaqueView = OpaqueViewFactory.create(with: .dark)
+        
+        XCTAssertEqual(opaqueView.backgroundColor, UIColor.black.withAlphaComponent(0.8))
+    }
+    
+}

--- a/GiniVision/Classes/CameraViewController.swift
+++ b/GiniVision/Classes/CameraViewController.swift
@@ -102,7 +102,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         view.backgroundColor = .black
         return view
     }()
-    fileprivate var blurEffect: UIVisualEffectView?
+    var opaqueView: UIView?
     fileprivate var defaultImageView: UIImageView?
     fileprivate var focusIndicatorImageView: UIImageView?
     var toolTipView: ToolTipView?
@@ -265,7 +265,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.toolTipView?.arrangeViews()
-        self.blurEffect?.frame = previewView.frame
+        self.opaqueView?.frame = previewView.frame
     }
     
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -324,7 +324,7 @@ extension CameraViewController {
      */
     public func showFileImportTip() {
         self.toolTipView?.show {
-            self.blurEffect?.alpha = 1
+            self.opaqueView?.alpha = 1
             self.captureButton.isEnabled = false
         }
         ToolTipView.shouldShowFileImportToolTip = false
@@ -597,9 +597,9 @@ extension CameraViewController {
     }
     
     fileprivate func createFileImportTip(giniConfiguration: GiniConfiguration) {
-        blurEffect = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffectStyle.light))
-        blurEffect?.alpha = 0
-        self.view.addSubview(blurEffect!)
+        opaqueView = OpaqueViewFactory.create(with: giniConfiguration.toolTipOpaqueBackgroundStyle)
+        opaqueView?.alpha = 0
+        self.view.addSubview(opaqueView!)
         
         toolTipView = ToolTipView(text: NSLocalizedString("ginivision.camera.fileImportTip",
                                                           bundle: Bundle(for: GiniVision.self),
@@ -614,7 +614,7 @@ extension CameraViewController {
         
         toolTipView?.willDismiss = { [weak self] in
             guard let `self` = self else { return }
-            self.blurEffect?.removeFromSuperview()
+            self.opaqueView?.removeFromSuperview()
             self.captureButton.isEnabled = true
         }
     }

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -310,6 +310,11 @@ import UIKit
     public var fileImportToolTipCloseButtonColor = Colors.Gini.grey
     
     /**
+     Sets the background style when the tooltip is shown
+     */
+    public var toolTipOpaqueBackgroundStyle: OpaqueViewStyle = .blurred(style: .dark)
+    
+    /**
      Sets the title text in the navigation bar on the camera screen.
      
      - note: Screen API only.

--- a/GiniVision/Classes/OpaqueViewFactory.swift
+++ b/GiniVision/Classes/OpaqueViewFactory.swift
@@ -12,9 +12,9 @@ public enum OpaqueViewStyle {
     case dimmed
 }
 
-final class OpaqueViewFactory {
+struct OpaqueViewFactory {
     
-    class func create(with style: OpaqueViewStyle) -> UIView {
+    static func create(with style: OpaqueViewStyle) -> UIView {
         switch style {
         case .blurred(let blurStyle):
             return UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))

--- a/GiniVision/Classes/OpaqueViewFactory.swift
+++ b/GiniVision/Classes/OpaqueViewFactory.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public enum OpaqueViewStyle {
     case blurred(style: UIBlurEffectStyle)
-    case dark
+    case dimmed
 }
 
 final class OpaqueViewFactory: UIView {
@@ -18,7 +18,7 @@ final class OpaqueViewFactory: UIView {
         switch style {
         case .blurred(let blurStyle):
             return UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))
-        case .dark:
+        case .dimmed:
             let view = UIView()
             view.backgroundColor = UIColor.black.withAlphaComponent(0.8)
             return view

--- a/GiniVision/Classes/OpaqueViewFactory.swift
+++ b/GiniVision/Classes/OpaqueViewFactory.swift
@@ -12,7 +12,7 @@ public enum OpaqueViewStyle {
     case dimmed
 }
 
-final class OpaqueViewFactory: UIView {
+final class OpaqueViewFactory {
     
     class func create(with style: OpaqueViewStyle) -> UIView {
         switch style {

--- a/GiniVision/Classes/OpaqueViewFactory.swift
+++ b/GiniVision/Classes/OpaqueViewFactory.swift
@@ -1,0 +1,27 @@
+//
+//  OpaqueViewFactory.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 6/13/18.
+//
+
+import UIKit
+
+public enum OpaqueViewStyle {
+    case blurred(style: UIBlurEffectStyle)
+    case dark
+}
+
+final class OpaqueViewFactory: UIView {
+    
+    class func create(with style: OpaqueViewStyle) -> UIView {
+        switch style {
+        case .blurred(let blurStyle):
+            return UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))
+        case .dark:
+            let view = UIView()
+            view.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+            return view
+        }
+    }
+}


### PR DESCRIPTION
The background view color when the tool tip was shown in the camera screen might be misleading for the user. Now it is possible to customize it with a different style: 

- Blurred with light style
- Blurred with dark style
- Dimmed (only dark)

### How to test
Change the value of `GiniConfiguration.toolTipOpaqueBackgroundStyle` and run the app for the first time. Open the screen API and check that the background shown below the tool tip matches the value specified in the property.

### Merging
Automatic

### Issue
#247 
