### PR TITLE
Fixed tests issue

### DIFF
--- a/GiniVision/Tests/GiniVisionFontTests.swift
+++ b/GiniVision/Tests/GiniVisionFontTests.swift
@@ -20,32 +20,32 @@ final class GiniVisionFontTests: XCTestCase {
         super.setUp()
     }
     
-    @available(iOS 11.0, *)
     func testRegularDynamicFontGeneration() {
-        let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.regular)
-        
-        XCTAssertEqual(dynamicFont, font.with(weight: .regular, size: 14, style: .body))
+        if #available(iOS 11.0, *) {
+            let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.regular)
+            XCTAssertEqual(dynamicFont, font.with(weight: .regular, size: 14, style: .body))
+        }
     }
     
-    @available(iOS 11.0, *)
     func testBoldDynamicFontGeneration() {
-        let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.bold)
-        
-        XCTAssertEqual(dynamicFont, font.with(weight: .bold, size: 14, style: .body))
+        if #available(iOS 11.0, *) {
+            let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.bold)
+            XCTAssertEqual(dynamicFont, font.with(weight: .bold, size: 14, style: .body))
+        }
     }
     
-    @available(iOS 11.0, *)
     func testThinDynamicFontGeneration() {
-        let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.thin)
-        
-        XCTAssertEqual(dynamicFont, font.with(weight: .thin, size: 14, style: .body))
+        if #available(iOS 11.0, *) {
+            let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.thin)
+            XCTAssertEqual(dynamicFont, font.with(weight: .thin, size: 14, style: .body))
+        }
     }
     
-    @available(iOS 11.0, *)
     func testLightDynamicFontGeneration() {
-        let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.light)
-        
-        XCTAssertEqual(dynamicFont, font.with(weight: .light, size: 14, style: .body))
+        if #available(iOS 11.0, *) {
+            let dynamicFont = UIFontMetrics(forTextStyle: .body).scaledFont(for: font.light)
+            XCTAssertEqual(dynamicFont, font.with(weight: .light, size: 14, style: .body))
+        }
     }
     
 }


### PR DESCRIPTION
### Description
The `xcodebuild` command is not able to check the `@available` attribute in every test case, failing when Cocoapods tried to test against the minimun iOS version (9.3) during `pod lib lint` execution. 

### How to test
Run `pod lib lint` 

### Merging
Automatic
