### PR TITLE
Add file check for empty files

### DIFF
--- a/GiniVision/Classes/Core/Helpers/GiniVisionDocumentValidator.swift
+++ b/GiniVision/Classes/Core/Helpers/GiniVisionDocumentValidator.swift
@@ -23,17 +23,16 @@ public final class GiniVisionDocumentValidator {
      
      */
     public class func validate(_ document: GiniVisionDocument, withConfig giniConfiguration: GiniConfiguration) throws {
-        if !maxFileSizeExceeded(forData: document.data) {
-            try validateType(for: document)
-            let customValidationResult = giniConfiguration.customDocumentValidations(document)
-            if let error = customValidationResult.error, !customValidationResult.isSuccess {
-                throw error
-            }
-        } else {
-            throw DocumentValidationError.exceededMaxFileSize
+        try validateSize(for: document.data)
+        try validateType(for: document)
+        
+        let customValidationResult = giniConfiguration.customDocumentValidations(document)
+        if let error = customValidationResult.error, !customValidationResult.isSuccess {
+            throw error
         }
+        
     }
-
+    
 }
 
 // MARK: - Fileprivate
@@ -44,11 +43,16 @@ fileprivate extension GiniVisionDocumentValidator {
         return 10 * 1024 * 1024
     }
     
-    class func maxFileSizeExceeded(forData data: Data) -> Bool {
+    class func validateSize(for data: Data) throws {
         if data.count > maxFileSize {
-            return true
+            throw DocumentValidationError.exceededMaxFileSize
         }
-        return false
+        
+        if data.count == 0 {
+            throw DocumentValidationError.fileFormatNotValid
+        }
+        
+        return
     }
     
     class func validateType(for document: GiniVisionDocument) throws {

--- a/GiniVision/Tests/GiniVisionDocumentValidatorTests.swift
+++ b/GiniVision/Tests/GiniVisionDocumentValidatorTests.swift
@@ -48,6 +48,17 @@ final class GiniVisionDocumentValidatorTests: XCTestCase {
                          "Valid images should validate without throwing an exception")
     }
     
+    func testEmptyFileValidation() {
+        let pdfDocument = GiniPDFDocument(data: Data(count: 0))
+
+        XCTAssertThrowsError(try GiniVisionDocumentValidator.validate(pdfDocument,
+                                                                      withConfig: giniConfiguration),
+                             "Empty files should not be valid") { error in
+                                XCTAssert(error as? DocumentValidationError == .fileFormatNotValid,
+                                          "should indicate that the file format is invalid")
+        }
+    }
+    
     fileprivate func generateFakeData(megaBytes lengthInMB: Int) -> Data {
         let length = lengthInMB * 1000000
         return Data(count: length)


### PR DESCRIPTION
### Description
When using an empty file, it should also prevent to upload it to the backend.

### How to test
Run the example app and select an empty file from the file browser

### Merging
Automatic

