### PR TITLE
5.x: Fixes EPS QR Codes when using the default networking pod

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,13 +5,13 @@ PODS:
   - Gini-iOS-SDK/Core (1.4.0):
     - Bolts/Tasks (~> 1.9)
   - Gini/DocumentsAPI (0.5.2)
-  - GiniVision (5.3.7):
-    - GiniVision/Core (= 5.3.7)
-  - GiniVision/Core (5.3.7)
-  - GiniVision/Networking (5.3.7):
+  - GiniVision (5.5.0):
+    - GiniVision/Core (= 5.5.0)
+  - GiniVision/Core (5.5.0)
+  - GiniVision/Networking (5.5.0):
     - Gini/DocumentsAPI (~> 0.5.2)
     - GiniVision/Core
-  - GiniVision/Tests (5.3.7)
+  - GiniVision/Tests (5.5.0)
 
 DEPENDENCIES:
   - Gini-iOS-SDK (~> 1.4)
@@ -34,7 +34,7 @@ SPEC CHECKSUMS:
   Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
   Gini: 79e3ee06d18ecb8be27112563a84cecff4e73e0b
   Gini-iOS-SDK: 270169987acb2ebd83d1e11d029daa81b6f89682
-  GiniVision: 2ffc31e74ccae220fc6e97d1d57e0e16fc18b71b
+  GiniVision: d46169673c9ab6962ce5111a21f10fe0c28706b4
 
 PODFILE CHECKSUM: ad712b962d37e080a6b89d14b6c67309b4987f8b
 

--- a/GiniVision/Classes/Networking/GiniNetworkingScreenAPICoordinator.swift
+++ b/GiniVision/Classes/Networking/GiniNetworkingScreenAPICoordinator.swift
@@ -98,8 +98,7 @@ final class GiniNetworkingScreenAPICoordinator: GiniScreenAPICoordinator {
     }
     
     func deliver(result: ExtractionResult, analysisDelegate: AnalysisDelegate) {
-        let resultParameters = ["paymentRecipient", "iban", "bic", "paymentReference", "amountToPay"]
-        let hasExtactions = result.extractions.filter { resultParameters.contains($0.name ?? "no-name") }.count > 0
+        let hasExtactions = result.extractions.count > 0
         
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }


### PR DESCRIPTION
Simplifies condition to show no results screen: checks only that there is at least one extraction.

[PIA-897](https://ginis.atlassian.net/browse/PIA-897)