### PR TITLE
Fix navigation bar issue after picking a document

### DIFF
--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -36,7 +36,7 @@ final class AppCoordinator: Coordinator {
         giniConfiguration.qrCodeScanningEnabled = true
         giniConfiguration.multipageEnabled = true
         giniConfiguration.flashToggleEnabled = true
-        giniConfiguration.navigationBarItemTintColor = UIColor.white
+        giniConfiguration.navigationBarItemTintColor = .white
         giniConfiguration.customDocumentValidations = { document in
             // As an example of custom document validation, we add a more strict check for file size
             let maxFileSize = 5 * 1024 * 1024

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,17 +12,17 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.3.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.6.0):
-    - GiniVision/Core (= 4.6.0)
-  - GiniVision/Core (4.6.0)
-  - GiniVision/Networking (4.6.0):
+  - GiniVision (4.7.0):
+    - GiniVision/Core (= 4.7.0)
+  - GiniVision/Core (4.7.0)
+  - GiniVision/Networking (4.7.0):
     - Bolts (~> 1.9)
     - Gini-iOS-SDK (~> 1.3)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.6.0)":
+  - "GiniVision/Networking+Pinning (4.7.0)":
     - Gini-iOS-SDK/Pinning (~> 1.3)
     - GiniVision/Networking
-  - GiniVision/Tests (4.6.0)
+  - GiniVision/Tests (4.7.0)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -44,7 +44,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: b3da30a0893efb297d37cf5b837e80e49455d281
-  GiniVision: 484accdabb16da1e73b7f6457dbed8119841b253
+  GiniVision: ad0e12c10173447f8c3cd4ee7ac4f18f3bdec6e1
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4

--- a/GiniVision/Classes/Core/GiniConfiguration.swift
+++ b/GiniVision/Classes/Core/GiniConfiguration.swift
@@ -147,6 +147,7 @@ import UIKit
     /**
      Sets the tint color of the UIDocumentPickerViewController navigation bar.
      
+     - note: Use only if you have a custom `UIAppearance` for your UINavigationBar
      - note: Only iOS >= 11.0
      */
     @objc public var documentPickerNavigationBarTintColor: UIColor?

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -179,13 +179,13 @@ public final class DocumentPickerCoordinator: NSObject {
         if #available(iOS 11.0, *) {
             documentPicker.allowsMultipleSelection = giniConfiguration.multipageEnabled
             
-            // Starting with iOS 11.0, the UIDocumentPickerViewController navigation bar almost can't be customized,
-            // only being possible to customize the tint color. To avoid issues with custom UIAppearance styles,
-            // this is reset to default, saving the current state in order to restore it during dismissal.
-            saveCurrentNavBarAppearance()
-            applyDefaultNavBarAppearance()
-            
             if let tintColor = giniConfiguration.documentPickerNavigationBarTintColor {
+                // Starting with iOS 11.0, the UIDocumentPickerViewController navigation bar almost can't be customized,
+                // only being possible to customize the tint color. To avoid issues with custom UIAppearance styles,
+                // this is reset to default, saving the current state in order to restore it during dismissal.
+                saveCurrentNavBarAppearance()
+                applyDefaultNavBarAppearance()
+                
                 UINavigationBar.appearance().tintColor = tintColor
                 UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self])
                     .setTitleTextAttributes([.foregroundColor: tintColor],
@@ -326,7 +326,7 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
             .compactMap(self.data)
             .compactMap(self.createDocument)
         
-        if #available(iOS 11.0, *) {
+        if #available(iOS 11.0, *), giniConfiguration.documentPickerNavigationBarTintColor != nil {
             restoreSavedNavBarAppearance()
         }
         
@@ -338,7 +338,7 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
     }
     
     public func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-        if #available(iOS 11.0, *) {
+        if #available(iOS 11.0, *), giniConfiguration.documentPickerNavigationBarTintColor != nil {
             restoreSavedNavBarAppearance()
         }
         


### PR DESCRIPTION
### Description
Fixes an issue with the navigation bar appearance when using a custom tint color.

### How to test
Change the UINavigation appearance and set the tint color to check that it's changed.

### Merging
Automatic


