### PR TITLE
GiniVision: added condition giniConfiguration.qrCodeScanningEnabled f…

### DIFF
--- a/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -130,7 +130,13 @@ extension GiniScreenAPICoordinator: CameraViewControllerDelegate {
             
             cameraViewController.showCameraOverlay()
             cameraViewController.showCaptureButton()
-            cameraViewController.showFileImportTip()
+            if let config = self?.giniConfiguration {
+                if config.fileImportSupportedTypes != GiniConfiguration.GiniVisionImportFileTypes.none {
+                    cameraViewController.showFileImportTip()
+                } else if config.qrCodeScanningEnabled {
+                    cameraViewController.showQrCodeTip()
+                }
+            }
             
             completion()
         }


### PR DESCRIPTION
…or showing qrCodeToolTip

added check if fileImportToolTip is not presented, then toggle capture button after camera setup:
Example Swift: added showing tooltip depending on giniConfiguration settings: qrCodeScanningEnabled or fileImportSupportedTypes (PIA-711)

### Description


### How to test


### Merging
Automatic

### Issues

