### PR TITLE
PIA

### DIFF
--- a/GiniVision/Classes/Core/Screens/Camera/CameraButtonsViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraButtonsViewController.swift
@@ -166,7 +166,7 @@ final class CameraButtonsViewController: UIViewController {
             }
         }
         
-        flashToggleButtonContainerView.isHidden = true
+        flashToggleButtonContainerView.isHidden = !isFlashSupported
         
         addConstraints()
     }


### PR DESCRIPTION
Sometimes the camera is initialised before `loadView()` is called and then the default hiding of the toggle would override the true setting. 

The solution is to always consult `isFlashSupported` which is set to `false` by default and then reset to the correct value once the camera is set up.