### PR TITLE
Fix qr code image in the popup

### DIFF
--- a/GiniVision/Classes/Core/Extensions/UIImage.swift
+++ b/GiniVision/Classes/Core/Extensions/UIImage.swift
@@ -15,7 +15,17 @@ extension UIImage {
         filter?.setValue("Q", forKey: "inputCorrectionLevel")
 
         if let outputImage = filter?.outputImage {
-            self.init(ciImage: outputImage.transformed(by: CGAffineTransform(scaleX: 2, y: 2)))
+            // Convert to CGImage because UIImage(ciImage:) was not working on the iOS 13.1 beta
+            let ciContext = CIContext(options: nil)
+            defer {
+                if #available(iOS 10.0, *) {
+                    ciContext.clearCaches()
+                }
+            }
+            guard let cgOutputImage = ciContext.createCGImage(outputImage, from: outputImage.extent) else {
+                return nil
+            }
+            self.init(cgImage: cgOutputImage)
         } else {
             return nil
         }


### PR DESCRIPTION
### Description
In iOS 13 the qr code image was not rendered. This fixes it by converting the CI image to a CG image before passing it to a UIImage to be rendered.

### How to test
Build with Xcode 11 and run on an iOS 13 device. Scan a BezahlCode and the qr code should be shown in the popup.

### Issues
PIA-347
