### PR TITLE
Fixed issue with vertical ambiguity in view

### DIFF
--- a/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewPagesCollectionFooter.swift
+++ b/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewPagesCollectionFooter.swift
@@ -143,15 +143,13 @@ extension MultipageReviewPagesCollectionFooter {
         
         // addButton
         Constraints.active(item: addButton, attr: .centerX, relatedBy: .equal, to: roundMask, attr: .centerX)
-        Constraints.active(item: addButton, attr: .centerY, relatedBy: .lessThanOrEqual, to: roundMask,
-                           attr: .centerY, constant: -20, priority: 999)
-        Constraints.active(item: addButton, attr: .height, relatedBy: .lessThanOrEqual, to: nil,
-                           attr: .notAnAttribute, constant: 60)
-        Constraints.active(item: addButton, attr: .height, relatedBy: .greaterThanOrEqual, to: nil,
-                           attr: .notAnAttribute, constant: 20)
+        Constraints.active(item: addButton, attr: .centerY, relatedBy: .equal, to: roundMask,
+                           attr: .centerY, constant: -20)
+        Constraints.active(item: addButton, attr: .height, relatedBy: .equal, to: nil,
+                           attr: .notAnAttribute, constant: 60, priority: 999)
         Constraints.active(item: addButton, attr: .width, relatedBy: .equal, to: addButton, attr: .height)
         Constraints.active(item: addButton, attr: .top, relatedBy: .greaterThanOrEqual, to: roundMask,
-                           attr: .top, constant: MultipageReviewPagesCollectionFooter.padding().top, priority: 750)
+                           attr: .top, constant: MultipageReviewPagesCollectionFooter.padding().top)
         
         // addLabel
         Constraints.active(item: addLabel, attr: .top, relatedBy: .equal, to: addButton, attr: .bottom,


### PR DESCRIPTION
### Description
Fixed issue with vertical ambiguity in "Add image" cell in the MultipageReview screen, that was only affecting iOS 12.

### How to test
Run the example app in an device running iOS 12 and check that the cell is properly shown.

### Merging
Automatic

