### PR TITLE
PIA-687: iOS: Allow image asset customisation in Xamarin

### DIFF
--- a/GiniVision/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniVision/Classes/Core/Extensions/UIViewController.swift
@@ -17,11 +17,13 @@ extension UIViewController {
                              selector: Selector,
                              position: NavBarItemPosition,
                              target: AnyObject?) {
-        let buttonText = preferredResources.preferredText
-        if buttonText != nil && !buttonText!.isEmpty {
+        
+        let buttonText = preferredResources.preferredText ?? ""
+        
+        if !buttonText.isEmpty || preferredResources.preferredImage != nil {
             let navButton = GiniBarButtonItem(
                 image: preferredResources.preferredImage,
-                title: buttonText,
+                title: preferredResources.preferredText,
                 style: .plain,
                 target: target,
                 action: selector

--- a/GiniVision/Classes/Core/GiniConfiguration.swift
+++ b/GiniVision/Classes/Core/GiniConfiguration.swift
@@ -628,4 +628,12 @@ import UIKit
      Sets if the Drag&Drop step should be shown in the "Open with" tutorial
      */
     @objc public var shouldShowDragAndDropTutorial = true
+    
+    // Undocumented--Xamarin only
+    @objc public var closeButtonResource: PreferredButtonResource?
+    @objc public var helpButtonResource: PreferredButtonResource?
+    @objc public var backToCameraButtonResource: PreferredButtonResource?
+    @objc public var backToMenuButtonResource: PreferredButtonResource?
+    @objc public var nextButtonResource: PreferredButtonResource?
+    @objc public var cancelButtonResource: PreferredButtonResource?
 }

--- a/GiniVision/Classes/Core/Helpers/PreferredButtonResource.swift
+++ b/GiniVision/Classes/Core/Helpers/PreferredButtonResource.swift
@@ -8,6 +8,13 @@
 
 import UIKit
 
+@objc
+public protocol PreferredButtonResource {
+    
+    var preferredImage: UIImage? { get }
+    var preferredText: String? { get }
+}
+
 enum ResourceOrigin {
     case unknown
     case library
@@ -22,15 +29,15 @@ enum ResourceOrigin {
  * their catalog. In this case, the customized image will be used.
  */
 
-struct PreferredButtonResource {
+class GiniPreferredButtonResource: PreferredButtonResource {
     
-    let imageName: String?
-    let localizedTextKey: String?
-    let localizedTextComment: String?
-    let localizedConfigEntry: String?
-    let appBundle = Bundle.main
-    let libBundle = Bundle(for: GiniVision.self)
-    var imageSource: ResourceOrigin {
+    private let imageName: String?
+    private let localizedTextKey: String?
+    private let localizedTextComment: String?
+    private let localizedConfigEntry: String?
+    private let appBundle = Bundle.main
+    private let libBundle = Bundle(for: GiniVision.self)
+    private var imageSource: ResourceOrigin {
         if let name = imageName {
             if UIImage(named: name, in: appBundle, compatibleWith: nil) != nil {
                 return .custom
@@ -41,7 +48,7 @@ struct PreferredButtonResource {
         return.unknown
     }
     
-    var textSource: ResourceOrigin {
+    private var textSource: ResourceOrigin {
         if localizedConfigEntry != nil && !localizedConfigEntry!.isEmpty {
             return .custom
         }

--- a/GiniVision/Classes/Core/Screens/Help/HelpMenuViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Help/HelpMenuViewController.swift
@@ -83,17 +83,19 @@ final public class HelpMenuViewController: UITableViewController {
     
     // Button resources
     fileprivate lazy var backToCameraButtonResource =
-        PreferredButtonResource(image: "navigationReviewBack",
-                                title: "ginivision.navigationbar.review.back",
-                                comment: "Button title in the navigation bar for the " +
-                                         "back button on the help menu screen",
-                                configEntry: self.giniConfiguration.navigationBarHelpMenuTitleBackToCameraButton)
+        giniConfiguration.backToCameraButtonResource ??
+            GiniPreferredButtonResource(image: "navigationReviewBack",
+                                        title: "ginivision.navigationbar.review.back",
+                                        comment: "Button title in the navigation bar for the " +
+                "back button on the help menu screen",
+                                        configEntry: self.giniConfiguration.navigationBarHelpMenuTitleBackToCameraButton)
     
     fileprivate lazy var backToMenuButtonResource =
-        PreferredButtonResource(image: "arrowBack",
-                                title: "ginivision.navigationbar.review.back",
-                                comment: "Button title in the navigation bar for the back button on the help screen",
-                                configEntry: self.giniConfiguration.navigationBarHelpScreenTitleBackToMenuButton)
+        giniConfiguration.backToMenuButtonResource ??
+            GiniPreferredButtonResource(image: "arrowBack",
+                                        title: "ginivision.navigationbar.review.back",
+                                        comment: "Button title in the navigation bar for the back button on the help screen",
+                                        configEntry: self.giniConfiguration.navigationBarHelpScreenTitleBackToMenuButton)
     
     public init(giniConfiguration: GiniConfiguration) {
         self.giniConfiguration = giniConfiguration

--- a/GiniVision/Classes/Core/Screens/Onboarding/OnboardingContainerViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Onboarding/OnboardingContainerViewController.swift
@@ -58,11 +58,11 @@ final class OnboardingContainerViewController: UIViewController, ContainerViewCo
     
     fileprivate lazy var continueButton: UIBarButtonItem = {
         let continueButtonResources =
-            PreferredButtonResource(image: "navigationOnboardingContinue",
-                                    title: "ginivision.navigationbar.onboarding.continue",
-                                    comment: "Button title in the navigation bar for the " +
+            GiniPreferredButtonResource(image: "navigationOnboardingContinue",
+                                        title: "ginivision.navigationbar.onboarding.continue",
+                                        comment: "Button title in the navigation bar for the " +
                 "continue button on the onboarding screen",
-                                    configEntry: self.giniConfiguration.navigationBarOnboardingTitleContinueButton)
+                                        configEntry: self.giniConfiguration.navigationBarOnboardingTitleContinueButton)
         return GiniBarButtonItem(
             image: continueButtonResources.preferredImage,
             title: continueButtonResources.preferredText,

--- a/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator.swift
@@ -52,37 +52,41 @@ class GiniScreenAPICoordinator: NSObject, Coordinator {
     
     // Resources
     fileprivate(set) lazy var backButtonResource =
-        PreferredButtonResource(image: "navigationReviewBack",
-                                title: "ginivision.navigationbar.review.back",
-                                comment: "Button title in the navigation bar for the back button on the review screen",
-                                configEntry: self.giniConfiguration.navigationBarReviewTitleBackButton)
+        GiniPreferredButtonResource(image: "navigationReviewBack",
+                                    title: "ginivision.navigationbar.review.back",
+                                    comment: "Button title in the navigation bar for the back button on the review screen",
+                                    configEntry: self.giniConfiguration.navigationBarReviewTitleBackButton)
     fileprivate(set) lazy var cancelButtonResource =
-        PreferredButtonResource(image: "navigationAnalysisBack",
-                                title: "ginivision.navigationbar.analysis.back",
-                                comment: "Button title in the navigation bar for" +
-            "the back button on the analysis screen",
-                                configEntry: self.giniConfiguration.navigationBarAnalysisTitleBackButton)
+        giniConfiguration.cancelButtonResource ??
+            GiniPreferredButtonResource(image: "navigationAnalysisBack",
+                                        title: "ginivision.navigationbar.analysis.back",
+                                        comment: "Button title in the navigation bar for" +
+                "the back button on the analysis screen",
+                                        configEntry: self.giniConfiguration.navigationBarAnalysisTitleBackButton)
     fileprivate(set) lazy var closeButtonResource =
-        PreferredButtonResource(image: "navigationCameraClose",
-                                title: "ginivision.navigationbar.camera.close",
-                                comment: "Button title in the navigation bar for the close button on the camera screen",
-                                configEntry: self.giniConfiguration.navigationBarCameraTitleCloseButton)
+        giniConfiguration.closeButtonResource ??
+            GiniPreferredButtonResource(image: "navigationCameraClose",
+                                        title: "ginivision.navigationbar.camera.close",
+                                        comment: "Button title in the navigation bar for the close button on the camera screen",
+                                        configEntry: self.giniConfiguration.navigationBarCameraTitleCloseButton)
     fileprivate(set) lazy var helpButtonResource =
-        PreferredButtonResource(image: "navigationCameraHelp",
-                                title: "ginivision.navigationbar.camera.help",
-                                comment: "Button title in the navigation bar for the help button on the camera screen",
-                                configEntry: self.giniConfiguration.navigationBarCameraTitleHelpButton)
+        giniConfiguration.helpButtonResource ??
+            GiniPreferredButtonResource(image: "navigationCameraHelp",
+                                        title: "ginivision.navigationbar.camera.help",
+                                        comment: "Button title in the navigation bar for the help button on the camera screen",
+                                        configEntry: self.giniConfiguration.navigationBarCameraTitleHelpButton)
     fileprivate(set) lazy var nextButtonResource =
-        PreferredButtonResource(image: "navigationReviewContinue",
-                                title: "ginivision.navigationbar.review.continue",
-                                comment: "Button title in the navigation bar for " +
-            "the continue button on the review screen",
-                                configEntry: self.giniConfiguration.navigationBarReviewTitleContinueButton)
+        giniConfiguration.nextButtonResource ??
+            GiniPreferredButtonResource(image: "navigationReviewContinue",
+                                        title: "ginivision.navigationbar.review.continue",
+                                        comment: "Button title in the navigation bar for " +
+                "the continue button on the review screen",
+                                        configEntry: self.giniConfiguration.navigationBarReviewTitleContinueButton)
     fileprivate lazy var backToHelpMenuButtonResource =
-        PreferredButtonResource(image: "arrowBack",
-                                title: "ginivision.navigationbar.review.back",
-                                comment: "Button title in the navigation bar for the back button on the help screen",
-                                configEntry: self.giniConfiguration.navigationBarHelpScreenTitleBackToMenuButton)
+        GiniPreferredButtonResource(image: "arrowBack",
+                                    title: "ginivision.navigationbar.review.back",
+                                    comment: "Button title in the navigation bar for the back button on the help screen",
+                                    configEntry: self.giniConfiguration.navigationBarHelpScreenTitleBackToMenuButton)
     
     init(withDelegate delegate: GiniVisionDelegate?,
          giniConfiguration: GiniConfiguration) {


### PR DESCRIPTION
The asset catalogue in a Xamarin project doesn't seem to override the GVL asset catalogue, so I'm allowing to inject preferred resources through GiniConfiguration.