### PR TITLE
Documents metadata for networking plugin

### DIFF
--- a/Documentation/source/Integration.md
+++ b/Documentation/source/Integration.md
@@ -11,13 +11,14 @@ The Screen API provides a custom `UIViewController` object, which can be present
 The Screen API, in turn, offers two different ways of implementation:
 
 #### UI with Networking (Recommended)
-Using this method you don't need to care about handling the analysis process with the [Gini API SDK](https://github.com/gini/gini-sdk-ios), you only need to provide your API credentials and a delegate to get the analysis results. Optionally - if you want to use _Certificate pinning_ - you can provide your public key pinning configuration (see [TrustKit repo](https://github.com/datatheorem/TrustKit) for more information).
+Using this method you don't need to care about handling the analysis process with the [Gini API SDK](https://github.com/gini/gini-sdk-ios), you only need to provide your API credentials and a delegate to get the analysis results. Optionally - if you want to use _Certificate pinning_ - you can provide your public key pinning configuration (see [TrustKit repo](https://github.com/datatheorem/TrustKit) for more information), and - if you want to provide metadata for the upload process - you can specify it as follows:
 
 ```swift
 let viewController = GiniVision.viewController(withClient: client,
                                                configuration: giniConfiguration,
                                                resultsDelegate: self,
-                                               publicKeyPinningConfig: pinningConfig)
+                                               publicKeyPinningConfig: pinningConfig,
+                                               documentMetadata: documentMetadata)
 
 present(viewController, animated: true, completion:nil)
 ```

--- a/Documentation/source/Integration.md
+++ b/Documentation/source/Integration.md
@@ -11,7 +11,17 @@ The Screen API provides a custom `UIViewController` object, which can be present
 The Screen API, in turn, offers two different ways of implementation:
 
 #### UI with Networking (Recommended)
-Using this method you don't need to care about handling the analysis process with the [Gini API SDK](https://github.com/gini/gini-sdk-ios), you only need to provide your API credentials and a delegate to get the analysis results. Optionally - if you want to use _Certificate pinning_ - you can provide your public key pinning configuration (see [TrustKit repo](https://github.com/datatheorem/TrustKit) for more information), and - if you want to provide metadata for the upload process - you can specify it as follows:
+Using this method you don't need to care about handling the analysis process with the [Gini API SDK](https://github.com/gini/gini-sdk-ios), you only need to provide your API credentials and a delegate to get the analysis results.
+
+```swift
+let viewController = GiniVision.viewController(withClient: client,
+                                               configuration: giniConfiguration,
+                                               resultsDelegate: self)
+
+present(viewController, animated: true, completion:nil)
+```
+
+Additionally if you want to use _Certificate pinning_ or you want to provide metadata for the upload process you can pass both your public key pinning configuration (see [TrustKit repo](https://github.com/datatheorem/TrustKit) for more information) and the metadata information as follows:
 
 ```swift
 let viewController = GiniVision.viewController(withClient: client,
@@ -23,6 +33,7 @@ let viewController = GiniVision.viewController(withClient: client,
 present(viewController, animated: true, completion:nil)
 ```
 
+**Note** The document metadata for the upload process is intended to be used for reporting.
 
 #### Only UI
 

--- a/Example/Example ObjC/ScreenAPIViewController.m
+++ b/Example/Example ObjC/ScreenAPIViewController.m
@@ -63,8 +63,9 @@ NSString *kClientDomain = @"client_domain";
     // 2. Create the Gini Vision Library view controller, set a delegate object and pass in the configuration object
     UIViewController *vc = [GiniVision viewControllerWithClient:client
                                               importedDocuments:NULL
-                                                  configuration:giniConfiguration
-                                                resultsDelegate:self];
+                                            configuration:giniConfiguration
+                                                resultsDelegate:self
+                                               documentMetadata: nil];
     // 3. Present the Gini Vision Library Screen API modally
     [self presentViewController:vc animated:YES completion:nil];
     

--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -97,7 +97,8 @@ final class AppCoordinator: Coordinator {
     }
     
     fileprivate func showScreenAPI(with pages: [GiniVisionPage]? = nil) {
-        documentMetadata = GINIDocumentMetadata(headers: [documentMetadataAppFlowKey: "ScreenAPI"])
+        documentMetadata = GINIDocumentMetadata(branchId: documentMetadataBranchId,
+                                                additionalHeaders: [documentMetadataAppFlowKey: "ScreenAPI"])
         let screenAPICoordinator = ScreenAPICoordinator(configuration: giniConfiguration,
                                                         importedDocuments: pages?.map { $0.document },
                                                         client: client,

--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -50,6 +50,8 @@ final class AppCoordinator: Coordinator {
     
     private lazy var client: GiniClient = CredentialsManager.fetchClientFromBundle()
     private var documentMetadata: GINIDocumentMetadata?
+    private let documentMetadataBranchId = "GVLExampleIOS"
+    private let documentMetadataAppFlowKey = "AppFlow"
 
     init(window: UIWindow) {
         self.window = window
@@ -95,7 +97,7 @@ final class AppCoordinator: Coordinator {
     }
     
     fileprivate func showScreenAPI(with pages: [GiniVisionPage]? = nil) {
-        documentMetadata = GINIDocumentMetadata(branchId: "GVLExampliiiiIOS")
+        documentMetadata = GINIDocumentMetadata(headers: [documentMetadataAppFlowKey: "ScreenAPI"])
         let screenAPICoordinator = ScreenAPICoordinator(configuration: giniConfiguration,
                                                         importedDocuments: pages?.map { $0.document },
                                                         client: client,
@@ -126,7 +128,8 @@ final class AppCoordinator: Coordinator {
             fatalError("It wasn't possible to build a Gini API SDK ")
         }
         
-        documentMetadata = GINIDocumentMetadata(branchId: "GVLExampliiiiIOS")
+        documentMetadata = GINIDocumentMetadata(branchId: documentMetadataBranchId,
+                                                additionalHeaders: [documentMetadataAppFlowKey: "ComponentAPI"])
         return ComponentAPIDocumentsService(sdk: sdk, documentMetadata: documentMetadata)
     }
     

--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -49,7 +49,8 @@ final class AppCoordinator: Coordinator {
     }()
     
     private lazy var client: GiniClient = CredentialsManager.fetchClientFromBundle()
-    
+    private var documentMetadata: GINIDocumentMetadata?
+
     init(window: UIWindow) {
         self.window = window
         print("------------------------------------\n\n",
@@ -94,9 +95,11 @@ final class AppCoordinator: Coordinator {
     }
     
     fileprivate func showScreenAPI(with pages: [GiniVisionPage]? = nil) {
+        documentMetadata = GINIDocumentMetadata(branchId: "GVLExampliiiiIOS")
         let screenAPICoordinator = ScreenAPICoordinator(configuration: giniConfiguration,
                                                         importedDocuments: pages?.map { $0.document },
-                                                        client: client)
+                                                        client: client,
+                                                        documentMetadata: documentMetadata)
         screenAPICoordinator.delegate = self
         screenAPICoordinator.start()
         add(childCoordinator: screenAPICoordinator)
@@ -123,7 +126,8 @@ final class AppCoordinator: Coordinator {
             fatalError("It wasn't possible to build a Gini API SDK ")
         }
         
-        return ComponentAPIDocumentsService(sdk: sdk)
+        documentMetadata = GINIDocumentMetadata(branchId: "GVLExampliiiiIOS")
+        return ComponentAPIDocumentsService(sdk: sdk, documentMetadata: documentMetadata)
     }
     
     fileprivate func showSettings() {

--- a/Example/Example Swift/ComponentAPIDocumentServiceProtocol.swift
+++ b/Example/Example Swift/ComponentAPIDocumentServiceProtocol.swift
@@ -35,7 +35,7 @@ protocol ComponentAPIDocumentServiceProtocol: class {
     var compositeDocument: GINIDocument? { get set }
     var analysisCancellationToken: BFCancellationTokenSource? { get set }
     
-    init(sdk: GiniSDK)
+    init(sdk: GiniSDK, documentMetadata: GINIDocumentMetadata?)
     func cancelAnalysis()
     func remove(document: GiniVisionDocument)
     func resetToInitialState()

--- a/Example/Example Swift/ComponentAPIDocumentsService.swift
+++ b/Example/Example Swift/ComponentAPIDocumentsService.swift
@@ -15,9 +15,11 @@ final class ComponentAPIDocumentsService: ComponentAPIDocumentServiceProtocol {
     var partialDocuments: [String: PartialDocumentInfo] = [:]
     var compositeDocument: GINIDocument?
     var analysisCancellationToken: BFCancellationTokenSource?
+    var documentMetadata: GINIDocumentMetadata?
     
-    init(sdk: GiniSDK) {
+    init(sdk: GiniSDK, documentMetadata: GINIDocumentMetadata?) {
         self.giniSDK = sdk
+        self.documentMetadata = documentMetadata
     }
     
     func startAnalysis(completion: @escaping ComponentAPIAnalysisCompletion) {
@@ -130,6 +132,7 @@ extension ComponentAPIDocumentsService {
                 return self?.giniSDK.documentTaskManager.createPartialDocument(withFilename: fileName,
                                                                                from: document.data,
                                                                                docType: docType,
+                                                                               metadata: self?.documentMetadata,
                                                                                cancellationToken: cancellationToken)
             }).continueWith(block: { task in
                 if let createdDocument = task.result as? GINIDocument {
@@ -200,6 +203,7 @@ extension ComponentAPIDocumentsService {
             .createCompositeDocument(withPartialDocumentsInfo: documents,
                                      fileName: fileName,
                                      docType: "",
+                                     metadata: documentMetadata,
                                      cancellationToken: analysisCancellationToken?.token)
             .continueOnSuccessWith { task in
                 if let document = task.result as? GINIDocument {

--- a/Example/Example Swift/ScreenAPICoordinator.swift
+++ b/Example/Example Swift/ScreenAPICoordinator.swift
@@ -25,6 +25,7 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
     var screenAPIViewController: UINavigationController!
     
     let client: GiniClient
+    let documentMetadata: GINIDocumentMetadata?
     weak var analysisDelegate: AnalysisDelegate?
     var visionDocuments: [GiniVisionDocument]?
     var visionConfiguration: GiniConfiguration
@@ -32,10 +33,12 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
     
     init(configuration: GiniConfiguration,
          importedDocuments documents: [GiniVisionDocument]?,
-         client: GiniClient) {
+         client: GiniClient,
+         documentMetadata: GINIDocumentMetadata?) {
         self.visionConfiguration = configuration
         self.visionDocuments = documents
         self.client = client
+        self.documentMetadata = documentMetadata
         super.init()
     }
     
@@ -43,7 +46,8 @@ final class ScreenAPICoordinator: NSObject, Coordinator {
         let viewController = GiniVision.viewController(withClient: client,
                                                        importedDocuments: visionDocuments,
                                                        configuration: visionConfiguration,
-                                                       resultsDelegate: self)
+                                                       resultsDelegate: self,
+                                                       documentMetadata: documentMetadata)
         screenAPIViewController = RootNavigationController(rootViewController: viewController)
         screenAPIViewController.navigationBar.barTintColor = visionConfiguration.navigationBarTintColor
         screenAPIViewController.navigationBar.tintColor = visionConfiguration.navigationBarTitleColor

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,23 +5,23 @@ PODS:
   - Bolts/AppLinks (1.9.0):
     - Bolts/Tasks
   - Bolts/Tasks (1.9.0)
-  - Gini-iOS-SDK (1.0.0):
-    - Gini-iOS-SDK/Core (= 1.0.0)
-  - Gini-iOS-SDK/Core (1.0.0):
+  - Gini-iOS-SDK (1.1.0):
+    - Gini-iOS-SDK/Core (= 1.1.0)
+  - Gini-iOS-SDK/Core (1.1.0):
     - Bolts (~> 1.9)
-  - Gini-iOS-SDK/Pinning (1.0.0):
+  - Gini-iOS-SDK/Pinning (1.1.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.0.1):
-    - GiniVision/Core (= 4.0.1)
-  - GiniVision/Core (4.0.1)
-  - GiniVision/Networking (4.0.1):
-    - Gini-iOS-SDK (~> 1.0)
+  - GiniVision (4.0.2):
+    - GiniVision/Core (= 4.0.2)
+  - GiniVision/Core (4.0.2)
+  - GiniVision/Networking (4.0.2):
+    - Gini-iOS-SDK (~> 1.1)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.0.1)":
-    - Gini-iOS-SDK/Pinning (~> 1.0)
+  - "GiniVision/Networking+Pinning (4.0.2)":
+    - Gini-iOS-SDK/Pinning (~> 1.1)
     - GiniVision/Networking
-  - GiniVision/Tests (4.0.1)
+  - GiniVision/Tests (4.0.2)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -43,8 +43,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
-  Gini-iOS-SDK: 50ea7250382ec595f44f043816e98f7e78ba0545
-  GiniVision: c07f20a920b041e2051b92fa320b7b53034b953e
+  Gini-iOS-SDK: 6201faff254c70c20305f11f3ccda0f534d35537
+  GiniVision: c5af40cd1dcf5222ab6fe67183aae3471ca5f401
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 232227d09f64ac089d4c08e7784f6f7152b29e42

--- a/Example/Tests/DocumentServiceMock.swift
+++ b/Example/Tests/DocumentServiceMock.swift
@@ -17,8 +17,8 @@ final class DocumentServiceMock: ComponentAPIDocumentServiceProtocol {
     var compositeDocument: GINIDocument?
     var analysisCancellationToken: BFCancellationTokenSource?
     
-    init(sdk: GiniSDK) {
-        giniSDK = sdk
+    init(sdk: GiniSDK, documentMetadata: GINIDocumentMetadata?) {
+        self.giniSDK = sdk
     }
     
     func cancelAnalysis() {
@@ -57,6 +57,6 @@ final class DocumentServiceMock: ComponentAPIDocumentServiceProtocol {
 
 extension DocumentServiceMock {
     convenience init() {
-        self.init(sdk: GiniSDK())
+        self.init(sdk: GiniSDK(), documentMetadata: nil)
     }
 }

--- a/Example/Tests/ScreenAPICoordinatorTests.swift
+++ b/Example/Tests/ScreenAPICoordinatorTests.swift
@@ -20,7 +20,8 @@ final class ScreenAPICoordinatorTests: XCTestCase {
     func testInitialization() {
         screenAPICoordinator = ScreenAPICoordinator(configuration: GiniConfiguration(),
                                                     importedDocuments: nil,
-                                                    client: client)
+                                                    client: client,
+                                                    documentMetadata: nil)
         screenAPICoordinator?.start()
         
         XCTAssertNotNil(screenAPICoordinator?.rootViewController,

--- a/GiniVision.podspec
+++ b/GiniVision.podspec
@@ -28,13 +28,13 @@ The Gini Vision Library for iOS provides functionality to capture documents with
   s.subspec 'Networking' do |networking|
     networking.source_files = 'GiniVision/Classes/Networking/*.swift', 'GiniVision/Classes/Networking/Extensions/*.swift'
     networking.dependency "GiniVision/Core"
-    networking.dependency "Gini-iOS-SDK", "~> 1.0"
+    networking.dependency "Gini-iOS-SDK", "~> 1.1"
   end
 
   s.subspec 'Networking+Pinning' do |pinning|
     pinning.source_files = 'GiniVision/Classes/Networking/Pinning/*'
     pinning.dependency "GiniVision/Networking"
-    pinning.dependency "Gini-iOS-SDK/Pinning", "~> 1.0"
+    pinning.dependency "Gini-iOS-SDK/Pinning", "~> 1.1"
   end
 
   s.test_spec 'Tests' do |test_spec|

--- a/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
+++ b/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
@@ -19,7 +19,7 @@ protocol DocumentServiceProtocol: class {
     var compositeDocument: GINIDocument? { get set }
     var analysisCancellationToken: BFCancellationTokenSource? { get set }
 
-    init(sdk: GiniSDK)
+    init(sdk: GiniSDK, metadata: GINIDocumentMetadata?)
     func cancelAnalysis()
     func remove(document: GiniVisionDocument)
     func resetToInitialState()
@@ -29,4 +29,11 @@ protocol DocumentServiceProtocol: class {
     func upload(document: GiniVisionDocument,
                 completion: UploadDocumentCompletion?)
     func update(imageDocument: GiniImageDocument)
+}
+
+extension DocumentServiceProtocol {
+    
+    init(sdk: GiniSDK) {
+        self.init(sdk: sdk, metadata: nil)
+    }
 }

--- a/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
+++ b/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
@@ -30,10 +30,3 @@ protocol DocumentServiceProtocol: class {
                 completion: UploadDocumentCompletion?)
     func update(imageDocument: GiniImageDocument)
 }
-
-extension DocumentServiceProtocol {
-    
-    init(sdk: GiniSDK) {
-        self.init(sdk: sdk, metadata: nil)
-    }
-}

--- a/GiniVision/Classes/Networking/DocumentsService.swift
+++ b/GiniVision/Classes/Networking/DocumentsService.swift
@@ -14,8 +14,10 @@ final class DocumentsService: DocumentServiceProtocol {
     var partialDocuments: [String: PartialDocumentInfo] = [:]
     var compositeDocument: GINIDocument?
     var analysisCancellationToken: BFCancellationTokenSource?
+    var metadata: GINIDocumentMetadata?
     
-    init(sdk: GiniSDK) {
+    init(sdk: GiniSDK, metadata: GINIDocumentMetadata?) {
+        self.metadata = metadata
         self.giniSDK = sdk
         self.giniSDK.sessionManager.logIn()
     }
@@ -133,6 +135,7 @@ extension DocumentsService {
                 return self?.giniSDK.documentTaskManager.createPartialDocument(withFilename: fileName,
                                                                                from: document.data,
                                                                                docType: docType,
+                                                                               metadata: self?.metadata,
                                                                                cancellationToken: cancellationToken)
             }).continueWith(block: { task in
                 if let createdDocument = task.result as? GINIDocument {
@@ -203,6 +206,7 @@ extension DocumentsService {
             .createCompositeDocument(withPartialDocumentsInfo: documents,
                                      fileName: fileName,
                                      docType: "",
+                                     metadata: metadata,
                                      cancellationToken: analysisCancellationToken?.token)
             .continueOnSuccessWith { task in
                 if let document = task.result as? GINIDocument {

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -72,7 +72,8 @@ extension GiniScreenAPICoordinator {
     
     convenience init(client: GiniClient,
                      resultsDelegate: GiniVisionResultsDelegate,
-                     giniConfiguration: GiniConfiguration) {
+                     giniConfiguration: GiniConfiguration,
+                     documentMetadata: GINIDocumentMetadata?) {
         self.init(withDelegate: nil,
                   giniConfiguration: giniConfiguration)
         self.visionDelegate = self
@@ -83,7 +84,7 @@ extension GiniScreenAPICoordinator {
                                                    userEmailDomain: client.clientEmailDomain)
         
         if let sdk = builder?.build() {
-            self.documentService = DocumentsService(sdk: sdk)
+            self.documentService = DocumentsService(sdk: sdk, metadata: documentMetadata)
         }
     }
     

--- a/GiniVision/Classes/Networking/Extensions/GiniVision+GiniVisionDelegate.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniVision+GiniVisionDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Gini_iOS_SDK
 
 extension GiniVision {
     /**
@@ -26,11 +27,13 @@ extension GiniVision {
     @objc public class func viewController(withClient client: GiniClient,
                                            importedDocuments: [GiniVisionDocument]? = nil,
                                            configuration: GiniConfiguration,
-                                           resultsDelegate: GiniVisionResultsDelegate) -> UIViewController {
+                                           resultsDelegate: GiniVisionResultsDelegate,
+                                           documentMetadata: GINIDocumentMetadata? = nil) -> UIViewController {
         GiniVision.setConfiguration(configuration)
         let screenCoordinator = GiniScreenAPICoordinator(client: client,
                                                          resultsDelegate: resultsDelegate,
-                                                         giniConfiguration: configuration)
+                                                         giniConfiguration: configuration,
+                                                         documentMetadata: documentMetadata)
         return screenCoordinator.start(withDocuments: importedDocuments)
     }
     

--- a/GiniVision/Classes/Networking/Pinning/GiniScreenAPICoordinator+Pinning.swift
+++ b/GiniVision/Classes/Networking/Pinning/GiniScreenAPICoordinator+Pinning.swift
@@ -12,7 +12,8 @@ extension GiniScreenAPICoordinator {
     convenience init(client: GiniClient,
                      resultsDelegate: GiniVisionResultsDelegate,
                      giniConfiguration: GiniConfiguration,
-                     publicKeyPinningConfig: [String: Any]) {
+                     publicKeyPinningConfig: [String: Any],
+                     documentMetadata: GINIDocumentMetadata?) {
         self.init(withDelegate: nil,
                   giniConfiguration: giniConfiguration)
         self.visionDelegate = self
@@ -23,7 +24,7 @@ extension GiniScreenAPICoordinator {
                                                    userEmailDomain: client.clientEmailDomain,
                                                    publicKeyPinningConfig: publicKeyPinningConfig)
         if let sdk = builder?.build() {
-            self.documentService = DocumentsService(sdk: sdk)
+            self.documentService = DocumentsService(sdk: sdk, metadata: documentMetadata)
         }
     }
 }

--- a/GiniVision/Classes/Networking/Pinning/GiniVision+Pinning.swift
+++ b/GiniVision/Classes/Networking/Pinning/GiniVision+Pinning.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Gini_iOS_SDK
 
 extension GiniVision {
     /**
@@ -29,12 +30,14 @@ extension GiniVision {
                                            importedDocuments: [GiniVisionDocument]? = nil,
                                            configuration: GiniConfiguration,
                                            resultsDelegate: GiniVisionResultsDelegate,
-                                           publicKeyPinningConfig: [String: Any]) -> UIViewController {
+                                           publicKeyPinningConfig: [String: Any],
+                                           documentMetadata: GINIDocumentMetadata? = nil) -> UIViewController {
         GiniVision.setConfiguration(configuration)
         let screenCoordinator = GiniScreenAPICoordinator(client: client,
                                                          resultsDelegate: resultsDelegate,
                                                          giniConfiguration: configuration,
-                                                         publicKeyPinningConfig: publicKeyPinningConfig)
+                                                         publicKeyPinningConfig: publicKeyPinningConfig,
+                                                         documentMetadata: documentMetadata)
         return screenCoordinator.start(withDocuments: importedDocuments)
     }
     


### PR DESCRIPTION
### Description
Added document upload metadata support for the networking plugin. Additionally, it has been added to the Component API example as well.

### How to test
Run the example app, and check that when creating partial and composite documents, the metadata headers are added to the request (in both the Screen API and Component API)

### Merging
Manual


