### PR TITLE
Fixed Onboarding transition issue

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,17 +12,17 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.2.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.3.2):
-    - GiniVision/Core (= 4.3.2)
-  - GiniVision/Core (4.3.2)
-  - GiniVision/Networking (4.3.2):
+  - GiniVision (4.4.0):
+    - GiniVision/Core (= 4.4.0)
+  - GiniVision/Core (4.4.0)
+  - GiniVision/Networking (4.4.0):
     - Bolts (~> 1.9)
     - Gini-iOS-SDK (~> 1.2)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.3.2)":
+  - "GiniVision/Networking+Pinning (4.4.0)":
     - Gini-iOS-SDK/Pinning (~> 1.2)
     - GiniVision/Networking
-  - GiniVision/Tests (4.3.2)
+  - GiniVision/Tests (4.4.0)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -44,7 +44,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: cfec665b042acb86e1e18cef964fbaa8196635f1
-  GiniVision: 597e3d071dd43d067fd05a9ccffdabf8eced923d
+  GiniVision: 28b038eac605641251b6717b8ad6cb9ba6308ad9
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4

--- a/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -128,6 +128,16 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
         let navigationController = UINavigationController(rootViewController: vc)
         navigationController.applyStyle(withConfiguration: giniConfiguration)
         navigationController.modalPresentationStyle = .overCurrentContext
+        
+        // Since the onboarding appears on startup, it could be the case where there are two consecutive 'coverVertical'
+        // modal transitions. When the Screen API is embedded in a UINavigationController, it still has that
+        // transition but it's not used.
+        if let rootContainerViewController = rootViewController.parent,
+            rootContainerViewController.modalTransitionStyle == .coverVertical,
+            !(rootContainerViewController.parent is UINavigationController) {
+            navigationController.modalTransitionStyle = .crossDissolve
+        }
+        
         screenAPINavigationController.present(navigationController, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
### Description
Fixed issue with Onboarding transition when the Screen API was presented modally.

### How to test
Present the Screen API from a UIViewController (not UINavigationController), with a `coverVertical` transition, and check that the Onboarding screen is presented with a `.crossDisolve` style.

### Merging
Automatic

### Issues

