### PR TITLE
Fixes implicit dependency issue with Bolts

### DIFF
--- a/Example/Example Swift/ComponentAPIDocumentServiceProtocol.swift
+++ b/Example/Example Swift/ComponentAPIDocumentServiceProtocol.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Gini_iOS_SDK
 import GiniVision
+import Bolts
 
 public typealias Extraction = GINIExtraction
 

--- a/Example/Example Swift/ComponentAPIDocumentsService.swift
+++ b/Example/Example Swift/ComponentAPIDocumentsService.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Gini_iOS_SDK
 import GiniVision
+import Bolts
 
 final class ComponentAPIDocumentsService: ComponentAPIDocumentServiceProtocol {
     

--- a/Example/GiniVision.xcodeproj/project.pbxproj
+++ b/Example/GiniVision.xcodeproj/project.pbxproj
@@ -577,7 +577,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Example Swift/Pods-Example Swift-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Example Swift/Pods-Example Swift-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Bolts/Bolts.framework",
 				"${BUILT_PRODUCTS_DIR}/Gini-iOS-SDK/Gini_iOS_SDK.framework",
 				"${BUILT_PRODUCTS_DIR}/GiniVision/GiniVision.framework",
@@ -592,7 +592,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example Swift/Pods-Example Swift-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example Swift/Pods-Example Swift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1FE5C1321FD582370086AA08 /* Swiftlint */ = {
@@ -633,7 +633,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Example ObjC/Pods-Example ObjC-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Example ObjC/Pods-Example ObjC-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Bolts/Bolts.framework",
 				"${BUILT_PRODUCTS_DIR}/Gini-iOS-SDK/Gini_iOS_SDK.framework",
 				"${BUILT_PRODUCTS_DIR}/GiniVision/GiniVision.framework",
@@ -648,7 +648,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example ObjC/Pods-Example ObjC-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example ObjC/Pods-Example ObjC-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		74CB0615257AB7AEF338996D /* [CP] Check Pods Manifest.lock */ = {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,16 +12,17 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.2.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.3.0):
-    - GiniVision/Core (= 4.3.0)
-  - GiniVision/Core (4.3.0)
-  - GiniVision/Networking (4.3.0):
+  - GiniVision (4.3.2):
+    - GiniVision/Core (= 4.3.2)
+  - GiniVision/Core (4.3.2)
+  - GiniVision/Networking (4.3.2):
+    - Bolts (~> 1.9)
     - Gini-iOS-SDK (~> 1.2)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.3.0)":
+  - "GiniVision/Networking+Pinning (4.3.2)":
     - Gini-iOS-SDK/Pinning (~> 1.2)
     - GiniVision/Networking
-  - GiniVision/Tests (4.3.0)
+  - GiniVision/Tests (4.3.2)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -43,9 +44,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: cfec665b042acb86e1e18cef964fbaa8196635f1
-  GiniVision: 4a570de848274172cb00c8065dad8a66796c398e
+  GiniVision: 597e3d071dd43d067fd05a9ccffdabf8eced923d
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.0

--- a/Example/Tests/DocumentServiceMock.swift
+++ b/Example/Tests/DocumentServiceMock.swift
@@ -11,7 +11,6 @@ import Foundation
 @testable import GiniVision
 @testable import Example_Swift
 
-
 final class DocumentServiceMock: ComponentAPIDocumentServiceProtocol {
 
     var giniSDK: GiniSDK

--- a/Example/Tests/DocumentServiceMock.swift
+++ b/Example/Tests/DocumentServiceMock.swift
@@ -11,6 +11,7 @@ import Foundation
 @testable import GiniVision
 @testable import Example_Swift
 
+
 final class DocumentServiceMock: ComponentAPIDocumentServiceProtocol {
 
     var giniSDK: GiniSDK

--- a/GiniVision.podspec
+++ b/GiniVision.podspec
@@ -29,6 +29,7 @@ The Gini Vision Library for iOS provides functionality to capture documents with
     networking.source_files = 'GiniVision/Classes/Networking/*.swift', 'GiniVision/Classes/Networking/Extensions/*.swift'
     networking.dependency "GiniVision/Core"
     networking.dependency "Gini-iOS-SDK", "~> 1.2"
+    networking.dependency "Bolts", "~> 1.9"
   end
 
   s.subspec 'Networking+Pinning' do |pinning|

--- a/GiniVision/Classes/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Analysis/AnalysisViewController.swift
@@ -286,7 +286,9 @@ import UIKit
                                          subtitle: giniConfiguration
                                             .analysisPDFNumberOfPages(pagesCount: document.numberPages),
                                          textColor: giniConfiguration.analysisPDFInformationTextColor,
-                                         textFont: giniConfiguration.customFont.with(weight: .regular, size: 16, style: .body),
+                                         textFont: giniConfiguration.customFont.with(weight: .regular,
+                                                                                     size: 16,
+                                                                                     style: .body),
                                          backgroundColor: giniConfiguration.analysisPDFInformationBackgroundColor,
                                          superView: self.view,
                                          viewBelow: self.imageView)

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -60,6 +60,7 @@ public protocol DocumentPickerCoordinatorDelegate: class {
  - note: Component API only.
  */
 
+//swiftlint:disable file_length
 public final class DocumentPickerCoordinator: NSObject {
     
     /**

--- a/GiniVision/Classes/Core/Screens/Help/Open with tutorial/OpenWithTutorialViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Help/Open with tutorial/OpenWithTutorialViewController.swift
@@ -124,9 +124,10 @@ final class OpenWithTutorialViewController: UICollectionViewController {
             .dequeueReusableSupplementaryView(ofKind: kind,
                                               withReuseIdentifier: openWithTutorialCollectionHeaderIdentifier,
                                               for: indexPath) as? OpenWithTutorialCollectionHeader)!
-        header.headerTitle.font = giniConfiguration.customFont.with(weight: .regular,
-                                                                    size: OpenWithTutorialCollectionHeader.maxHeaderFontSize,
-                                                                    style: .body)
+        header.headerTitle.font = giniConfiguration
+            .customFont.with(weight: .regular,
+                             size: OpenWithTutorialCollectionHeader.maxHeaderFontSize,
+                             style: .body)
         header.headerTitle.text = headerTitle
         return header
     }

--- a/GiniVision/Classes/Networking/AccountingDocumentService.swift
+++ b/GiniVision/Classes/Networking/AccountingDocumentService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Gini_iOS_SDK
+import Bolts
 
 final class AccountingDocumentService: DocumentServiceProtocol {
     var giniSDK: GiniSDK

--- a/GiniVision/Classes/Networking/DocumentService.swift
+++ b/GiniVision/Classes/Networking/DocumentService.swift
@@ -9,7 +9,6 @@ import UIKit
 import Gini_iOS_SDK
 import Bolts
 
-
 final class DocumentService: DocumentServiceProtocol {
     
     var giniSDK: GiniSDK

--- a/GiniVision/Classes/Networking/DocumentService.swift
+++ b/GiniVision/Classes/Networking/DocumentService.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import Gini_iOS_SDK
+import Bolts
+
 
 final class DocumentService: DocumentServiceProtocol {
     

--- a/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
+++ b/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import Gini_iOS_SDK
+import Bolts
+
 
 public typealias Extraction = GINIExtraction
 

--- a/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
+++ b/GiniVision/Classes/Networking/DocumentServiceProtocol.swift
@@ -9,7 +9,6 @@ import Foundation
 import Gini_iOS_SDK
 import Bolts
 
-
 public typealias Extraction = GINIExtraction
 
 typealias UploadDocumentCompletion = (Result<GINIDocument>) -> Void


### PR DESCRIPTION
### Description
There was an issue with framework linking when using the networking module in latest versions of Cocoapods. To solve it, an explicit declaration of Bolts has been added in the _GiniVision_ podspec.

Kudos to @couchdeveloper for spotting this issue 💯.

### How to test
Run `Pod install` in the Example app, build the project and see that there aren't issues.

### Merging
Automatic

### Issues

