### PR TITLE
Add tint color customization for Document Explorer screen

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,16 +12,16 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.2.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.2.0):
-    - GiniVision/Core (= 4.2.0)
-  - GiniVision/Core (4.2.0)
-  - GiniVision/Networking (4.2.0):
+  - GiniVision (4.3.0):
+    - GiniVision/Core (= 4.3.0)
+  - GiniVision/Core (4.3.0)
+  - GiniVision/Networking (4.3.0):
     - Gini-iOS-SDK (~> 1.2)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.2.0)":
+  - "GiniVision/Networking+Pinning (4.3.0)":
     - Gini-iOS-SDK/Pinning (~> 1.2)
     - GiniVision/Networking
-  - GiniVision/Tests (4.2.0)
+  - GiniVision/Tests (4.3.0)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -43,7 +43,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: cfec665b042acb86e1e18cef964fbaa8196635f1
-  GiniVision: bda0949f1a3ee2c46c11abc836adc7c43b9e53da
+  GiniVision: 4a570de848274172cb00c8065dad8a66796c398e
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4

--- a/GiniVision/Classes/Core/GiniConfiguration.swift
+++ b/GiniVision/Classes/Core/GiniConfiguration.swift
@@ -152,6 +152,13 @@ import UIKit
         .titleTextAttributes?[NSAttributedString.Key.font] as? UIFont ?? UIFont.systemFont(ofSize: 16, weight: .regular)
     
     /**
+     Sets the tint color of the UIDocumentPickerViewController navigation bar.
+     
+     - note: Only iOS >= 11.0
+     */
+    @objc public var documentPickerNavigationBarTintColor: UIColor?
+    
+    /**
      Sets the background color of an informal notice. Notices are small pieces of
      information appearing underneath the navigation bar.
      */

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -97,9 +97,11 @@ public final class DocumentPickerCoordinator: NSObject {
     
     let galleryCoordinator: GalleryCoordinator
     let giniConfiguration: GiniConfiguration
+    
     fileprivate lazy var navigationBarAppearance: UINavigationBar = .init()
     fileprivate lazy var searchBarAppearance: UISearchBar = .init()
     fileprivate lazy var barButtonItemAppearance: UIBarButtonItem = .init()
+    fileprivate lazy var barButtonItemAppearanceInSearchBar: UIBarButtonItem = .init()
     
     fileprivate var acceptedDocumentTypes: [String] {
         switch giniConfiguration.fileImportSupportedTypes {
@@ -182,7 +184,13 @@ public final class DocumentPickerCoordinator: NSObject {
             saveCurrentAppAppearance()
             applyDefaultAppAppearance()
             
-            UINavigationBar.appearance().tintColor = giniConfiguration.documentPickerNavigationBarTintColor
+            if let tintColor = giniConfiguration.documentPickerNavigationBarTintColor {
+                UINavigationBar.appearance().tintColor = tintColor
+                UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self])
+                    .setTitleTextAttributes([.foregroundColor: tintColor],
+                                            for: .normal)
+            }
+
         }
         
         // This is needed since the UIDocumentPickerViewController on iPad is presented over the current view controller
@@ -242,6 +250,8 @@ extension DocumentPickerCoordinator {
         update(navigationBarAppearance, with: UINavigationBar.appearance())
         update(searchBarAppearance, with: UISearchBar.appearance())
         update(barButtonItemAppearance, with: UIBarButtonItem.appearance())
+        update(barButtonItemAppearanceInSearchBar,
+               with: UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]))
     }
     
     @available(iOS 11.0, *)
@@ -249,6 +259,8 @@ extension DocumentPickerCoordinator {
         update(UINavigationBar.appearance(), with: nil)
         update(UISearchBar.appearance(), with: nil)
         update(UIBarButtonItem.appearance(), with: nil)
+        update(UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]),
+               with: nil)
     }
     
     @available(iOS 11.0, *)
@@ -256,6 +268,9 @@ extension DocumentPickerCoordinator {
         update(UINavigationBar.appearance(), with: navigationBarAppearance)
         update(UISearchBar.appearance(), with: searchBarAppearance)
         update(UIBarButtonItem.appearance(), with: barButtonItemAppearance)
+        update(UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]),
+               with: barButtonItemAppearance)
+
     }
     
     @available(iOS 11.0, *)

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -224,15 +224,15 @@ public final class DocumentPickerCoordinator: NSObject {
 
 // MARK: - Fileprivate methods
 
-extension DocumentPickerCoordinator {
-    fileprivate func createDocument(fromData data: Data) -> GiniVisionDocument? {
+fileprivate extension DocumentPickerCoordinator {
+    func createDocument(fromData data: Data) -> GiniVisionDocument? {
         let documentBuilder = GiniVisionDocumentBuilder(data: data, documentSource: .external)
         documentBuilder.importMethod = .picker
         
         return documentBuilder.build()
     }
     
-    fileprivate func data(fromUrl url: URL) -> Data? {
+    func data(fromUrl url: URL) -> Data? {
         do {
             _ = url.startAccessingSecurityScopedResource()
             let data = try Data(contentsOf: url)
@@ -246,7 +246,7 @@ extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    fileprivate func saveCurrentAppAppearance() {
+    func saveCurrentAppAppearance() {
         update(navigationBarAppearance, with: UINavigationBar.appearance())
         update(searchBarAppearance, with: UISearchBar.appearance())
         update(barButtonItemAppearance, with: UIBarButtonItem.appearance())
@@ -255,7 +255,7 @@ extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    fileprivate func applyDefaultAppAppearance() {
+    func applyDefaultAppAppearance() {
         update(UINavigationBar.appearance(), with: nil)
         update(UISearchBar.appearance(), with: nil)
         update(UIBarButtonItem.appearance(), with: nil)
@@ -264,7 +264,7 @@ extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    fileprivate func restoreAppApperance() {
+    func restoreAppApperance() {
         update(UINavigationBar.appearance(), with: navigationBarAppearance)
         update(UISearchBar.appearance(), with: searchBarAppearance)
         update(UIBarButtonItem.appearance(), with: barButtonItemAppearance)
@@ -274,7 +274,7 @@ extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    fileprivate func update(_ currentNavigationBar: UINavigationBar, with navigationBar: UINavigationBar?) {
+    func update(_ currentNavigationBar: UINavigationBar, with navigationBar: UINavigationBar?) {
         currentNavigationBar.barTintColor = navigationBar?.barTintColor
         currentNavigationBar.tintColor = navigationBar?.tintColor
         currentNavigationBar.backgroundColor = navigationBar?.backgroundColor
@@ -285,7 +285,7 @@ extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    fileprivate func update(_ currentSearchBar: UISearchBar, with searchBar: UISearchBar?) {
+    func update(_ currentSearchBar: UISearchBar, with searchBar: UISearchBar?) {
         currentSearchBar.backgroundColor = searchBar?.backgroundColor
         currentSearchBar.barTintColor = searchBar?.barTintColor
         currentSearchBar.tintColor = searchBar?.tintColor
@@ -294,7 +294,7 @@ extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    fileprivate func update(_ currentBarButtonItem: UIBarButtonItem, with barButtonItem: UIBarButtonItem?) {
+    func update(_ currentBarButtonItem: UIBarButtonItem, with barButtonItem: UIBarButtonItem?) {
         currentBarButtonItem.setTitleTextAttributes(barButtonItem?.titleTextAttributes(for: .normal),
                                                     for: .normal)
         currentBarButtonItem.setTitleTextAttributes(barButtonItem?.titleTextAttributes(for: .highlighted),

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -178,11 +178,11 @@ public final class DocumentPickerCoordinator: NSObject {
         if #available(iOS 11.0, *) {
             documentPicker.allowsMultipleSelection = giniConfiguration.multipageEnabled
             
-            // Starting on iOS 11.0, the UIDocumentPickerViewController navigation bar can't almost be customized,
-            // being only possible to customize the tint color. To avoid issues with custom UIAppearance styles,
-            // this is reset to default, saving the current state for further restoring when dismissing.
-            saveCurrentAppAppearance()
-            applyDefaultAppAppearance()
+            // Starting with iOS 11.0, the UIDocumentPickerViewController navigation bar almost can't be customized,
+            // only being possible to customize the tint color. To avoid issues with custom UIAppearance styles,
+            // this is reset to default, saving the current state in order to restore it during dismissal.
+            saveCurrentNavBarAppearance()
+            applyDefaultNavBarAppearance()
             
             if let tintColor = giniConfiguration.documentPickerNavigationBarTintColor {
                 UINavigationBar.appearance().tintColor = tintColor
@@ -246,7 +246,7 @@ fileprivate extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    func saveCurrentAppAppearance() {
+    func saveCurrentNavBarAppearance() {
         update(navigationBarAppearance, with: UINavigationBar.appearance())
         update(searchBarAppearance, with: UISearchBar.appearance())
         update(barButtonItemAppearance, with: UIBarButtonItem.appearance())
@@ -255,7 +255,7 @@ fileprivate extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    func applyDefaultAppAppearance() {
+    func applyDefaultNavBarAppearance() {
         update(UINavigationBar.appearance(), with: nil)
         update(UISearchBar.appearance(), with: nil)
         update(UIBarButtonItem.appearance(), with: nil)
@@ -264,7 +264,7 @@ fileprivate extension DocumentPickerCoordinator {
     }
     
     @available(iOS 11.0, *)
-    func restoreAppApperance() {
+    func restoreSavedNavBarAppearance() {
         update(UINavigationBar.appearance(), with: navigationBarAppearance)
         update(UISearchBar.appearance(), with: searchBarAppearance)
         update(UIBarButtonItem.appearance(), with: barButtonItemAppearance)
@@ -326,7 +326,7 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
             .compactMap(self.createDocument)
         
         if #available(iOS 11.0, *) {
-            restoreAppApperance()
+            restoreSavedNavBarAppearance()
         }
         
         delegate?.documentPicker(self, didPick: documents)
@@ -338,7 +338,7 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
     
     public func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
         if #available(iOS 11.0, *) {
-            restoreAppApperance()
+            restoreSavedNavBarAppearance()
         }
         
         controller.dismiss(animated: false, completion: nil)


### PR DESCRIPTION
### Description
If using a custom UIAppearance in the host app, there were some issues that could affect the document explorer screen in the GVL for iOS >= 11.0. To fix this, a new property in the `GiniConfiguration` was added, allowing the tint color customization.

### How to test
Customize the UIAppearance for the UINavigationBar, UISearchBar and UIBarButtonItem, and launch the document explorer in the GVL to check that there is no issues.

### Merging
Automatic

