### PR TITLE
Move QR code validation to camera

### DIFF
--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -412,10 +412,13 @@ extension ComponentAPICoordinator: UINavigationControllerDelegate {
             documentService?.sendFeedback(with: resultsScreen.result)
         }
         
-        if let cameraViewController = toVC as? CameraViewController,
-            fromVC is MultipageReviewViewController {
-            cameraViewController
-                .replaceCapturedStackImages(with: pages.compactMap { $0.document.previewImage })
+        if let cameraViewController = toVC as? CameraViewController {
+            if fromVC is MultipageReviewViewController {
+                cameraViewController
+                    .replaceCapturedStackImages(with: pages.compactMap { $0.document.previewImage })
+            } else {
+                pages.removeAll()
+            }
         }
         
         return nil
@@ -430,25 +433,15 @@ extension ComponentAPICoordinator: CameraViewControllerDelegate {
         validate([document]) { result in
             switch result {
             case .success(let validatedPages):
-                switch document {
-                case let qrCodeDocument as GiniQRCodeDocument:
-                    viewController.showPopup(forQRDetected: qrCodeDocument) {
-                        self.pages.removeAll()
-                        self.pages.append(contentsOf: validatedPages)
-                        self.upload(pages: validatedPages)
-                        self.showNextScreenAfterPicking()
-                    }
-                case let imageDocument as GiniImageDocument:
-                    self.pages.append(contentsOf: validatedPages)
-                    self.upload(pages: validatedPages)
-                    
-                    if self.pages.count > 1 {
-                        viewController.animateToControlsView(imageDocument: imageDocument)
-                    } else {
-                        self.showNextScreenAfterPicking()
-                    }
-                    
-                default: break
+                self.pages.append(contentsOf: validatedPages)
+                self.upload(pages: validatedPages)
+
+                // In case that there is more than one image already captured, an animation is shown instead of
+                // going to next screen
+                if let imageDocument = document as? GiniImageDocument, self.pages.count > 1 {
+                    viewController.animateToControlsView(imageDocument: imageDocument)
+                } else {
+                    self.showNextScreenAfterPicking()
                 }
             case .failure(let error):
                 if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -394,31 +394,26 @@ extension ComponentAPICoordinator: UINavigationControllerDelegate {
             if let document = pages.first?.document {
                 documentService?.delete(document)
             }
-            pages.removeAll()
         }
         
         if fromVC is AnalysisViewController && operation == .pop {
-            // Going directly from the analysis to the camera means that
-            // the document is not an image and should be removed
-            if toVC is CameraViewController {
-                pages.removeAll()
-            }
-            
             analysisScreen = nil
             documentService?.cancelAnalysis()
+        }
+        
+        if toVC is CameraViewController && (fromVC is ReviewViewController || fromVC is AnalysisViewController) {
+            // When going directly from the analysis or from the single page review screen to the camera the pages
+            // collection should be cleared, since the document processed in that cases is not going to be reused
+            pages.removeAll()
         }
         
         if let resultsScreen = fromVC as? ResultTableViewController {
             documentService?.sendFeedback(with: resultsScreen.result)
         }
         
-        if let cameraViewController = toVC as? CameraViewController {
-            if fromVC is MultipageReviewViewController {
-                cameraViewController
-                    .replaceCapturedStackImages(with: pages.compactMap { $0.document.previewImage })
-            } else {
-                pages.removeAll()
-            }
+        if let cameraViewController = toVC as? CameraViewController, fromVC is MultipageReviewViewController {
+            cameraViewController
+                .replaceCapturedStackImages(with: pages.compactMap { $0.document.previewImage })
         }
         
         return nil

--- a/GiniVision/Classes/Core/CameraViewController.swift
+++ b/GiniVision/Classes/Core/CameraViewController.swift
@@ -526,7 +526,7 @@ extension CameraViewController {
                     addNotAuthorizedView()
                 default:
                     if GiniConfiguration.DEBUG {
-                        cameraState = .valid;
+                        cameraState = .valid
                         #if targetEnvironment(simulator)
                             addDefaultImage()
                         #endif
@@ -538,7 +538,9 @@ extension CameraViewController {
         self.camera?.didDetectQR = {[weak self] qrDocument in
             if self?.detectedQRCodeDocument != qrDocument {
                 self?.detectedQRCodeDocument = qrDocument
-                self?.didPick(qrDocument)
+                self?.showPopup(forQRDetected: qrDocument) {
+                    self?.didPick(qrDocument)
+                }
             }
         }
     }

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator+Camera.swift
@@ -23,26 +23,17 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
         validate([document]) { result in
             loadingView.removeFromSuperview()
             switch result {
-            case .success(let validatedDocuments):
-                let validatedDocument = validatedDocuments[0]
-                if let qrCodeDocument = document as? GiniQRCodeDocument {
-                    viewController.showPopup(forQRDetected: qrCodeDocument) {
-                        self.clearDocuments()
-                        self.addToDocuments(new: [validatedDocument])
-                        self.didCaptureAndValidate(document)
-                        self.showNextScreenAfterPicking(pages: self.pages)
-                    }
-                } else if let imageDocument = document as? GiniImageDocument {
-                    self.addToDocuments(new: [validatedDocument])
-                    self.didCaptureAndValidate(document)
-                    
-                    // In case that there is more than one image already captured, an animation is shown instead of
-                    // going to next screen
-                    if self.pages.count > 1 {
-                        viewController.animateToControlsView(imageDocument: imageDocument)
-                    } else {
-                        self.showNextScreenAfterPicking(pages: [validatedDocument])
-                    }
+            case .success(let validatedPages):
+                let validatedPage = validatedPages[0]
+                self.addToDocuments(new: [validatedPage])
+                self.didCaptureAndValidate(document)
+                
+                // In case that there is more than one image already captured, an animation is shown instead of
+                // going to next screen
+                if let imageDocument = document as? GiniImageDocument, self.pages.count > 1 {
+                    viewController.animateToControlsView(imageDocument: imageDocument)
+                } else {
+                    self.showNextScreenAfterPicking(pages: [validatedPage])
                 }
             case .failure(let error):
                 if let error = error as? FilePickerError, error == .maxFilesPickedCountExceeded {

--- a/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/GiniScreenAPICoordinator.swift
@@ -248,7 +248,7 @@ extension GiniScreenAPICoordinator: UINavigationControllerDelegate {
             }
         }
         
-        if toVC == cameraViewController && (fromVC is ReviewViewController || fromVC is AnalysisViewController) {
+        if toVC is CameraViewController && (fromVC is ReviewViewController || fromVC is AnalysisViewController) {
             // When going directly from the analysis or from the single page review screen to the camera the pages
             // collection should be cleared, since the document processed in that cases is not going to be reused
             clearDocuments()


### PR DESCRIPTION
### Description
Now QR code documents are validated in the camera screen show there is no need to validate them outside of it. This implies that once the document (either image or QR code) has been capture in the camera, both are processed in the same way.

### How to test
Run the example app, scan a QR code and check that it is processed as it was before.

### Merging
Automatic

### Issues
#242 
