### PR TITLE
PIA-374: Excessive memory usage by the image gallery.

### DIFF
--- a/GiniVision/Classes/Core/Screens/Document picker/Gallery/GalleryManager.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/Gallery/GalleryManager.swift
@@ -64,14 +64,14 @@ final class GalleryManager: GalleryManagerProtocol {
     }
     
     func startCachingImages(for album: Album) {
-        self.cachingImageManager.startCachingImages(for: album.assets.map { $0.value },
+        self.cachingImageManager.startCachingImages(for: album.assets.suffix(5).map { $0.value },
                                                     targetSize: PHImageManagerMaximumSize,
                                                     contentMode: .default,
                                                     options: nil)
     }
     
     func stopCachingImages(for album: Album) {
-        self.cachingImageManager.stopCachingImages(for: album.assets.map { $0.value },
+        self.cachingImageManager.stopCachingImages(for: album.assets.suffix(5).map { $0.value },
                                                    targetSize: PHImageManagerMaximumSize,
                                                    contentMode: .default,
                                                    options: nil)


### PR DESCRIPTION
The image caching by `PHCachingImageManager` results in large memory use if the user has many pictures on their phone. 

This PR reduces the number of cached images to the 5 last ones. The performance doesn't seem affected for some of the earlier ones anyway.