### PR TITLE
Extract camera preview to a different view controller

### DIFF
--- a/CameraMock.swift
+++ b/CameraMock.swift
@@ -1,0 +1,59 @@
+//
+//  CameraMock.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 2/11/19.
+//
+
+import Foundation
+import AVFoundation
+@testable import GiniVision
+
+final class CameraMock: CameraProtocol {
+    
+    enum CameraAuthState {
+        case authorized
+        case unauthorized
+    }
+    
+    var session: AVCaptureSession = .init()
+    var videoDeviceInput: AVCaptureDeviceInput?
+    var didDetectQR: ((GiniQRCodeDocument) -> Void)?
+    let state: CameraAuthState
+    
+    init(state: CameraAuthState) {
+        self.state = state
+    }
+    
+    func captureStillImage(completion: @escaping (Data?, CameraError?) -> Void) {
+        
+    }
+    
+    func focus(withMode mode: AVCaptureDevice.FocusMode,
+               exposeWithMode exposureMode: AVCaptureDevice.ExposureMode,
+               atDevicePoint point: CGPoint,
+               monitorSubjectAreaChange: Bool) {
+        
+    }
+    
+    func setup(completion: ((CameraError?) -> Void)) {
+        switch state {
+        case .authorized:
+            completion(nil)
+        case .unauthorized:
+            completion(.notAuthorizedToUseDevice)
+        }
+    }
+    
+    func setupQRScanningOutput() {
+        
+    }
+    
+    func start() {
+        
+    }
+    
+    func stop() {
+        
+    }
+}

--- a/GiniVision/Classes/Core/GiniConfiguration.swift
+++ b/GiniVision/Classes/Core/GiniConfiguration.swift
@@ -31,13 +31,6 @@ import UIKit
     static var shared = GiniConfiguration()
     
     /**
-     Shorthand check if debug mode is turned on.
-     */
-    static var DEBUG: Bool {
-        return shared.debugModeOn
-    }
-    
-    /**
      Supported document types by Gini Vision library.
     */
     

--- a/GiniVision/Classes/Core/Screens/Camera/Camera.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/Camera.swift
@@ -10,7 +10,23 @@ import UIKit
 import AVFoundation
 import Photos
 
-final class Camera: NSObject {
+protocol CameraProtocol: class {
+    var session: AVCaptureSession { get }
+    var videoDeviceInput: AVCaptureDeviceInput? { get }
+    var didDetectQR: ((GiniQRCodeDocument) -> Void)? { get set }
+    
+    func captureStillImage(completion: @escaping (Data?, CameraError?) -> Void)
+    func focus(withMode mode: AVCaptureDevice.FocusMode,
+               exposeWithMode exposureMode: AVCaptureDevice.ExposureMode,
+               atDevicePoint point: CGPoint,
+               monitorSubjectAreaChange: Bool)
+    func setup(completion: ((CameraError?) -> Void))
+    func setupQRScanningOutput()
+    func start()
+    func stop()
+}
+
+final class Camera: NSObject, CameraProtocol {
     
     // Session management
     var session: AVCaptureSession = AVCaptureSession()

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewView.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewView.swift
@@ -18,7 +18,7 @@ final class CameraPreviewView: UIView {
     /// 0.9 = 90% of the view
     let guideLineSize: CGFloat = 0.9
     var guideColor = UIColor.white
-    
+    var ratio: CGFloat = 21.0 / 31.0 // A4 by default
     var guidesLayer: CAShapeLayer?
     var frameLayer: CAShapeLayer?
     
@@ -37,6 +37,10 @@ final class CameraPreviewView: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
+        positionViews()
+    }
+    
+    func positionViews() {
         positionGuides()
         positionFrame()
     }
@@ -98,23 +102,22 @@ extension CameraPreviewView {
     }
     
     fileprivate func biggestA4SizeRect() -> CGRect {
-        let a4Ratio: CGFloat = 21.0 / 31.0
         let wholeFrame = bounds
         let maxWidth = wholeFrame.width * guideLineSize
         let maxHeight = wholeFrame.height * guideLineSize
 
         if (maxHeight > maxWidth || UIApplication.shared.statusBarOrientation.isPortrait) &&
-            maxWidth > maxHeight * a4Ratio {
-            return CGRect(x: 0, y: 0, width: maxHeight * a4Ratio, height: maxHeight)
+            maxWidth > maxHeight * ratio {
+            return CGRect(x: 0, y: 0, width: maxHeight * ratio, height: maxHeight)
         } else {
             let height: CGFloat
-            if maxWidth > maxHeight * a4Ratio {
+            if maxWidth > maxHeight * ratio {
                 // This only happens when the app is on landscape mode and
                 // it fills all the window (no SplitMode on iPads).
                 // In this case the a4 would be landscape (31.0 / 21.0)
-                height = maxWidth * a4Ratio
+                height = maxWidth * ratio
             } else {
-                height = maxWidth / a4Ratio
+                height = maxWidth / ratio
             }
             return CGRect(x: 0, y: 0, width: maxWidth, height: height)
         }

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -163,7 +163,7 @@ final class CameraPreviewViewController: UIViewController {
         camera.captureStillImage(completion: { data, error in
             if let data = data,
                 let image = UIImage(data: data),
-                let imageData = image.jpegData(compressionQuality: 0.9) {
+                let imageData = image.jpegData(compressionQuality: 1.0) {
                 completion(imageData, error)
             } else {
                 completion(data, error)

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -1,0 +1,368 @@
+//
+//  CameraPreviewViewController.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 8/10/18.
+//
+
+import UIKit
+import AVFoundation
+
+protocol CameraPreviewViewControllerDelegate: class {
+    func cameraPreview(viewController: CameraPreviewViewController,
+                       didDetect qrCodeDocument: GiniQRCodeDocument)
+}
+
+final class CameraPreviewViewController: UIViewController {
+    
+    weak var delegate: CameraPreviewViewControllerDelegate?
+    
+    var documentDetector: DocumentDetectorProtocol?
+    fileprivate let giniConfiguration: GiniConfiguration
+    fileprivate typealias FocusIndicator = UIImageView
+    fileprivate var camera: Camera?
+    fileprivate var cameraState = CameraState.notValid
+    fileprivate var documentDetectedInfo: DetectedDocumentInfo?
+    fileprivate var defaultImageView: UIImageView?
+    fileprivate var focusIndicatorImageView: UIImageView?
+    fileprivate let interfaceOrientationsMapping: [UIInterfaceOrientation: AVCaptureVideoOrientation] = [
+        .portrait: .portrait,
+        .landscapeRight: .landscapeRight,
+        .landscapeLeft: .landscapeLeft,
+        .portraitUpsideDown: .portraitUpsideDown
+    ]
+    
+    fileprivate var cameraFocusSmall: UIImage? {
+        return UIImageNamedPreferred(named: "cameraFocusSmall")
+    }
+    
+    fileprivate var cameraFocusLarge: UIImage? {
+        return UIImageNamedPreferred(named: "cameraFocusLarge")
+    }
+    
+    fileprivate var defaultImage: UIImage? {
+        return UIImageNamedPreferred(named: "cameraDefaultDocumentImage")
+    }
+    
+    fileprivate enum CameraState {
+        case valid, notValid
+    }
+
+    lazy var previewView: CameraPreviewView = {
+        let previewView = CameraPreviewView()
+        previewView.translatesAutoresizingMaskIntoConstraints = false
+        (previewView.layer as? AVCaptureVideoPreviewLayer)?.videoGravity = .resize
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(focusAndExposeTap))
+        previewView.addGestureRecognizer(tapGesture)
+        return previewView
+    }()
+    
+    init(giniConfiguration: GiniConfiguration = .shared) {
+        self.giniConfiguration = giniConfiguration
+        super.init(nibName: nil, bundle: nil)
+        
+        setupCamera(giniConfiguration: giniConfiguration)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    override func loadView() {
+        super.loadView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        if let validCamera = camera {
+            cameraState = .valid
+            previewView.session = validCamera.session
+            NotificationCenter.default.addObserver(self,
+                                                   selector: #selector(subjectAreaDidChange),
+                                                   name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange,
+                                                   object: camera?.videoDeviceInput?.device)
+        }
+        previewView.drawGuides(withColor: giniConfiguration.cameraPreviewCornerGuidesColor)
+        
+        view.insertSubview(previewView, at: 0)
+        Constraints.pin(view: previewView, toSuperView: view)
+
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        updatePreviewViewOrientation() // Video orientation should be updated once the view has been loaded
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        camera?.start()
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        camera?.stop()
+    }
+    
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            guard let `self` = self else {
+                return
+            }
+            
+            self.updatePreviewViewOrientation()
+        })
+    }
+    
+    fileprivate func updatePreviewViewOrientation() {
+        let orientation: AVCaptureVideoOrientation
+        if UIDevice.current.isIpad {
+            orientation =  interfaceOrientationsMapping[UIApplication.shared.statusBarOrientation] ?? .portrait
+        } else {
+            orientation = .portrait
+        }
+        
+        let previewLayer = (self.previewView.layer as? AVCaptureVideoPreviewLayer)
+        previewLayer?.connection?.videoOrientation = orientation
+    }
+    
+    fileprivate func setupCamera(giniConfiguration: GiniConfiguration) {
+        camera = Camera(giniConfiguration: giniConfiguration) { error in
+            if let error = error {
+                switch error {
+                case .notAuthorizedToUseDevice:
+                    addNotAuthorizedView()
+                default:
+                    if GiniConfiguration.DEBUG {
+                        cameraState = .valid
+                        #if targetEnvironment(simulator)
+                        addDefaultImage()
+                        #endif
+                    }
+                }
+            }
+        }
+        
+        if giniConfiguration.qrCodeScanningEnabled {
+            camera?.setupQRScanningOutput()
+            camera?.didDetectQR = { [weak self] qrDocument in
+                guard let `self` = self else { return }
+                self.delegate?.cameraPreview(viewController: self, didDetect: qrDocument)
+            }
+        }
+        
+        if #available(iOS 11.0, *) {
+            documentDetector = DocumentDetector()
+            documentDetector?.delegate = self
+            
+            camera?.setupVideoOutput()
+            camera?.didCaptureImageBuffer = documentDetector?.detectDocument
+        }
+        
+    }
+    
+    func captureImage(completion: @escaping (Data?, CameraError?) -> Void) {
+        guard let camera = camera else {
+            Log(message: "No camera initialized", event: .warning)
+            return
+        }
+        
+        if GiniConfiguration.DEBUG {
+            // Retrieves the image from default image view to make sure the image
+            // was set and therefore the correct states were checked before.
+            #if targetEnvironment(simulator)
+            if let image = self.defaultImageView?.image,
+                let imageData = image.jpegData(compressionQuality: 0.2) {
+                completion(imageData, nil)
+            }
+            #endif
+        }
+        
+        camera.captureStillImage(completion: { data, error in
+            if let polyRect = self.documentDetectedInfo?.polyRect,
+                let data = data,
+                let image = UIImage(data: data)?.withFixedOrientation(),
+                let rotatedAndCropped = image.orientedAndCropped(polyRect: polyRect),
+                let croppedData = rotatedAndCropped.jpegData(compressionQuality: 0.9) {
+                completion(croppedData, error)
+            } else {
+                completion(data, error)
+            }
+        })
+    }
+    
+    func showCameraOverlay() {
+        guard cameraState == .valid else { return }
+        previewView.guidesLayer?.isHidden = false
+        previewView.frameLayer?.isHidden = false
+    }
+    
+    func hideCameraOverlay() {
+        previewView.guidesLayer?.isHidden = true
+        previewView.frameLayer?.isHidden = true
+    }
+    
+}
+
+// MARK: - Default and not authorized views
+
+extension CameraPreviewViewController {
+    fileprivate func addNotAuthorizedView() {
+        
+        // Add not authorized view
+        let view = CameraNotAuthorizedView()
+        super.view.addSubview(view)
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        Constraints.active(item: view, attr: .width, relatedBy: .equal, to: super.view, attr: .width)
+        Constraints.active(item: view, attr: .height, relatedBy: .equal, to: super.view, attr: .height)
+        Constraints.active(item: view, attr: .centerX, relatedBy: .equal, to: super.view, attr: .centerX)
+        Constraints.active(item: view, attr: .centerY, relatedBy: .equal, to: super.view, attr: .centerY)
+        
+        // Hide camera UI
+        hideCameraOverlay()
+    }
+    
+    /// Adds a default image to the canvas when no camera is available (DEBUG mode only)
+    fileprivate func addDefaultImage() {
+        defaultImageView = UIImageView(image: defaultImage)
+        guard let defaultImageView = defaultImageView else { return }
+        
+        defaultImageView.contentMode = .scaleAspectFit
+        previewView.addSubview(defaultImageView)
+        
+        defaultImageView.translatesAutoresizingMaskIntoConstraints = false
+        Constraints.active(item: defaultImageView, attr: .width, relatedBy: .equal, to: previewView, attr: .width)
+        Constraints.active(item: defaultImageView, attr: .height, relatedBy: .equal, to: previewView, attr: .height)
+        Constraints.active(item: defaultImageView, attr: .centerX, relatedBy: .equal, to: previewView, attr: .centerX)
+        Constraints.active(item: defaultImageView, attr: .centerY, relatedBy: .equal, to: previewView, attr: .centerY)
+    }
+}
+
+// MARK: - Focus handling
+
+extension CameraPreviewViewController {
+    
+    @objc fileprivate func focusAndExposeTap(_ sender: UITapGestureRecognizer) {
+        guard let previewLayer = previewView.layer as? AVCaptureVideoPreviewLayer else { return }
+        let devicePoint = previewLayer.captureDevicePointConverted(fromLayerPoint: sender.location(in: sender.view))
+        camera?.focus(withMode: .autoFocus,
+                      exposeWithMode: .autoExpose,
+                      atDevicePoint: devicePoint,
+                      monitorSubjectAreaChange: true)
+        let imageView =
+            createFocusIndicator(withImage: cameraFocusSmall,
+                                 atPoint: previewLayer.layerPointConverted(fromCaptureDevicePoint: devicePoint))
+        showFocusIndicator(imageView)
+    }
+    
+    fileprivate func createFocusIndicator(withImage image: UIImage?, atPoint point: CGPoint) -> FocusIndicator? {
+        guard let image = image else { return nil }
+        let imageView = UIImageView(image: image)
+        imageView.center = point
+        return imageView
+    }
+    
+    fileprivate func showFocusIndicator(_ imageView: FocusIndicator?) {
+        guard cameraState == .valid else { return }
+        guard let imageView = imageView else { return }
+        for subView in self.previewView.subviews {
+            if let focusIndicator = subView as? FocusIndicator {
+                focusIndicator.removeFromSuperview()
+            }
+        }
+        self.previewView.addSubview(imageView)
+        UIView.animate(withDuration: 1.5,
+                       animations: {
+                        imageView.alpha = 0.0
+        },
+                       completion: { _ in
+                        imageView.removeFromSuperview()
+        })
+    }
+    
+    @objc fileprivate func subjectAreaDidChange(_ notification: Notification) {
+        guard let previewLayer = previewView.layer as? AVCaptureVideoPreviewLayer else { return }
+        let devicePoint = CGPoint(x: 0.5, y: 0.5)
+        
+        camera?.focus(withMode: .continuousAutoFocus,
+                      exposeWithMode: .continuousAutoExposure,
+                      atDevicePoint: devicePoint,
+                      monitorSubjectAreaChange: false)
+        
+        let imageView =
+            createFocusIndicator(withImage: cameraFocusLarge,
+                                 atPoint: previewLayer.layerPointConverted(fromCaptureDevicePoint: devicePoint))
+        showFocusIndicator(imageView)
+    }
+    
+}
+
+@available(iOS 11.0, *)
+extension CameraPreviewViewController: DocumentDetectorDelegate {
+    func documentDetector(_ documentDetector: DocumentDetector, didDetect documentsInfo: [DetectedDocumentInfo]) {
+        self.previewView.subviews.forEach { if $0 is RectangleView { $0.removeFromSuperview() } }
+        self.documentDetectedInfo = nil
+        
+        if let documentInfo = documentsInfo.first {
+            self.drawRectangle(polyRect: documentInfo.polyRect)
+            self.documentDetectedInfo = documentInfo
+        }
+    }
+    
+    private func drawRectangle(polyRect: PolyRect) {
+        let xCoord = polyRect.minX * previewView.frame.size.width
+        let yCoord = polyRect.minY * previewView.frame.size.height
+        let width = polyRect.width * previewView.frame.size.width + 4
+        let height = polyRect.height * previewView.frame.size.height + 4
+
+        let rectangleView = RectangleView(polyRect: polyRect, refRect: previewView.frame)
+
+        rectangleView.frame = CGRect(x: xCoord.rounded(),
+                                     y: yCoord.rounded(),
+                                     width: width.rounded(),
+                                     height: height.rounded())
+
+        let newRatio = width / height
+        let threshold = newRatio * 0.25
+        if (newRatio < self.previewView.ratio - threshold) ||  (newRatio > self.previewView.ratio + threshold) {
+            self.previewView.ratio = width / height
+            self.previewView.layoutIfNeeded()
+        }
+
+        previewView.addSubview(rectangleView)
+        rectangleView.setNeedsDisplay()
+    }
+    
+//    func drawWordBox(box: VNTextObservation) {
+//        guard let boxes = box.characterBoxes else {return}
+//        var xMin: CGFloat = 9999.0
+//        var xMax: CGFloat = 0.0
+//        var yMin: CGFloat = 9999.0
+//        var yMax: CGFloat = 0.0
+//        
+//        for char in boxes {
+//            if char.bottomLeft.x < xMin {xMin = char.bottomLeft.x}
+//            if char.bottomRight.x > xMax {xMax = char.bottomRight.x}
+//            if char.bottomRight.y < yMin {yMin = char.bottomRight.y}
+//            if char.topRight.y > yMax {yMax = char.topRight.y}
+//        }
+//        
+//        let xCoord = xMin * previewView.frame.size.width
+//        let yCoord = (1 - yMax) * previewView.frame.size.height
+//        let width = (xMax - xMin) * previewView.frame.size.width
+//        let height = (yMax - yMin) * previewView.frame.size.height
+//        
+//        let layer = TextLayer()
+//        layer.frame = CGRect(x: xCoord, y: yCoord, width: width, height: height)
+//        layer.borderWidth = 2.0
+//        layer.borderColor = UIColor.green.cgColor
+//        
+//        previewView.layer.addSublayer(layer)
+//    }
+}

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -19,7 +19,7 @@ final class CameraPreviewViewController: UIViewController {
     
     fileprivate let giniConfiguration: GiniConfiguration
     fileprivate typealias FocusIndicator = UIImageView
-    fileprivate var camera: Camera
+    fileprivate var camera: CameraProtocol
     fileprivate var defaultImageView: UIImageView?
     fileprivate var focusIndicatorImageView: UIImageView?
     fileprivate let interfaceOrientationsMapping: [UIInterfaceOrientation: AVCaptureVideoOrientation] = [
@@ -50,9 +50,10 @@ final class CameraPreviewViewController: UIViewController {
         return previewView
     }()
     
-    init(giniConfiguration: GiniConfiguration = .shared) {
+    init(giniConfiguration: GiniConfiguration = .shared,
+         camera: CameraProtocol = Camera(giniConfiguration: .shared)) {
         self.giniConfiguration = giniConfiguration
-        self.camera = Camera(giniConfiguration: giniConfiguration)
+        self.camera = camera
         super.init(nibName: nil, bundle: nil)
         
     }
@@ -125,7 +126,7 @@ final class CameraPreviewViewController: UIViewController {
                 case .notAuthorizedToUseDevice:
                     addNotAuthorizedView()
                 default:
-                    if GiniConfiguration.DEBUG {
+                    if giniConfiguration.debugModeOn {
                         #if targetEnvironment(simulator)
                         addDefaultImage()
                         #endif
@@ -145,7 +146,7 @@ final class CameraPreviewViewController: UIViewController {
     }
     
     func captureImage(completion: @escaping (Data?, CameraError?) -> Void) {
-        if GiniConfiguration.DEBUG {
+        if giniConfiguration.debugModeOn {
             // Retrieves the image from default image view to make sure the image
             // was set and therefore the correct states were checked before.
             #if targetEnvironment(simulator)
@@ -153,6 +154,7 @@ final class CameraPreviewViewController: UIViewController {
                 let imageData = image.jpegData(compressionQuality: 0.2) {
                 completion(imageData, nil)
             }
+            return
             #endif
         }
         

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -102,11 +102,7 @@ final class CameraPreviewViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
         
         coordinator.animate(alongsideTransition: { [weak self] _ in
-            guard let `self` = self else {
-                return
-            }
-            
-            self.updatePreviewViewOrientation()
+            self?.updatePreviewViewOrientation()
         })
     }
     

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import AVFoundation
 
 protocol CameraPreviewViewControllerDelegate: class {
-    func cameraPreview(viewController: CameraPreviewViewController,
+    func cameraPreview(_ viewController: CameraPreviewViewController,
                        didDetect qrCodeDocument: GiniQRCodeDocument)
 }
 
@@ -150,7 +150,7 @@ final class CameraPreviewViewController: UIViewController {
             camera?.setupQRScanningOutput()
             camera?.didDetectQR = { [weak self] qrDocument in
                 guard let `self` = self else { return }
-                self.delegate?.cameraPreview(viewController: self, didDetect: qrDocument)
+                self.delegate?.cameraPreview(self, didDetect: qrDocument)
             }
         }
         

--- a/GiniVision/Classes/Core/Screens/Camera/CameraViewController+Constraints.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraViewController+Constraints.swift
@@ -21,16 +21,23 @@ extension CameraViewController {
     
     fileprivate func addPreviewViewConstraints() {
         if UIDevice.current.isIpad {
-            Constraints.active(item: previewView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
-            Constraints.active(item: previewView, attr: .bottom, relatedBy: .equal, to: self.view, attr: .bottom)
-            Constraints.active(item: previewView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
-            Constraints.active(item: previewView, attr: .trailing, relatedBy: .equal, to: controlsView, attr: .leading,
+            Constraints.active(item: cameraPreviewViewController.view, attr: .top, relatedBy: .equal,
+                               to: self.view, attr: .top)
+            Constraints.active(item: cameraPreviewViewController.view, attr: .bottom, relatedBy: .equal,
+                               to: self.view, attr: .bottom)
+            Constraints.active(item: cameraPreviewViewController.view, attr: .leading, relatedBy: .equal,
+                               to: self.view, attr: .leading)
+            Constraints.active(item: cameraPreviewViewController.view, attr: .trailing, relatedBy: .equal,
+                               to: controlsView, attr: .leading,
                               priority: 750)
         } else {
             // lower priority constraints - will make the preview "want" to get bigger
-            Constraints.active(item: previewView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
-            Constraints.active(item: previewView, attr: .leading, relatedBy: .equal, to: self.view, attr: .leading)
-            Constraints.active(item: previewView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
+            Constraints.active(item: cameraPreviewViewController.view, attr: .top, relatedBy: .equal,
+                               to: self.view, attr: .top)
+            Constraints.active(item: cameraPreviewViewController.view, attr: .leading, relatedBy: .equal,
+                               to: self.view, attr: .leading)
+            Constraints.active(item: cameraPreviewViewController.view, attr: .trailing, relatedBy: .equal,
+                               to: self.view, attr: .trailing)
         }
     }
     
@@ -39,10 +46,11 @@ extension CameraViewController {
             Constraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: self.view, attr: .top)
             Constraints.active(item: controlsView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)
             Constraints.active(item: controlsView, attr: .bottom, relatedBy: .equal, to: self.view, attr: .bottom)
-            Constraints.active(item: controlsView, attr: .leading, relatedBy: .equal, to: previewView, attr: .trailing,
-                              priority: 750)
+            Constraints.active(item: controlsView, attr: .leading, relatedBy: .equal,
+                               to: cameraPreviewViewController.view, attr: .trailing, priority: 750)
         } else {
-            Constraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: previewView, attr: .bottom)
+            Constraints.active(item: controlsView, attr: .top, relatedBy: .equal, to: cameraPreviewViewController.view,
+                               attr: .bottom)
             Constraints.active(item: controlsView, attr: .bottom, relatedBy: .equal, to: self.bottomLayoutGuide,
                               attr: .top)
             Constraints.active(item: controlsView, attr: .trailing, relatedBy: .equal, to: self.view, attr: .trailing)

--- a/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -104,23 +104,9 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     var opaqueView: UIView?
     var toolTipView: ToolTipView?
     let giniConfiguration: GiniConfiguration
-    fileprivate var camera: Camera?
-    fileprivate var cameraState = CameraState.notValid
-    fileprivate var currentQRCodePopup: QRCodeDetectedPopupView?
     fileprivate var detectedQRCodeDocument: GiniQRCodeDocument?
-    fileprivate var defaultImageView: UIImageView?
-    fileprivate var focusIndicatorImageView: UIImageView?
-    fileprivate let interfaceOrientationsMapping: [UIInterfaceOrientation: AVCaptureVideoOrientation] = [
-        .portrait: .portrait,
-        .landscapeRight: .landscapeRight,
-        .landscapeLeft: .landscapeLeft,
-        .portraitUpsideDown: .portraitUpsideDown
-    ]
-    
-    fileprivate enum CameraState {
-        case valid, notValid
-    }
-    
+    fileprivate var currentQRCodePopup: QRCodeDetectedPopupView?
+  
     // User interface
     lazy var captureButton: UIButton = {
         let button = UIButton()
@@ -159,15 +145,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         return view
     }()
     
-    lazy var previewView: CameraPreviewView = {
-        let previewView = CameraPreviewView()
-        previewView.translatesAutoresizingMaskIntoConstraints = false
-        (previewView.layer as? AVCaptureVideoPreviewLayer)?.videoGravity = .resizeAspectFill
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(focusAndExposeTap))
-        previewView.addGestureRecognizer(tapGesture)
-        return previewView
-    }()
-    
     lazy var controlsView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -175,18 +152,15 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         return view
     }()
     
+    lazy var cameraPreviewViewController: CameraPreviewViewController = {
+        let cameraPreviewViewController = CameraPreviewViewController()
+        cameraPreviewViewController.delegate = self
+        return cameraPreviewViewController
+    }()
+    
     // Images
-    fileprivate var defaultImage: UIImage? {
-        return UIImageNamedPreferred(named: "cameraDefaultDocumentImage")
-    }
     fileprivate var cameraCaptureButtonImage: UIImage? {
         return UIImageNamedPreferred(named: "cameraCaptureButton")
-    }
-    fileprivate var cameraFocusSmall: UIImage? {
-        return UIImageNamedPreferred(named: "cameraFocusSmall")
-    }
-    fileprivate var cameraFocusLarge: UIImage? {
-        return UIImageNamedPreferred(named: "cameraFocusLarge")
     }
     fileprivate var documentImportButtonImage: UIImage? {
         return UIImageNamedPreferred(named: "documentImportButton")
@@ -208,7 +182,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     public init(giniConfiguration: GiniConfiguration) {
         self.giniConfiguration = giniConfiguration
         super.init(nibName: nil, bundle: nil)
-        self.setupCamera(giniConfiguration: self.giniConfiguration)
     }
     
     /**
@@ -258,10 +231,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         fatalError("init(coder:) has not been implemented")
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     fileprivate func didPick(_ document: GiniVisionDocument) {
         if let delegate = delegate {
             delegate.camera(self, didCapture: document)
@@ -275,20 +244,13 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         edgesForExtendedLayout = []
         view.backgroundColor = giniConfiguration.backgroundColor
         
-        if let validCamera = camera {
-            cameraState = .valid
-            previewView.session = validCamera.session
-            NotificationCenter.default.addObserver(self,
-                                                   selector: #selector(subjectAreaDidChange),
-                                                   name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange,
-                                                   object: camera?.videoDeviceInput?.device)
-        }
-        
         // `previewView` must be added at 0 because otherwise NotAuthorizedView button won't ever be touchable
-        view.insertSubview(previewView, at: 0)
-        view.insertSubview(controlsView, aboveSubview: previewView)
+        addChild(cameraPreviewViewController)
+        view.addSubview(cameraPreviewViewController.view)
+        cameraPreviewViewController.didMove(toParent: self)
         
-        previewView.drawGuides(withColor: giniConfiguration.cameraPreviewCornerGuidesColor)
+        view.insertSubview(controlsView, aboveSubview: cameraPreviewViewController.view)
+        
         controlsView.addSubview(captureButton)
 
         if giniConfiguration.multipageEnabled {
@@ -300,8 +262,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
-        updatePreviewViewOrientation() // Video orientation should be updated once the view has been loaded
         
         if giniConfiguration.fileImportSupportedTypes != .none {
             enableFileImport()
@@ -317,7 +277,6 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setStatusBarStyle(to: giniConfiguration.statusBarStyle)
-        camera?.start()
     }
     
     public override func viewDidAppear(_ animated: Bool) {
@@ -325,16 +284,10 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
         delegate?.cameraDidAppear(self)        
     }
     
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        camera?.stop()
-    }
-    
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         self.toolTipView?.arrangeViews()
-        self.opaqueView?.frame = previewView.frame
+        self.opaqueView?.frame = cameraPreviewViewController.view.frame
     }
     
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -345,9 +298,7 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
                 return 
             }
             
-            self.updatePreviewViewOrientation()
             self.toolTipView?.arrangeViews()
-            
         })
     }
 }
@@ -360,7 +311,6 @@ extension CameraViewController {
      Show the capture button. Should be called when onboarding is dismissed.
      */
     public func showCaptureButton() {
-        guard cameraState == .valid else { return }
         controlsView.alpha = 1
     }
     
@@ -375,17 +325,14 @@ extension CameraViewController {
      Show the camera overlay. Should be called when onboarding is dismissed.
      */
     public func showCameraOverlay() {
-        guard cameraState == .valid else { return }
-        previewView.guidesLayer?.isHidden = false
-        previewView.frameLayer?.isHidden = false
+        cameraPreviewViewController.showCameraOverlay()
     }
     
     /**
      Hide the camera overlay. Should be called when onboarding is presented.
      */
     public func hideCameraOverlay() {
-        previewView.guidesLayer?.isHidden = true
-        previewView.frameLayer?.isHidden = true
+        cameraPreviewViewController.hideCameraOverlay()
     }
     
     /**
@@ -430,8 +377,8 @@ extension CameraViewController {
             UIView.animateKeyframes(withDuration: AnimationDuration.medium, delay: 0.6, animations: {
                 UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1, animations: {
                     let thumbnailSize = self.capturedImagesStackView.thumbnailSize
-                    let scaleRatioY = thumbnailSize.height / self.previewView.frame.height
-                    let scaleRatioX = thumbnailSize.width / self.previewView.frame.width
+                    let scaleRatioY = thumbnailSize.height / self.cameraPreviewViewController.view.frame.height
+                    let scaleRatioX = thumbnailSize.width / self.cameraPreviewViewController.view.frame.width
                     
                     previewImageView.transform = CGAffineTransform(scaleX: scaleRatioX, y: scaleRatioY)
                     previewImageView.center = self.capturedImagesStackView
@@ -465,7 +412,7 @@ extension CameraViewController {
             guard let `self` = self else { return }
             
             let newQRCodePopup = QRCodeDetectedPopupView(parent: self.view,
-                                                         refView: self.previewView,
+                                                         refView: self.cameraPreviewViewController.view,
                                                          document: qrDocument,
                                                          giniConfiguration: self.giniConfiguration)
             newQRCodePopup.didTapDone = { [weak self] in
@@ -491,63 +438,8 @@ extension CameraViewController {
         }
     }
     
-    fileprivate func setupCamera(giniConfiguration: GiniConfiguration) {
-        self.camera = Camera(giniConfiguration: giniConfiguration) {[weak self] error in
-            if let error = error {
-                switch error {
-                case .notAuthorizedToUseDevice:
-                    addNotAuthorizedView()
-                default:
-                    if GiniConfiguration.DEBUG {
-                        cameraState = .valid
-                        #if targetEnvironment(simulator)
-                            addDefaultImage()
-                        #endif
-                    }
-                }
-                self?.failureBlock?(error)
-            }
-        }
-        self.camera?.didDetectQR = {[weak self] qrDocument in
-            if self?.detectedQRCodeDocument != qrDocument {
-                self?.detectedQRCodeDocument = qrDocument
-                self?.showPopup(forQRDetected: qrDocument) {
-                    self?.didPick(qrDocument)
-                }
-            }
-        }
-    }
-    
     @objc fileprivate func captureImage(_ sender: AnyObject) {
-        guard let camera = camera else {
-            Log(message: "No camera initialized", event: .warning)
-            return
-        }
-        
-        if GiniConfiguration.DEBUG {
-            // Retrieves the image from default image view to make sure the image
-            // was set and therefore the correct states were checked before.
-            #if targetEnvironment(simulator)
-            if let image = self.defaultImageView?.image,
-                let imageData = image.jpegData(compressionQuality: 0.2) {
-                self.cameraDidCapture(imageData: imageData, error: nil)
-            }
-            #endif
-        }
-        
-        camera.captureStillImage(completion: self.cameraDidCapture)
-    }
-    
-    fileprivate func updatePreviewViewOrientation() {
-        let orientation: AVCaptureVideoOrientation
-        if UIDevice.current.isIpad {
-            orientation =  interfaceOrientationsMapping[UIApplication.shared.statusBarOrientation] ?? .portrait
-        } else {
-            orientation = .portrait
-        }
-        
-        let previewLayer = (self.previewView.layer as? AVCaptureVideoPreviewLayer)
-        previewLayer?.connection?.videoOrientation = orientation
+        cameraPreviewViewController.captureImage(completion: cameraDidCapture)
     }
     
     private func cameraDidCapture(imageData: Data?, error: CameraError?) {
@@ -564,9 +456,9 @@ extension CameraViewController {
     }
     
     private func previewCapturedImageView(with image: UIImage) -> UIImageView {
-        let imageFrame = previewView.frame
+        let imageFrame = cameraPreviewViewController.view.frame
         let imageView = UIImageView(frame: imageFrame)
-        imageView.center = previewView.center
+        imageView.center = cameraPreviewViewController.view.center
         imageView.image = image
         imageView.layer.shadowColor = UIColor.black.cgColor
         imageView.layer.shadowOffset = CGSize(width: -2, height: 2)
@@ -577,62 +469,15 @@ extension CameraViewController {
     }
 }
 
-// MARK: - Focus handling
-
-extension CameraViewController {
-    fileprivate typealias FocusIndicator = UIImageView
-    
-    @objc fileprivate func focusAndExposeTap(_ sender: UITapGestureRecognizer) {
-        guard let previewLayer = previewView.layer as? AVCaptureVideoPreviewLayer else { return }
-        let devicePoint = previewLayer.captureDevicePointConverted(fromLayerPoint: sender.location(in: sender.view))
-        camera?.focus(withMode: .autoFocus,
-                      exposeWithMode: .autoExpose,
-                      atDevicePoint: devicePoint,
-                      monitorSubjectAreaChange: true)
-        let imageView =
-            createFocusIndicator(withImage: cameraFocusSmall,
-                                 atPoint: previewLayer.layerPointConverted(fromCaptureDevicePoint: devicePoint))
-        showFocusIndicator(imageView)
-    }
-    
-    @objc fileprivate func subjectAreaDidChange(_ notification: Notification) {
-        guard let previewLayer = previewView.layer as? AVCaptureVideoPreviewLayer else { return }
-        let devicePoint = CGPoint(x: 0.5, y: 0.5)
-        
-        camera?.focus(withMode: .continuousAutoFocus,
-                      exposeWithMode: .continuousAutoExposure,
-                      atDevicePoint: devicePoint,
-                      monitorSubjectAreaChange: false)
-        
-        let imageView =
-            createFocusIndicator(withImage: cameraFocusLarge,
-                                 atPoint: previewLayer.layerPointConverted(fromCaptureDevicePoint: devicePoint))
-        showFocusIndicator(imageView)
-    }
-    
-    fileprivate func createFocusIndicator(withImage image: UIImage?, atPoint point: CGPoint) -> FocusIndicator? {
-        guard let image = image else { return nil }
-        let imageView = UIImageView(image: image)
-        imageView.center = point
-        return imageView
-    }
-    
-    fileprivate func showFocusIndicator(_ imageView: FocusIndicator?) {
-        guard cameraState == .valid else { return }
-        guard let imageView = imageView else { return }
-        for subView in self.previewView.subviews {
-            if let focusIndicator = subView as? FocusIndicator {
-                focusIndicator.removeFromSuperview()
+extension CameraViewController: CameraPreviewViewControllerDelegate {
+    func cameraPreview(viewController: CameraPreviewViewController, didDetect qrCodeDocument: GiniQRCodeDocument) {
+        if detectedQRCodeDocument != qrCodeDocument {
+            detectedQRCodeDocument = qrCodeDocument
+            showPopup(forQRDetected: qrCodeDocument) { [weak self] in
+                guard let `self` = self else { return }
+                self.didPick(qrCodeDocument)
             }
         }
-        self.previewView.addSubview(imageView)
-        UIView.animate(withDuration: 1.5,
-                       animations: {
-                        imageView.alpha = 0.0
-        },
-                       completion: { _ in
-                        imageView.removeFromSuperview()
-        })
     }
 }
 
@@ -708,41 +553,5 @@ extension CameraViewController {
             self.opaqueView?.removeFromSuperview()
             self.captureButton.isEnabled = true
         }
-    }
-}
-
-// MARK: - Default and not authorized views
-
-extension CameraViewController {
-    fileprivate func addNotAuthorizedView() {
-        
-        // Add not authorized view
-        let view = CameraNotAuthorizedView()
-        super.view.addSubview(view)
-        
-        view.translatesAutoresizingMaskIntoConstraints = false
-        Constraints.active(item: view, attr: .width, relatedBy: .equal, to: super.view, attr: .width)
-        Constraints.active(item: view, attr: .height, relatedBy: .equal, to: super.view, attr: .height)
-        Constraints.active(item: view, attr: .centerX, relatedBy: .equal, to: super.view, attr: .centerX)
-        Constraints.active(item: view, attr: .centerY, relatedBy: .equal, to: super.view, attr: .centerY)
-        
-        // Hide camera UI
-        hideCameraOverlay()
-        hideCaptureButton()
-    }
-    
-    /// Adds a default image to the canvas when no camera is available (DEBUG mode only)
-    fileprivate func addDefaultImage() {
-        defaultImageView = UIImageView(image: defaultImage)
-        guard let defaultImageView = defaultImageView else { return }
-        
-        defaultImageView.contentMode = .scaleAspectFit
-        previewView.addSubview(defaultImageView)
-        
-        defaultImageView.translatesAutoresizingMaskIntoConstraints = false
-        Constraints.active(item: defaultImageView, attr: .width, relatedBy: .equal, to: previewView, attr: .width)
-        Constraints.active(item: defaultImageView, attr: .height, relatedBy: .equal, to: previewView, attr: .height)
-        Constraints.active(item: defaultImageView, attr: .centerX, relatedBy: .equal, to: previewView, attr: .centerX)
-        Constraints.active(item: defaultImageView, attr: .centerY, relatedBy: .equal, to: previewView, attr: .centerY)
     }
 }

--- a/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -469,12 +469,14 @@ extension CameraViewController {
     }
 }
 
+// MARK: - CameraPreviewViewControllerDelegate
+
 extension CameraViewController: CameraPreviewViewControllerDelegate {
-    func cameraPreview(viewController: CameraPreviewViewController, didDetect qrCodeDocument: GiniQRCodeDocument) {
+    func cameraPreview(_ viewController: CameraPreviewViewController, didDetect qrCodeDocument: GiniQRCodeDocument) {
         if detectedQRCodeDocument != qrCodeDocument {
             detectedQRCodeDocument = qrCodeDocument
             showPopup(forQRDetected: qrCodeDocument) { [weak self] in
-                guard let `self` = self else { return }
+                guard let self = self else { return }
                 self.didPick(qrCodeDocument)
             }
         }

--- a/GiniVision/Tests/CameraPreviewViewControllerTests.swift
+++ b/GiniVision/Tests/CameraPreviewViewControllerTests.swift
@@ -1,0 +1,71 @@
+//
+//  CameraPreviewViewControllerTests.swift
+//  GiniVision
+//
+//  Created by Enrique del Pozo Gómez on 2/11/19.
+//
+
+import XCTest
+import AVFoundation
+@testable import GiniVision
+
+final class CameraPreviewViewControllerTests: XCTestCase {
+    
+    var cameraPreviewViewController: CameraPreviewViewController!
+    
+    override func setUp() {
+        super.setUp()
+        let camera = CameraMock(state: .authorized)
+        cameraPreviewViewController = CameraPreviewViewController(giniConfiguration: GiniConfiguration(),
+                                                                  camera: camera)
+    }
+    
+    func testSessionWhenViewIsLoaded() {
+        _ = cameraPreviewViewController.view
+        XCTAssertTrue(cameraPreviewViewController.view.subviews.contains(cameraPreviewViewController.previewView),
+                      "previewView must be added when loading the view")
+        XCTAssertNotNil(cameraPreviewViewController.previewView.session,
+                        "session must be assigned to previewView when view is loaded")
+    }
+    
+    func testAddNotAuthroizedView() {
+        let camera = CameraMock(state: .unauthorized)
+        cameraPreviewViewController = CameraPreviewViewController(giniConfiguration: GiniConfiguration(),
+                                                                  camera: camera)
+        let notAuthorizedView = cameraPreviewViewController
+            .view
+            .subviews
+            .compactMap { $0 as? CameraNotAuthorizedView }
+            .first
+        
+        XCTAssertNotNil(notAuthorizedView, "Not authorized view should be shown when camera permission not authorized")
+    }
+    
+    func testQrOutputSetUp() {
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.qrCodeScanningEnabled = true
+        cameraPreviewViewController = CameraPreviewViewController(giniConfiguration: giniConfiguration)
+        _ = cameraPreviewViewController.view
+        
+        let metadataOutput = cameraPreviewViewController.previewView.session
+            .outputs
+            .compactMap { $0 as? AVCaptureMetadataOutput }
+            .first
+        
+        XCTAssertNotNil(metadataOutput, "the camera session should have the metadata output")
+    }
+    
+    func testCaptureImage() {
+        let expect = expectation(description: "an image is captured")
+        let giniConfiguration = GiniConfiguration()
+        giniConfiguration.debugModeOn = true
+        cameraPreviewViewController = CameraPreviewViewController(giniConfiguration: giniConfiguration)
+        _ = cameraPreviewViewController.view
+        
+        cameraPreviewViewController.captureImage { imageData, _ in
+            XCTAssertNotNil(imageData, "image captured data should not be nil")
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 1.0)
+    }
+}

--- a/GiniVision/Tests/CameraViewControllerTests.swift
+++ b/GiniVision/Tests/CameraViewControllerTests.swift
@@ -70,7 +70,7 @@ final class CameraViewControllerTests: XCTestCase {
         GiniConfiguration.shared.onboardingShowAtLaunch = false
         GiniConfiguration.shared.onboardingShowAtFirstLaunch = false
         
-        cameraViewController = CameraViewController(successBlock: { _ in }, failureBlock: { _ in })
+        cameraViewController = CameraViewController.init(giniConfiguration: GiniConfiguration.shared)
         _ = cameraViewController.view
         
         XCTAssertEqual(cameraViewController.opaqueView?.backgroundColor, UIColor.black.withAlphaComponent(0.8))


### PR DESCRIPTION
### Description
All camera preview related functionality has been extracted from the `CameraViewController` to the new `CameraPreviewViewController`.

### How to test
Run the Example and check that everything was working as expected.

### Merging
Automatic

### Issues
