### PR TITLE
Fix dark mode issues

### DIFF
--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -151,6 +151,10 @@ final class AppCoordinator: Coordinator {
                                                     message: "Möchten Sie die importierte Datei mit dem " +
             "ScreenAPI oder ComponentAPI verwenden?",
                                                     preferredStyle: .alert)
+        
+        // Ignore dark mode
+        alertViewController.useLightUserInterfaceStyle()
+        
         alertViewController.addAction(UIAlertAction(title: "Screen API", style: .default) {[weak self] _ in
             self?.showScreenAPI(with: pages)
         })        
@@ -165,6 +169,10 @@ final class AppCoordinator: Coordinator {
         let alertViewController = UIAlertController(title: "Ungültiges Dokument",
                                                     message: "Dies ist kein gültiges Dokument",
                                                     preferredStyle: .alert)
+        
+        // Ignore dark mode
+        alertViewController.useLightUserInterfaceStyle()
+        
         alertViewController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
             alertViewController.dismiss(animated: true, completion: nil)
         })

--- a/Example/Example Swift/ComponentAPIOnboardingViewController.swift
+++ b/Example/Example Swift/ComponentAPIOnboardingViewController.swift
@@ -27,6 +27,9 @@ final class ComponentAPIOnboardingViewController: UIViewController {
         
         // 2. Display the onboarding view controller
         displayContent(contentController)
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     // Displays the content controller inside the container view

--- a/Example/Example Swift/NoResultViewController.swift
+++ b/Example/Example Swift/NoResultViewController.swift
@@ -21,6 +21,9 @@ final class NoResultViewController: UIViewController {
         super.viewDidLoad()
         
         rotateImageView.image = rotateImageView.image?.withRenderingMode(.alwaysTemplate)
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     @IBAction func retry(_ sender: AnyObject) {

--- a/Example/Example Swift/ResultTableViewController.swift
+++ b/Example/Example Swift/ResultTableViewController.swift
@@ -23,6 +23,12 @@ final class ResultTableViewController: UITableViewController {
     fileprivate var sortedKeys: [String] {
         return Array(result.keys).sorted(by: <)
     }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
 }
 
 extension ResultTableViewController {

--- a/Example/Example Swift/RootNavigationController.swift
+++ b/Example/Example Swift/RootNavigationController.swift
@@ -23,5 +23,11 @@ final class RootNavigationController: UINavigationController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return self.topViewController?.supportedInterfaceOrientations ?? .portrait
     }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
 }
 

--- a/Example/Example Swift/SelectAPIViewController.swift
+++ b/Example/Example Swift/SelectAPIViewController.swift
@@ -42,6 +42,8 @@ final class SelectAPIViewController: UIViewController {
         let metaTitle = "Gini Vision Library: (\(GiniVision.versionString)) / Client id: \(self.clientId ?? "")"
         metaInformationButton.setTitle(metaTitle, for: .normal)
         
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     // MARK: User interaction

--- a/Example/Example Swift/SettingsViewController.swift
+++ b/Example/Example Swift/SettingsViewController.swift
@@ -85,6 +85,8 @@ final class SettingsViewController: UIViewController {
             fileImportControl.selectedSegmentIndex = 2
         }
         
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
 
 }

--- a/Example/Example Swift/UIViewController.swift
+++ b/Example/Example Swift/UIViewController.swift
@@ -71,6 +71,10 @@ extension UIViewController {
                                  confirmAction: (() -> Void)? = nil) -> UIAlertController {
         
         let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
+        // Ignore dark mode
+        alertViewController.useLightUserInterfaceStyle()
+        
         alertViewController.addAction(UIAlertAction(title: cancelActionTitle,
                                                     style: .cancel,
                                                     handler: { _ in
@@ -86,5 +90,11 @@ extension UIViewController {
         }
         
         return alertViewController
+    }
+    
+    func useLightUserInterfaceStyle() {
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = .light
+        }
     }
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,17 +12,17 @@ PODS:
   - Gini-iOS-SDK/Pinning (1.3.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
-  - GiniVision (4.8.1):
-    - GiniVision/Core (= 4.8.1)
-  - GiniVision/Core (4.8.1)
-  - GiniVision/Networking (4.8.1):
+  - GiniVision (4.8.2):
+    - GiniVision/Core (= 4.8.2)
+  - GiniVision/Core (4.8.2)
+  - GiniVision/Networking (4.8.2):
     - Bolts (~> 1.9)
     - Gini-iOS-SDK (~> 1.3)
     - GiniVision/Core
-  - "GiniVision/Networking+Pinning (4.8.1)":
+  - "GiniVision/Networking+Pinning (4.8.2)":
     - Gini-iOS-SDK/Pinning (~> 1.3)
     - GiniVision/Networking
-  - GiniVision/Tests (4.8.1)
+  - GiniVision/Tests (4.8.2)
   - TrustKit (1.5.3)
 
 DEPENDENCIES:
@@ -44,7 +44,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini-iOS-SDK: b3da30a0893efb297d37cf5b837e80e49455d281
-  GiniVision: 17361599bf4c51d277a9e5149329fa090df5f925
+  GiniVision: 0343456ac4f090fa8e3c3ff690308d193f208b88
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 4c8963315542fbfa088ca9185fa3eb6c12dd6ea4

--- a/GiniVision/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniVision/Classes/Core/Extensions/UIViewController.swift
@@ -75,6 +75,10 @@ extension UIViewController {
                                  confirmAction: (() -> Void)? = nil) -> UIAlertController {
         
         let alertViewController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        
+        // Ignore dark mode
+        alertViewController.useLightUserInterfaceStyle()
+        
         alertViewController.addAction(UIAlertAction(title: cancelActionTitle,
                                                     style: .cancel,
                                                     handler: { _ in
@@ -90,5 +94,11 @@ extension UIViewController {
         }
         
         return alertViewController
+    }
+    
+    func useLightUserInterfaceStyle() {
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = .light
+        }
     }
 }

--- a/GiniVision/Classes/Core/Screens/Analysis/AnalysisViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Analysis/AnalysisViewController.swift
@@ -173,6 +173,12 @@ import UIKit
         addErrorView()
     }
     
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         didShowAnalysis?()

--- a/GiniVision/Classes/Core/Screens/Camera/CameraButtonsViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraButtonsViewController.swift
@@ -164,6 +164,12 @@ final class CameraButtonsViewController: UIViewController {
         addConstraints()
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     func addFileImportButton() {
         if currentDevice.isIpad {
             let bottomVerticalAlignedStackView = verticalAlignedStackView

--- a/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraPreviewViewController.swift
@@ -95,6 +95,9 @@ final class CameraPreviewViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         updatePreviewViewOrientation() // Video orientation should be updated once the view has been loaded
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -224,6 +224,9 @@ public typealias CameraScreenFailureBlock = (_ error: GiniVisionError) -> Void
                 }
             }
         }
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -478,6 +481,10 @@ extension CameraViewController {
         toolTipView?.dismiss(withCompletion: nil)
         
         let alertViewController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        // Ignore dark mode
+        alertViewController.useLightUserInterfaceStyle()
+        
         var alertViewControllerMessage: String = .localized(resource: CameraStrings.popupTitleImportPDF)
         
         if giniConfiguration.fileImportSupportedTypes == .pdf_and_images {

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -174,6 +174,10 @@ public final class DocumentPickerCoordinator: NSObject {
     public func showDocumentPicker(from viewController: UIViewController,
                                    device: UIDevice = UIDevice.current) {
         let documentPicker = UIDocumentPickerViewController(documentTypes: acceptedDocumentTypes, in: .import)
+        
+        // Ignore dark mode
+        documentPicker.useLightUserInterfaceStyle()
+        
         documentPicker.delegate = self
         
         if #available(iOS 11.0, *) {

--- a/GiniVision/Classes/Core/Screens/Document picker/Gallery/AlbumsPickerViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/Gallery/AlbumsPickerViewController.swift
@@ -54,6 +54,12 @@ final class AlbumsPickerViewController: UIViewController {
         Constraints.pin(view: albumsTableView, toSuperView: view)
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     func reloadAlbums() {
         albumsTableView.reloadData()
     }

--- a/GiniVision/Classes/Core/Screens/Document picker/Gallery/ImagePickerViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/Gallery/ImagePickerViewController.swift
@@ -72,6 +72,12 @@ final class ImagePickerViewController: UIViewController {
         Constraints.pin(view: collectionView, toSuperView: view)
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         scrollToBottomOnStartup()

--- a/GiniVision/Classes/Core/Screens/Help/HelpMenuViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Help/HelpMenuViewController.swift
@@ -124,6 +124,9 @@ final public class HelpMenuViewController: UITableViewController {
                                 position: .left,
                                 target: self)
         }
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     @objc func back() {

--- a/GiniVision/Classes/Core/Screens/Help/No results /ImageAnalysisNoResultsViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Help/No results /ImageAnalysisNoResultsViewController.swift
@@ -135,6 +135,12 @@ public final class ImageAnalysisNoResultsViewController: UIViewController {
         }, completion: nil)
     }
     
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     fileprivate func addConstraints() {
         
         // Collection View

--- a/GiniVision/Classes/Core/Screens/Help/Open with tutorial/OpenWithTutorialViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Help/Open with tutorial/OpenWithTutorialViewController.swift
@@ -77,6 +77,9 @@ final class OpenWithTutorialViewController: UICollectionViewController {
         stepsCollectionLayout.minimumLineSpacing = 1
         stepsCollectionLayout.minimumInteritemSpacing = 1
         stepsCollectionLayout.estimatedItemSize = estimatedCellSize(widthParentSize: view.frame.size)
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/GiniVision/Classes/Core/Screens/Help/Supported formats/SupportedFormatsViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Help/Supported formats/SupportedFormatsViewController.swift
@@ -67,6 +67,9 @@ final class SupportedFormatsViewController: UITableViewController {
         if #available(iOS 11.0, *) {
             tableView.contentInsetAdjustmentBehavior = .never
         }
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     // MARK: - Table view data source

--- a/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
@@ -238,6 +238,9 @@ extension MultipageReviewViewController {
         if ToolTipView.shouldShowReorderPagesButtonToolTip {
             createReorderPagesTip()
         }
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/GiniVision/Classes/Core/Screens/Onboarding/OnboardingContainerViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Onboarding/OnboardingContainerViewController.swift
@@ -107,6 +107,9 @@ final class OnboardingContainerViewController: UIViewController, ContainerViewCo
         
         // Add content to container view
         displayContent(contentController)
+        
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
     }
     
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/GiniVision/Classes/Core/Screens/Onboarding/OnboardingViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Onboarding/OnboardingViewController.swift
@@ -110,6 +110,12 @@ import UIKit
         addConstraints()
     }
     
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     /**
      Scrolls the scroll view to the next page.
      

--- a/GiniVision/Classes/Core/Screens/Review/ReviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Review/ReviewViewController.swift
@@ -230,6 +230,12 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> Void
         view.layoutIfNeeded()
     }
     
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        // Ignore dark mode
+        useLightUserInterfaceStyle()
+    }
+    
     /**
      Called to notify the view controller that its view has just laid out its subviews.
      */
@@ -242,7 +248,7 @@ public typealias ReviewScreenFailureBlock = (_ error: GiniVisionError) -> Void
         // inside the ScrollView when its size has changed
         self.updateConstraintsForSize(scrollView.bounds.size)
     }
-    
+        
     /**
      Notifies the view controller that its view was added to a view hierarchy.
      

--- a/GiniVision/Tests/GalleryCoordinatorTests.swift
+++ b/GiniVision/Tests/GalleryCoordinatorTests.swift
@@ -63,7 +63,7 @@ final class GalleryCoordinatorTests: XCTestCase {
                 let expect = self.expectation(for: NSPredicate(value: true),
                                               evaluatedWith: delegate.didOpenImages,
                                               handler: nil)
-                self.wait(for: [expect], timeout: 1)
+                self.wait(for: [expect], timeout: 2)
                 XCTAssertTrue(delegate.didOpenImages,
                               "gallery images picked should be processed after tapping open images button")
                 XCTAssertEqual(delegate.openedImageDocuments.count, 2,

--- a/GiniVision/Tests/HelpMenuViewControllerTests.swift
+++ b/GiniVision/Tests/HelpMenuViewControllerTests.swift
@@ -93,7 +93,8 @@ final class HelpMenuViewControllerTests: XCTestCase {
         
         XCTAssertEqual(itemText, cell.textLabel?.text,
                        "cell text in the first row should be the same as the first item text")
-        XCTAssertEqual(cellBackgroundColor, cell.backgroundColor, "cell background color should always be white")
+        // Compare cgColors because since iOS 13 cell.backgroundColor has the UIDynamicSystemColor type
+        XCTAssertEqual(cellBackgroundColor.cgColor, cell.backgroundColor!.cgColor, "cell background color should always be white")
         XCTAssertEqual(cellAccesoryType, cell.accessoryType, "cell accesory type should be and a disclosure indicator")
     }
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,17 +20,17 @@ pipeline {
     }
     stage('Build ObjC') {
       steps {
-        sh 'xcodebuild -workspace Example/GiniVision.xcworkspace -scheme "Example ObjC" -destination \'platform=iOS Simulator,name=iPhone 6\''
+        sh 'xcodebuild -workspace Example/GiniVision.xcworkspace -scheme "Example ObjC" -destination \'platform=iOS Simulator,name=iPhone 8\''
       }
     }
     stage('Build') {
       steps {
-        sh 'xcodebuild -workspace Example/GiniVision.xcworkspace -scheme "Example Swift" -destination \'platform=iOS Simulator,name=iPhone 6\''
+        sh 'xcodebuild -workspace Example/GiniVision.xcworkspace -scheme "Example Swift" -destination \'platform=iOS Simulator,name=iPhone 8\''
       }
     }
     stage('Unit tests') {
       steps {
-        sh 'xcodebuild test -workspace Example/GiniVision.xcworkspace -scheme "GiniVision-Unit-Tests" -destination \'platform=iOS Simulator,name=iPhone 6\''
+        sh 'xcodebuild test -workspace Example/GiniVision.xcworkspace -scheme "GiniVision-Unit-Tests" -destination \'platform=iOS Simulator,name=iPhone 8\''
       }
     }
     stage('Documentation') {


### PR DESCRIPTION
### Description
We opted to only allow light mode. Supporting dark mode entails a thorough redesign of all the screens. In the future we might add support for dark mode.

### How to test
Build with Xcode 11 and run on an iOS 13 device. Switch to dark mode. The example app should remain in light mode.

### Issues
PIA-302
