### PR TITLE
Bugfix/pia 1477 improve file picker

### DIFF
--- a/Example/Example Swift/AppCoordinator.swift
+++ b/Example/Example Swift/AppCoordinator.swift
@@ -90,6 +90,8 @@ final class AppCoordinator: Coordinator {
                 } catch {
                     self.showExternalDocumentNotValidDialog()
                 }
+            } else {
+                self.showExternalDocumentNotValidDialog()
             }
         }
     }

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -533,7 +533,7 @@ extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
                             }
                         }
                         
-                    case .photoLibraryAccessDenied:
+                    case .photoLibraryAccessDenied, .failedToOpenDocument:
                         break
                     }
                 }

--- a/Example/Example Swift/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/ComponentAPICoordinator.swift
@@ -548,7 +548,18 @@ extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
             }
             
         }
-    }    
+    }
+    
+    func documentPicker(_ coordinator: DocumentPickerCoordinator, failedToPickDocumentsAt urls: [URL]) {
+        let error = FilePickerError.failedToOpenDocument
+        if coordinator.currentPickerDismissesAutomatically {
+            self.cameraScreen?.showErrorDialog(for: error,
+                                               positiveAction: nil)
+        } else {
+            coordinator.currentPickerViewController?.showErrorDialog(for: error,
+                                                                     positiveAction: nil)
+        }
+    }
 }
 
 // MARK: - ReviewViewControllerDelegate

--- a/Example/Example Swift/UIViewController.swift
+++ b/Example/Example Swift/UIViewController.swift
@@ -45,6 +45,8 @@ extension UIViewController {
                 confirmActionTitle = NSLocalizedString("ginivision.camera.mixedarrayspopup.usePhotos",
                                                        bundle: Bundle(for: GiniVision.self),
                                                        comment: "use photos button text in popup")
+            case .failedToOpenDocument:
+                break
             }
         case let visionError as CustomAnalysisError:
             message = visionError.message

--- a/GiniVision/Assets/de.lproj/Localizable.strings
+++ b/GiniVision/Assets/de.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "ginivision.camera.captureFailed" = "Bilderfassung fehlgeschlagen";
 "ginivision.camera.filepicker.photoLibraryAccessDenied" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Fotos benötigt.";
 "ginivision.camera.filepicker.mixedDocumentsUnsupported" = "Es ist nur möglich einen Dateityp gleichzeitig auszuwählen.";
-"ginivision.camera.filepicker.failedToOpenDocument" = "Die Datei konnte nicht geöffnet werden.";
+"ginivision.camera.filepicker.failedToOpenDocument" = "Die Datei konnte nicht geöffnet werden. Bitte verwenden Sie einen anderen Dateityp.";
 "ginivision.camera.filepicker.errorPopup.cancelButton" = "Abbrechen";
 "ginivision.camera.filepicker.errorPopup.confirmButton" = "OK";
 "ginivision.camera.filepicker.errorPopup.grantAccessButton" = "Zugriff erteilen";

--- a/GiniVision/Assets/de.lproj/Localizable.strings
+++ b/GiniVision/Assets/de.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "ginivision.camera.captureFailed" = "Bilderfassung fehlgeschlagen";
 "ginivision.camera.filepicker.photoLibraryAccessDenied" = "Um gespeicherte Bilder zu analysieren, wird Zugriff auf Ihre Fotos benötigt.";
 "ginivision.camera.filepicker.mixedDocumentsUnsupported" = "Es ist nur möglich einen Dateityp gleichzeitig auszuwählen.";
+"ginivision.camera.filepicker.failedToOpenDocument" = "Die Datei konnte nicht geöffnet werden.";
 "ginivision.camera.filepicker.errorPopup.cancelButton" = "Abbrechen";
 "ginivision.camera.filepicker.errorPopup.confirmButton" = "OK";
 "ginivision.camera.filepicker.errorPopup.grantAccessButton" = "Zugriff erteilen";

--- a/GiniVision/Assets/en.lproj/Localizable.strings
+++ b/GiniVision/Assets/en.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "ginivision.camera.captureFailed" = "Image capture failed";
 "ginivision.camera.filepicker.photoLibraryAccessDenied" = "Permission to access your photos gallery is required to analyse saved photos";
 "ginivision.camera.filepicker.mixedDocumentsUnsupported" = "It is only possible to select one file type at the same time.";
-"ginivision.camera.filepicker.failedToOpenDocument" = "The file could not be opened.";
+"ginivision.camera.filepicker.failedToOpenDocument" = "The file could not be opened. Please use a different file type.";
 "ginivision.camera.filepicker.errorPopup.cancelButton" = "Cancel";
 "ginivision.camera.filepicker.errorPopup.confirmButton" = "OK";
 "ginivision.camera.filepicker.errorPopup.grantAccessButton" = "Grant permission";

--- a/GiniVision/Assets/en.lproj/Localizable.strings
+++ b/GiniVision/Assets/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "ginivision.camera.captureFailed" = "Image capture failed";
 "ginivision.camera.filepicker.photoLibraryAccessDenied" = "Permission to access your photos gallery is required to analyse saved photos";
 "ginivision.camera.filepicker.mixedDocumentsUnsupported" = "It is only possible to select one file type at the same time.";
+"ginivision.camera.filepicker.failedToOpenDocument" = "The file could not be opened.";
 "ginivision.camera.filepicker.errorPopup.cancelButton" = "Cancel";
 "ginivision.camera.filepicker.errorPopup.confirmButton" = "OK";
 "ginivision.camera.filepicker.errorPopup.grantAccessButton" = "Grant permission";

--- a/GiniVision/Classes/Core/Extensions/UIViewController.swift
+++ b/GiniVision/Classes/Core/Extensions/UIViewController.swift
@@ -57,6 +57,8 @@ extension UIViewController {
             case .mixedDocumentsUnsupported:
                 cancelActionTitle = .localized(resource: CameraStrings.mixedArraysPopupCancelButton)
                 confirmActionTitle = .localized(resource: CameraStrings.mixedArraysPopupUsePhotosButton)
+            case .failedToOpenDocument:
+                break
             }
         default:
             message = DocumentValidationError.unknown.message

--- a/GiniVision/Classes/Core/Helpers/Localization/String Resources/CameraStrings.swift
+++ b/GiniVision/Classes/Core/Helpers/Localization/String Resources/CameraStrings.swift
@@ -15,7 +15,8 @@ enum CameraStrings: LocalizableStringResource {
     mixedArraysPopupCancelButton, mixedArraysPopupUsePhotosButton, mixedDocumentsErrorMessage, notAuthorizedButton,
     notAuthorizedMessage, photoLibraryAccessDeniedMessage, qrCodeDetectedPopupMessage, qrCodeDetectedPopupButton,
     tooManyPagesErrorMessage, unknownErrorMessage, wrongFormatErrorMessage, popupTitleImportPDF, popupOptionPhotos,
-    popupOptionFiles, popupTitleImportPDForPhotos, popupCancel, unsupportedQrCodeDetectedPopupMessage
+    popupOptionFiles, popupTitleImportPDForPhotos, popupCancel, unsupportedQrCodeDetectedPopupMessage,
+    failedToOpenDocumentErrorMessage
     
     var tableName: String {
         return "camera"
@@ -90,7 +91,9 @@ enum CameraStrings: LocalizableStringResource {
             return ("unsupportedQrCodeDetectedPopup.message", "Popup message")
         case .qrCodeTipLabel:
             return ("qrCodeTip", "tooltip text indicating new qr code feature")
-
+        case .failedToOpenDocumentErrorMessage:
+            return ("filepicker.failedToOpenDocument",
+                    "Error message when the the picked document couldn't be opened")
         }
     }
     
@@ -101,7 +104,7 @@ enum CameraStrings: LocalizableStringResource {
              .exceededFileSizeErrorMessage, .documentValidationGeneralErrorMessage,
              .mixedArraysPopupCancelButton, .mixedArraysPopupUsePhotosButton, .mixedDocumentsErrorMessage,
              .notAuthorizedButton, .notAuthorizedMessage, .photoLibraryAccessDeniedMessage, .qrCodeDetectedPopupMessage,
-             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage, .unsupportedQrCodeDetectedPopupMessage, .fileImportTipLabel, .qrCodeTipLabel, .importFileButtonLabel:
+             .qrCodeDetectedPopupButton, .tooManyPagesErrorMessage, .unknownErrorMessage, .wrongFormatErrorMessage, .unsupportedQrCodeDetectedPopupMessage, .fileImportTipLabel, .qrCodeTipLabel, .importFileButtonLabel, .failedToOpenDocumentErrorMessage:
             return true
         case .capturedImagesStackSubtitleLabel, .popupTitleImportPDF,
              .popupTitleImportPDForPhotos, .popupOptionPhotos, .popupOptionFiles, .popupCancel:

--- a/GiniVision/Classes/Core/Models/GiniError.swift
+++ b/GiniVision/Classes/Core/Models/GiniError.swift
@@ -73,6 +73,8 @@ public protocol GiniVisionError: Error {
     /// Mixed documents unsupported
     case mixedDocumentsUnsupported
     
+    case failedToOpenDocument
+    
     public var message: String {
         switch self {
         case .photoLibraryAccessDenied:
@@ -81,7 +83,8 @@ public protocol GiniVisionError: Error {
             return .localized(resource: CameraStrings.tooManyPagesErrorMessage)
         case .mixedDocumentsUnsupported:
             return .localized(resource: CameraStrings.mixedDocumentsErrorMessage)
-
+        case .failedToOpenDocument:
+            return .localized(resource: CameraStrings.failedToOpenDocumentErrorMessage)
         }
     }
 }

--- a/GiniVision/Classes/Core/Models/GiniError.swift
+++ b/GiniVision/Classes/Core/Models/GiniError.swift
@@ -73,6 +73,7 @@ public protocol GiniVisionError: Error {
     /// Mixed documents unsupported
     case mixedDocumentsUnsupported
     
+    /// Could not open the document (data could not be read or unsupported file type or some other issue)
     case failedToOpenDocument
     
     public var message: String {

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -32,6 +32,9 @@ public protocol DocumentPickerCoordinatorDelegate: AnyObject {
      */
     func documentPicker(_ coordinator: DocumentPickerCoordinator,
                         didPick documents: [GiniVisionDocument])
+    
+    func documentPicker(_ coordinator: DocumentPickerCoordinator,
+                        failedToPickDocumentsAt urls: [URL])
 }
 
 /**
@@ -326,6 +329,11 @@ extension DocumentPickerCoordinator: UIDocumentPickerDelegate {
         let documents: [GiniVisionDocument] = urls
             .compactMap(self.data)
             .compactMap(self.createDocument)
+        
+        guard documents.isNotEmpty else {
+            delegate?.documentPicker(self, failedToPickDocumentsAt: urls)
+            return
+        }
         
         if #available(iOS 11.0, *), giniConfiguration.documentPickerNavigationBarTintColor != nil {
             restoreSavedNavBarAppearance()

--- a/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
+++ b/GiniVision/Classes/Core/Screens/Document picker/DocumentPickerCoordinator.swift
@@ -18,21 +18,19 @@ import MobileCoreServices
 public protocol DocumentPickerCoordinatorDelegate: AnyObject {
     /**
      Called when a user picks one or several files from either the gallery or the files explorer.
-     The completion might provide errors that must be handled here before dismissing the
-     pickers. It only applies to the `GalleryCoordinator` since on one side it is not possible
-     to handle the dismissal of UIDocumentPickerViewController and on the other side
-     the Drag&Drop is not done in a separate view.
      
      - parameter coordinator: `DocumentPickerCoordinator` where the documents were imported.
      - parameter documents: One or several documents imported.
-     - parameter from: Picker used (either gallery, files explorer or drag&drop).
-     - parameter validationHandler: `DocumentValidationHandler` block used to check if there is an issue with
-     the captured documents. The handler has an inner completion block that is executed once the
-     picker has been dismissed when there are no errors.
      */
     func documentPicker(_ coordinator: DocumentPickerCoordinator,
                         didPick documents: [GiniVisionDocument])
     
+    /**
+     Called when the picked documents could not be opened.
+     
+     - parameter coordinator: `DocumentPickerCoordinator` where the documents were imported.
+     - parameter urls: URLs of the picked documents.
+     */
     func documentPicker(_ coordinator: DocumentPickerCoordinator,
                         failedToPickDocumentsAt urls: [URL])
 }

--- a/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -213,7 +213,7 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
                             }
                         }
                         
-                    case .photoLibraryAccessDenied:
+                    case .photoLibraryAccessDenied, .failedToOpenDocument:
                         break
                     }
                 }

--- a/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
+++ b/GiniVision/Classes/Core/Screens/Screen API Coordinator/GiniScreenAPICoordinator+Camera.swift
@@ -230,6 +230,17 @@ extension GiniScreenAPICoordinator: DocumentPickerCoordinatorDelegate {
         }
     }
     
+    func documentPicker(_ coordinator: DocumentPickerCoordinator, failedToPickDocumentsAt urls: [URL]) {
+        let error = FilePickerError.failedToOpenDocument
+        if coordinator.currentPickerDismissesAutomatically {
+            self.cameraViewController?.showErrorDialog(for: error,
+                                                       positiveAction: nil)
+        } else {
+            coordinator.currentPickerViewController?.showErrorDialog(for: error,
+                                                                     positiveAction: nil)
+        }
+    }
+    
     @available(iOS 11.0, *)
     fileprivate func addDropInteraction(forView view: UIView, with delegate: UIDropInteractionDelegate) {
         let dropInteraction = UIDropInteraction(delegate: delegate)


### PR DESCRIPTION
### Description
If none of the picked files can be converted to `GiniVisionDocuments` then a new `DocumentPickerCoordinatorDelegate` method is called. In this case an error dialog is shown with the new error `FilePickerError.failedToOpenDocument`.

### How to test
Import the pdfs from the ticket and verify that the `good-...pdf` works and the `bad-...pdf` results in an alert dialog saying that the document couldn't be opened.

### Merging
Automatic

### Issues
https://ginis.atlassian.net/browse/PIA-1477
