### PR TITLE
Fix color for Open button text in ImagePickerViewController

### DIFF
--- a/GiniVision/Classes/Core/Screens/Document picker/Gallery/GalleryCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/Gallery/GalleryCoordinator.swift
@@ -62,7 +62,7 @@ final class GalleryCoordinator: NSObject, Coordinator {
         let button = UIButton(type: UIButtonType.custom)
         button.addTarget(self, action: #selector(openImages), for: .touchUpInside)
         button.frame.size = CGSize(width: 50, height: 20)
-        button.titleLabel?.textColor = .white
+        button.titleLabel?.textColor = giniConfiguration.navigationBarItemTintColor
         
         let currentFont = button.titleLabel?.font
         let fontSize = currentFont?.pointSize ?? 18


### PR DESCRIPTION
### Description
Changed open button text color in ImagePickerViewController, so now it takes the GiniConfiguration bar item color instead of being always white

### How to test
Change the `navigationBarItemTintColor` property in the `GiniConfiguration` and check that the button text color matches that value

### Merging
Automatic

