### PR TITLE
Fallback for out of bounds item positions

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,17 +12,17 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.3.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.8.0):
-    - GiniVision/Core (= 4.8.0)
-  - GiniVision/Core (4.8.0)
-  - GiniVision/Networking (4.8.0):
+  - GiniVision (4.8.1):
+    - GiniVision/Core (= 4.8.1)
+  - GiniVision/Core (4.8.1)
+  - GiniVision/Networking (4.8.1):
     - Bolts (~> 1.9)
     - Gini-iOS-SDK (~> 1.3)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.8.0)":
+  - "GiniVision/Networking+Pinning (4.8.1)":
     - Gini-iOS-SDK/Pinning (~> 1.3)
     - GiniVision/Networking
-  - GiniVision/Tests (4.8.0)
+  - GiniVision/Tests (4.8.1)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -44,7 +44,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: b3da30a0893efb297d37cf5b837e80e49455d281
-  GiniVision: ddc156690dd5a708534c436d51aa0a132bfa4ea0
+  GiniVision: 17361599bf4c51d277a9e5149329fa090df5f925
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4

--- a/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
@@ -322,7 +322,12 @@ extension MultipageReviewViewController {
     }
     
     func selectItem(at position: Int, in section: Int = 0, animated: Bool = true) {
-        let indexPath = IndexPath(row: position, section: section)
+        var indexPathRow = position
+        if position < 0 || position >= self.pages.count {
+            indexPathRow = 0
+        }
+        
+        let indexPath = IndexPath(row: indexPathRow, section: section)
         pagesCollection.selectItem(at: indexPath,
                                    animated: animated,
                                    scrollPosition: .centeredHorizontally)

--- a/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
@@ -322,6 +322,10 @@ extension MultipageReviewViewController {
     }
     
     func selectItem(at position: Int, in section: Int = 0, animated: Bool = true) {
+        guard self.pages.count > 0 else {
+            return
+        }
+        
         var indexPathRow = position
         if position < 0 || position >= self.pages.count {
             indexPathRow = 0

--- a/GiniVision/Tests/MultipageReviewViewControllerTests.swift
+++ b/GiniVision/Tests/MultipageReviewViewControllerTests.swift
@@ -239,7 +239,7 @@ final class MultipageReviewViewControllerTests: XCTestCase {
     }
     
     func testSelectingItemAtNegativePositionSelectsFirstItem() {
-        ToolTipView.shouldShowReorderPagesButtonToolTip = true
+        ToolTipView.shouldShowReorderPagesButtonToolTip = false
         
         multipageReviewViewController = MultipageReviewViewController(pages: imagePages,
                                                                       giniConfiguration: giniConfiguration)
@@ -252,7 +252,7 @@ final class MultipageReviewViewControllerTests: XCTestCase {
     }
     
     func testSelectingItemAtOutOfUpperBoundPositionSelectsFirstItem() {
-        ToolTipView.shouldShowReorderPagesButtonToolTip = true
+        ToolTipView.shouldShowReorderPagesButtonToolTip = false
         
         multipageReviewViewController = MultipageReviewViewController(pages: imagePages,
                                                                       giniConfiguration: giniConfiguration)
@@ -262,5 +262,18 @@ final class MultipageReviewViewControllerTests: XCTestCase {
         
         XCTAssertEqual(multipageReviewViewController.pagesCollection.indexPathsForSelectedItems?[0].row, 0,
                        "pages collection selected item position should be 0")
+    }
+    
+    func testSelectingItemDoesNothingIfPagesIsEmpty() {
+        ToolTipView.shouldShowReorderPagesButtonToolTip = false
+        
+        multipageReviewViewController = MultipageReviewViewController(pages: [],
+                                                                      giniConfiguration: giniConfiguration)
+        _ = multipageReviewViewController.view
+        
+        multipageReviewViewController.selectItem(at: 1)
+        
+        XCTAssertEqual(multipageReviewViewController.pagesCollection.indexPathsForSelectedItems?.count, 0,
+                       "pages collection has no selected items")
     }
 }

--- a/GiniVision/Tests/MultipageReviewViewControllerTests.swift
+++ b/GiniVision/Tests/MultipageReviewViewControllerTests.swift
@@ -237,4 +237,30 @@ final class MultipageReviewViewControllerTests: XCTestCase {
                      "rotate button should be disabled when tooltip is shown")
         
     }
+    
+    func testSelectingItemAtNegativePositionSelectsFirstItem() {
+        ToolTipView.shouldShowReorderPagesButtonToolTip = true
+        
+        multipageReviewViewController = MultipageReviewViewController(pages: imagePages,
+                                                                      giniConfiguration: giniConfiguration)
+        _ = multipageReviewViewController.view
+        
+        multipageReviewViewController.selectItem(at: -1)
+        
+        XCTAssertEqual(multipageReviewViewController.pagesCollection.indexPathsForSelectedItems?[0].row, 0,
+                       "pages collection selected item position should be 0")
+    }
+    
+    func testSelectingItemAtOutOfUpperBoundPositionSelectsFirstItem() {
+        ToolTipView.shouldShowReorderPagesButtonToolTip = true
+        
+        multipageReviewViewController = MultipageReviewViewController(pages: imagePages,
+                                                                      giniConfiguration: giniConfiguration)
+        _ = multipageReviewViewController.view
+        
+        multipageReviewViewController.selectItem(at: imagePages.count)
+        
+        XCTAssertEqual(multipageReviewViewController.pagesCollection.indexPathsForSelectedItems?[0].row, 0,
+                       "pages collection selected item position should be 0")
+    }
 }


### PR DESCRIPTION
### Description
We fall back to position 0 if the item position is out of bounds. Also if the pages array is empty the item selection does nothing.

### How to test
Run the MultipageReviewViewControllerTests.

### Issues
#345, [PIA-291](https://ginis.atlassian.net/browse/PIA-291)

