### PR TITLE
Added flag for drag and drop in Open with tutorial

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
     - Gini-iOS-SDK/Core (= 0.6.0)
   - Gini-iOS-SDK/Core (0.6.0):
     - Bolts (~> 1.1.5)
-  - GiniVision (3.3.3)
+  - GiniVision (3.3.4)
 
 DEPENDENCIES:
   - Gini-iOS-SDK
@@ -28,8 +28,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
   Gini-iOS-SDK: 75c35076dbbdeff5b7ac8c90b8cbd63274dbc209
-  GiniVision: bac50dcc1c5c640e8481035ee825f2b6f0a27c17
+  GiniVision: 2a07124cb1c4be8717a274732f950d51ce03bdac
 
 PODFILE CHECKSUM: 06f7834b2b47d77f0913939fdb40daff97ddd35b
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.5.3

--- a/Example/Tests/GINIOpenWithTutorialViewControllerTests.swift
+++ b/Example/Tests/GINIOpenWithTutorialViewControllerTests.swift
@@ -125,13 +125,13 @@ class GINIOpenWithTutorialViewControllerTests: XCTestCase {
     func testItemsWhenDragAndDropTipDoesNotAppear() {
         let giniConfiguration = GiniConfiguration()
         giniConfiguration.shouldShowDragAndDropTutorial = false
-        let openWithTutorialViewController = OpenWithTutorialViewController(giniConfiguration: giniConfiguration)
         
-        _ = openWithTutorialViewController.view
-        let collectionSection0ItemsCount = openWithTutorialViewController
-            .collectionView(openWithTutorialViewController.collectionView!, numberOfItemsInSection: 0)
-        openWithTutorialViewController.items
-        XCTAssertEqual(2, collectionSection0ItemsCount,
-                       "the items count in section 0 should be 2")
+        let openWithTutorialViewController = OpenWithTutorialViewController(giniConfiguration: giniConfiguration)
+        let dragAndDropStepImage = UIImage(named: "openWithTutorialStep3",
+                                         in: Bundle(for: GiniVision.self),
+                                         compatibleWith: nil)
+        
+        XCTAssertFalse(openWithTutorialViewController.items.map { $0.image }.contains(dragAndDropStepImage),
+                      "open with items should not contain drag and drop image")
     }
 }

--- a/Example/Tests/GINIOpenWithTutorialViewControllerTests.swift
+++ b/Example/Tests/GINIOpenWithTutorialViewControllerTests.swift
@@ -121,4 +121,17 @@ class GINIOpenWithTutorialViewControllerTests: XCTestCase {
         XCTAssertEqual(headerSize.height, 0, "header size should be 0 on landscape mode")
         
     }
+    
+    func testItemsWhenDragAndDropTipNotAppear() {
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.shouldShowDragAndDropTutorial = false
+        let openWithTutorialViewController = OpenWithTutorialViewController(giniConfiguration: giniConfiguration)
+        
+        _ = openWithTutorialViewController.view
+        let collectionSection0ItemsCount = openWithTutorialViewController
+            .collectionView(openWithTutorialViewController.collectionView!, numberOfItemsInSection: 0)
+        
+        XCTAssertEqual(2, collectionSection0ItemsCount,
+                       "the items count in section 0 should be 2")
+    }
 }

--- a/Example/Tests/GINIOpenWithTutorialViewControllerTests.swift
+++ b/Example/Tests/GINIOpenWithTutorialViewControllerTests.swift
@@ -122,7 +122,7 @@ class GINIOpenWithTutorialViewControllerTests: XCTestCase {
         
     }
     
-    func testItemsWhenDragAndDropTipNotAppear() {
+    func testItemsWhenDragAndDropTipDoesNotAppear() {
         let giniConfiguration = GiniConfiguration()
         giniConfiguration.shouldShowDragAndDropTutorial = false
         let openWithTutorialViewController = OpenWithTutorialViewController(giniConfiguration: giniConfiguration)
@@ -130,7 +130,7 @@ class GINIOpenWithTutorialViewControllerTests: XCTestCase {
         _ = openWithTutorialViewController.view
         let collectionSection0ItemsCount = openWithTutorialViewController
             .collectionView(openWithTutorialViewController.collectionView!, numberOfItemsInSection: 0)
-        
+        openWithTutorialViewController.items
         XCTAssertEqual(2, collectionSection0ItemsCount,
                        "the items count in section 0 should be 2")
     }

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -667,4 +667,9 @@ import UIKit
      Sets the color of the warning container background to the specified color
      */
     public var noResultsWarningContainerIconColor = Colors.Gini.rose
+    
+    /**
+     Sets if the Drag&Drop step should be shown in the open with tutorial list
+     */
+    public var shouldShowDragAndDropTutorial = true
 }

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -669,7 +669,7 @@ import UIKit
     public var noResultsWarningContainerIconColor = Colors.Gini.rose
     
     /**
-     Sets if the Drag&Drop step should be shown in the open with tutorial list
+     Sets if the Drag&Drop step should be shown in the "Open with" tutorial list
      */
     public var shouldShowDragAndDropTutorial = true
 }

--- a/GiniVision/Classes/GiniConfiguration.swift
+++ b/GiniVision/Classes/GiniConfiguration.swift
@@ -669,7 +669,7 @@ import UIKit
     public var noResultsWarningContainerIconColor = Colors.Gini.rose
     
     /**
-     Sets if the Drag&Drop step should be shown in the "Open with" tutorial list
+     Sets if the Drag&Drop step should be shown in the "Open with" tutorial
      */
     public var shouldShowDragAndDropTutorial = true
 }

--- a/GiniVision/Classes/OpenWithTutorialViewController.swift
+++ b/GiniVision/Classes/OpenWithTutorialViewController.swift
@@ -14,32 +14,41 @@ final class OpenWithTutorialViewController: UICollectionViewController {
     let openWithTutorialCollectionCellIdentifier = "openWithTutorialCollectionCellIdentifier"
     let openWithTutorialCollectionHeaderIdentifier = "openWithTutorialCollectionHeaderIdentifier"
     
+    let giniConfiguration: GiniConfiguration
     var appName: String {
-        return GiniConfiguration.sharedConfiguration.openWithAppNameForTexts
+        return giniConfiguration.openWithAppNameForTexts
     }
     
-    lazy var items: [OpenWithTutorialStep] = [
-        (NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step1.title",
-                                    comment: "first step title for open with tutorial"),
-         NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step1.subTitle",
-                                    comment: "first step subtitle for open with tutorial"),
-         UIImageNamedPreferred(named: "openWithTutorialStep1")),
-        (NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step2.title",
-                                    comment: "second step title for open with tutorial"),
-         String(format: NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step2.subTitle",
-                                                   comment: "second step subtitle for open with tutorial"),
-                self.appName,
-                self.appName),
-            UIImageNamedPreferred(named: "openWithTutorialStep2")),
-        (NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step3.title",
-                                    comment: "third step title for open with tutorial"),
-         String(format: NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step3.subTitle",
-                                                   comment: "third step subtitle for open with tutorial"),
-                self.appName,
-                self.appName,
-                self.appName),
-            UIImageNamedPreferred(named: "openWithTutorialStep3"))
-    ]
+    lazy var items: [OpenWithTutorialStep] = {
+        var items = [
+            (NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step1.title",
+                                        comment: "first step title for open with tutorial"),
+             NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step1.subTitle",
+                                        comment: "first step subtitle for open with tutorial"),
+             UIImageNamedPreferred(named: "openWithTutorialStep1")),
+            (NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step2.title",
+                                        comment: "second step title for open with tutorial"),
+             String(format: NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step2.subTitle",
+                                                       comment: "second step subtitle for open with tutorial"),
+                    self.appName,
+                    self.appName),
+             UIImageNamedPreferred(named: "openWithTutorialStep2"))
+        ]
+        
+        if self.giniConfiguration.shouldShowDragAndDropTutorial {
+            items.append((NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step3.title",
+                                                     comment: "third step title for open with tutorial"),
+                          String(format: NSLocalizedStringPreferred("ginivision.help.openWithTutorial.step3.subTitle",
+                                                                    comment: "third step subtitle for open with tutorial"),
+                                 self.appName,
+                                 self.appName,
+                                 self.appName),
+                          UIImageNamedPreferred(named: "openWithTutorialStep3")))
+        }
+        
+        return items
+    }()
+    
     
     lazy var headerTitle: String = {
         let localizedString = NSLocalizedStringPreferred("ginivision.help.openWithTutorial.collectionHeader",
@@ -51,7 +60,8 @@ final class OpenWithTutorialViewController: UICollectionViewController {
         return (self.collectionView?.collectionViewLayout as? OpenWithTutorialCollectionFlowLayout)!
     }
     
-    init() {
+    init(giniConfiguration: GiniConfiguration = .sharedConfiguration) {
+        self.giniConfiguration = giniConfiguration
         super.init(collectionViewLayout: OpenWithTutorialCollectionFlowLayout())
     }
     


### PR DESCRIPTION
### Description
Now the drag and drop step within the open with tutorial is optional.

### How to test
Change the `shouldShowDragAndDropTutorial` in the `GiniConfiguration` to false and check that the last step is not shown.

### Merging
Automatic

### Issues

