### PR TITLE
Added missing styling for pages in multipage screen

### DIFF
--- a/Documentation/source/Customization guide.md
+++ b/Documentation/source/Customization guide.md
@@ -119,6 +119,8 @@ Customizable assets can be found in [the Assets repo](https://github.com/gini/gi
 ##### 3. Page item
 - Page indicator color &#8594; `GiniConfiguration.multipagePageIndicatorColor`
 - Page background color &#8594; `GiniConfiguration.multipagePageBackgroundColor`
+- Page selected indicator color &#8594; `GiniConfiguration.multipagePageSelectedIndicatorColor`
+- Page draggable icon tint color &#8594; `GiniConfiguration.multipageDraggableIconColor`
 
 ##### 4. Bottom container
 - Background color &#8594; `GiniConfiguration.multipagePagesContainerAndToolBarColor`

--- a/Example/Tests/MultipageReviewPagesCollectionCellTests.swift
+++ b/Example/Tests/MultipageReviewPagesCollectionCellTests.swift
@@ -46,7 +46,7 @@ final class MultipageReviewPagesCollectionCellTests: XCTestCase {
                    giniConfiguration: giniConfiguration)
         
         XCTAssertEqual(cell.pageSelectedLine.backgroundColor, giniConfiguration.multipagePageSelectedIndicatorColor,
-                       "page cell background color should match the one specified in the configuration")
+                       "selected line indicator background color should match the one specified in the configuration")
     }
     
     func testPageDraggableIconColor() {
@@ -58,7 +58,7 @@ final class MultipageReviewPagesCollectionCellTests: XCTestCase {
                    giniConfiguration: giniConfiguration)
         
         XCTAssertEqual(cell.pageSelectedLine.backgroundColor, giniConfiguration.multipagePageSelectedIndicatorColor,
-                       "page cell background color should match the one specified in the configuration")
+                       "page draggable icon tint color should match the one specified in the configuration")
     }
     
 }

--- a/Example/Tests/MultipageReviewPagesCollectionCellTests.swift
+++ b/Example/Tests/MultipageReviewPagesCollectionCellTests.swift
@@ -16,7 +16,6 @@ final class MultipageReviewPagesCollectionCellTests: XCTestCase {
     func testPageIndicatorLabel() {
         let giniConfiguration = GiniConfiguration()
         giniConfiguration.multipagePageIndicatorColor = .black
-        giniConfiguration.multipagePageBackgroundColor = .red
 
         cell.setUp(with: GiniVisionTestsHelper.loadImagePage(withName: "invoice"),
                    at: 0,
@@ -28,7 +27,6 @@ final class MultipageReviewPagesCollectionCellTests: XCTestCase {
     
     func testPageBottomContainerColor() {
         let giniConfiguration = GiniConfiguration()
-        giniConfiguration.multipagePageIndicatorColor = .black
         giniConfiguration.multipagePageBackgroundColor = .red
 
         cell.setUp(with: GiniVisionTestsHelper.loadImagePage(withName: "invoice"),
@@ -36,6 +34,30 @@ final class MultipageReviewPagesCollectionCellTests: XCTestCase {
                    giniConfiguration: giniConfiguration)
         
         XCTAssertEqual(cell.bottomContainer.backgroundColor, giniConfiguration.multipagePageBackgroundColor,
+                       "page cell background color should match the one specified in the configuration")
+    }
+    
+    func testPageSelectedIndicatorColor() {
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.multipagePageSelectedIndicatorColor = .red
+        
+        cell.setUp(with: GiniVisionTestsHelper.loadImagePage(withName: "invoice"),
+                   at: 0,
+                   giniConfiguration: giniConfiguration)
+        
+        XCTAssertEqual(cell.pageSelectedLine.backgroundColor, giniConfiguration.multipagePageSelectedIndicatorColor,
+                       "page cell background color should match the one specified in the configuration")
+    }
+    
+    func testPageDraggableIconColor() {
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.multipageDraggableIconColor = .red
+        
+        cell.setUp(with: GiniVisionTestsHelper.loadImagePage(withName: "invoice"),
+                   at: 0,
+                   giniConfiguration: giniConfiguration)
+        
+        XCTAssertEqual(cell.pageSelectedLine.backgroundColor, giniConfiguration.multipagePageSelectedIndicatorColor,
                        "page cell background color should match the one specified in the configuration")
     }
     

--- a/Example/Tests/MultipageReviewPagesCollectionCellTests.swift
+++ b/Example/Tests/MultipageReviewPagesCollectionCellTests.swift
@@ -57,7 +57,7 @@ final class MultipageReviewPagesCollectionCellTests: XCTestCase {
                    at: 0,
                    giniConfiguration: giniConfiguration)
         
-        XCTAssertEqual(cell.pageSelectedLine.backgroundColor, giniConfiguration.multipagePageSelectedIndicatorColor,
+        XCTAssertEqual(cell.draggableIcon.tintColor, giniConfiguration.multipageDraggableIconColor,
                        "page draggable icon tint color should match the one specified in the configuration")
     }
     

--- a/GiniVision/Classes/Core/GiniConfiguration.swift
+++ b/GiniVision/Classes/Core/GiniConfiguration.swift
@@ -659,7 +659,7 @@ import UIKit
     @objc public var multipagePageBackgroundColor = UIColor.white
     
     /**
-     Sets the tint color of the draggable icon 
+     Sets the tint color of the draggable icon in the page collection cell
      */
     @objc public var multipageDraggableIconColor = Colors.Gini.veryLightGray
 

--- a/GiniVision/Classes/Core/GiniConfiguration.swift
+++ b/GiniVision/Classes/Core/GiniConfiguration.swift
@@ -649,9 +649,19 @@ import UIKit
     @objc public var multipagePageIndicatorColor = Colors.Gini.blue
     
     /**
+     Sets the background color of the page selected indicator
+     */
+    @objc public var multipagePageSelectedIndicatorColor = Colors.Gini.blue
+    
+    /**
      Sets the tint color of the page background
      */
     @objc public var multipagePageBackgroundColor = UIColor.white
+    
+    /**
+     Sets the tint color of the draggable icon 
+     */
+    @objc public var multipageDraggableIconColor = Colors.Gini.veryLightGray
 
     /**
      Sets the background style when the tooltip is shown in the multipage screen

--- a/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewPagesCollectionCell.swift
+++ b/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewPagesCollectionCell.swift
@@ -49,7 +49,7 @@ final class MultipageReviewPagesCollectionCell: UICollectionViewCell {
     
     lazy var draggableIcon: UIImageView = {
         let image = UIImage(named: "draggablePageIcon", in: Bundle(for: GiniVision.self), compatibleWith: nil)
-        let imageView = UIImageView(image: image)
+        let imageView = UIImageView(image: image?.withRenderingMode(.alwaysTemplate))
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
         return imageView
@@ -209,6 +209,8 @@ final class MultipageReviewPagesCollectionCell: UICollectionViewCell {
         }
         pageIndicatorLabel.text = "\(index + 1)"
         pageIndicatorLabel.textColor = giniConfiguration.multipagePageIndicatorColor
+        pageSelectedLine.backgroundColor = giniConfiguration.multipagePageSelectedIndicatorColor
+        draggableIcon.tintColor = giniConfiguration.multipageDraggableIconColor
         bottomContainer.backgroundColor = giniConfiguration.multipagePageBackgroundColor
         
         if page.isUploaded {


### PR DESCRIPTION
### Description
Both the selected line and draggable icon are now customizable in the multipage page collection items.

### How to test
Change the configuration properties in the `GiniConfiguration` and run the Example app to check that it is working.

### Merging
Automatic

### Issues

