### PR TITLE
Add missing document creation cancellation

### DIFF
--- a/Documentation/source/Integration.md
+++ b/Documentation/source/Integration.md
@@ -34,7 +34,11 @@ let viewController = GiniVision.viewController(withClient: client,
 present(viewController, animated: true, completion:nil)
 ```
 
-**Note** The document metadata for the upload process is intended to be used for reporting.
+
+> ⚠️  **Important**
+> - The document metadata for the upload process is intended to be used for reporting.
+> - The multipage is supported only by the `.default` api, not the `.accounting` api. The `GiniConfiguration.multipageEnabled` property must not be `true` if you use the `.accounting` api.
+
 
 #### Only UI
 

--- a/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
+++ b/GiniVision/Classes/Networking/Extensions/GiniScreenAPICoordinator+Networking.swift
@@ -171,9 +171,13 @@ extension GiniScreenAPICoordinator {
             self.startAnalysis(networkDelegate: networkDelegate)
         }, didFail: { _, error in
             let error = error as? GiniVisionError ?? AnalysisError.documentCreation
-            networkDelegate.displayError(withMessage: error.message, andAction: {
-                uploadDidFail()
-            })
+            
+            guard let analysisError = error as? AnalysisError, case analysisError = AnalysisError.cancelled else {
+                networkDelegate.displayError(withMessage: error.message, andAction: {
+                    uploadDidFail()
+                })
+                return
+            }
         })
     }
 }


### PR DESCRIPTION
### Description
The cancellation for document creation was missing in the accounting document service. Also a warning for multipage support was missing in the integration guide.

### How to test
Run the example app with .accounting API, take a picture, go to the analysis and once there cancel it.

### Merging
Automatic

### Issues

