### PR TITLE
Switch to @objcMembers attribute in Component classes.

### DIFF
--- a/GiniVision/Classes/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Analysis/AnalysisViewController.swift
@@ -39,7 +39,7 @@ import UIKit
  
  - note: Component API only.
  */
-@objc public final class AnalysisViewController: UIViewController {
+@objcMembers public final class AnalysisViewController: UIViewController {
     
     var didShowAnalysis: (() -> Void)?
     fileprivate let document: GiniVisionDocument

--- a/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -94,7 +94,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
  */
 //swiftlint:disable file_length
 
-@objc public final class CameraViewController: UIViewController {
+@objcMembers public final class CameraViewController: UIViewController {
     
     /**
      The object that acts as the delegate of the camera view controller.

--- a/GiniVision/Classes/Core/Screens/Onboarding/OnboardingPage.swift
+++ b/GiniVision/Classes/Core/Screens/Onboarding/OnboardingPage.swift
@@ -15,7 +15,7 @@ import UIKit
  - note: The text length should not exceed 50 characters, depending on the font used,
          and should preferably stretch out over three lines.
  */
-@objc public final class OnboardingPage: UIView {
+@objcMembers public final class OnboardingPage: UIView {
     
     fileprivate var contentView = UIView()
     fileprivate var imageView = UIImageView()

--- a/GiniVision/Classes/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -33,7 +33,7 @@ import UIKit
 
  - note: Component API only.
  */
-@objc public final class OnboardingViewController: UIViewController {
+@objcMembers public final class OnboardingViewController: UIViewController {
     
     weak var scrollViewDelegate: UIScrollViewDelegate?
     

--- a/GiniVision/Classes/Core/Screens/Review/ReviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Review/ReviewViewController.swift
@@ -57,7 +57,7 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> Void
  
  - note: Component API only.
  */
-@objc public final class ReviewViewController: UIViewController {
+@objcMembers public final class ReviewViewController: UIViewController {
     
     /**
      The object that acts as the delegate of the review view controller.


### PR DESCRIPTION
### Description
Some methods weren't exposed in Obj-C with the `@objc` attribute.

### How to test
Try to instantiate these files in the Objective C Example

### Merging
Automatic

### Issues
#308 
