### PR TITLE
Added flash toggle image asset names to customization guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Example/Credentials.plist
 /fastlane/screenshots/screenshots.html
 /fastlane/screenshots/*/*-portrait_framed.png
 /fastlane/screenshots/*/*-landscape_framed.png
+
+# Documentation
+Documentation/Api

--- a/Documentation/source/Customization guide.md
+++ b/Documentation/source/Customization guide.md
@@ -64,6 +64,9 @@ Customizable assets can be found in [the Assets repo](https://github.com/gini/gi
 	- Image &#8594; <span style="color:#009EDF">*documentImportButton*</span> image asset
 - Captured images stack indicator color &#8594; `GiniConfiguration.imagesStackIndicatorLabelTextcolor`
 - Flash toggle can be enabled through &#8594; `GiniConfiguration.flashToggleEnabled`
+- Flash button
+    - Image &#8594; <span style="color:#009EDF">*flashOn*</span> image asset
+    - Image &#8594; <span style="color:#009EDF">*flashOff*</span> image asset
 
 ##### 4. QR code popup
 <br>


### PR DESCRIPTION
### Description
The image assets for the flash toggle icon were omitted from the customization guide and have been added now.

### Issues
[PIA-282](https://ginis.atlassian.net/browse/PIA-282)
