### PR TITLE
Fix feedback sending in Obj-C example

### DIFF
--- a/Example/Example ObjC/ScreenAPIViewController.m
+++ b/Example/Example ObjC/ScreenAPIViewController.m
@@ -15,7 +15,7 @@
 @interface ScreenAPIViewController () <GiniVisionResultsDelegate>
 
 @property (nonatomic, strong) NSString *errorMessage;
-@property (nonatomic, strong) NSDictionary *result;
+@property (nonatomic, strong) AnalysisResult *result;
 @property (nonatomic, strong) GINIDocument *document;
 @property (nonatomic, strong) UIViewController *giniVisionVC;
 
@@ -84,9 +84,9 @@ NSString *kClientDomain = @"client_domain";
     }
 }
 
-- (void)giniVisionAnalysisDidFinishWith:(NSDictionary<NSString *,GINIExtraction *> *)results
-                      sendFeedbackBlock:(void (^)(NSDictionary<NSString *,GINIExtraction *> * _Nonnull))sendFeedbackBlock {
-    _result = results;
+- (void)giniVisionAnalysisDidFinishWithResult:(AnalysisResult *)result
+                            sendFeedbackBlock:(void (^)(NSDictionary<NSString *,GINIExtraction *> * _Nonnull))sendFeedbackBlock {
+    _result = result;
     [self presentResultsWithSendFeedbackBlock:sendFeedbackBlock];
 }
 
@@ -95,7 +95,7 @@ NSString *kClientDomain = @"client_domain";
     NSArray *payFive = @[@"paymentReference", @"iban", @"bic", @"amountToPay", @"paymentRecipient"];
     BOOL hasPayFive = NO;
     for (NSString *key in payFive) {
-        if (_result[key]) {
+        if (_result.extractions[key]) {
             hasPayFive = YES;
             break;
         }
@@ -104,7 +104,7 @@ NSString *kClientDomain = @"client_domain";
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:NULL];
     if (hasPayFive) {
         ResultTableViewController *vc = [storyboard instantiateViewControllerWithIdentifier:@"resultScreen"];
-        vc.result = _result;
+        vc.result = _result.extractions;
         vc.sendFeedback = sendFeedbackBlock;
         dispatch_async(dispatch_get_main_queue(), ^{
             [self.navigationController pushViewController:vc animated:NO];

--- a/Example/Example ObjC/ScreenAPIViewController.m
+++ b/Example/Example ObjC/ScreenAPIViewController.m
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) NSString *errorMessage;
 @property (nonatomic, strong) NSDictionary *result;
 @property (nonatomic, strong) GINIDocument *document;
+@property (nonatomic, strong) UIViewController *giniVisionVC;
 
 @end
 
@@ -61,14 +62,14 @@ NSString *kClientDomain = @"client_domain";
                                                  clientSecret:credentials[kClientPassword]
                                             clientEmailDomain:credentials[kClientPassword]];
     // 2. Create the Gini Vision Library view controller, set a delegate object and pass in the configuration object
-    UIViewController *vc = [GiniVision viewControllerWithClient:client
+    self.giniVisionVC = [GiniVision viewControllerWithClient:client
                                               importedDocuments:NULL
                                                   configuration:giniConfiguration
                                                 resultsDelegate:self
                                                documentMetadata:nil
                                                             api:GINIAPITypeDefault];
     // 3. Present the Gini Vision Library Screen API modally
-    [self presentViewController:vc animated:YES completion:nil];
+    [self presentViewController:_giniVisionVC animated:YES completion:nil];
     
     // 4. Handle callbacks send out via the `GINIVisionDelegate` to get results, errors or updates on other user actions
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,17 +12,17 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.3.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.7.0):
-    - GiniVision/Core (= 4.7.0)
-  - GiniVision/Core (4.7.0)
-  - GiniVision/Networking (4.7.0):
+  - GiniVision (4.8.0):
+    - GiniVision/Core (= 4.8.0)
+  - GiniVision/Core (4.8.0)
+  - GiniVision/Networking (4.8.0):
     - Bolts (~> 1.9)
     - Gini-iOS-SDK (~> 1.3)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.7.0)":
+  - "GiniVision/Networking+Pinning (4.8.0)":
     - Gini-iOS-SDK/Pinning (~> 1.3)
     - GiniVision/Networking
-  - GiniVision/Tests (4.7.0)
+  - GiniVision/Tests (4.8.0)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -44,9 +44,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: b3da30a0893efb297d37cf5b837e80e49455d281
-  GiniVision: ad0e12c10173447f8c3cd4ee7ac4f18f3bdec6e1
+  GiniVision: ddc156690dd5a708534c436d51aa0a132bfa4ea0
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.1

--- a/GiniVision/Classes/Networking/AnalysisResult.swift
+++ b/GiniVision/Classes/Networking/AnalysisResult.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@objc public class AnalysisResult: NSObject {
+@objcMembers public class AnalysisResult: NSObject {
     /// Images processed in the analysis
     public let images: [UIImage]
     /*


### PR DESCRIPTION
Keeping a reference to the Gini ViewController so that the `GiniScreenAPICoordinator` instance is available when the send feedback block is invoked from the results screen.

