### PR TITLE
Remove 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => 'YES'

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -31,7 +31,7 @@ SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Bolts
     - TrustKit
-  https://github.com/gini/gini-podspecs.git:
+  https://github.com/gini/gini-podspecs:
     - Gini
     - Gini-iOS-SDK
 
@@ -43,7 +43,7 @@ SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   Gini: 47615b7d05a0c4e836ab7b32c0260db106e89abe
   Gini-iOS-SDK: 270169987acb2ebd83d1e11d029daa81b6f89682
-  GiniVision: 1b39d405719eadc69eb5adf12f0d01092408659e
+  GiniVision: 7fbbf62fa760b01edf5948b852d0d149168522f5
   TrustKit: 073855e3adecd317417bda4ac9e9ac54a2e3b9f2
 
 PODFILE CHECKSUM: 4f5efaa1ca96405c622c9cf1566264685a082e61

--- a/GiniVision.podspec
+++ b/GiniVision.podspec
@@ -19,10 +19,6 @@ The Gini Vision Library for iOS provides functionality to capture documents with
   s.swift_version    = '5.0'
   s.ios.deployment_target = '10.0'
   
-  # workaround for https://github.com/CocoaPods/CocoaPods/issues/9521
-  # Remove after iOS 11 is dropped.
-  s.xcconfig = { 'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => 'YES' }
-  
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |core|


### PR DESCRIPTION
I've found a cheeky way to fix the lib lint which doesn't require the workaround that results in the library being much bigger. You simply need to remove the sim runtimes for iOS earlier than 12 from the build machine and the utility will be forced to use the runtime that doesn't have the bug that's causing the problems including AVFoundation in the test target.