### PR TITLE
MultipageReviewViewController: Detected memory leak (PIA-1778)

### DIFF
--- a/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Multipage Review/MultipageReviewViewController.swift
@@ -328,8 +328,8 @@ extension MultipageReviewViewController {
             return
         }
         
-        collection.performBatchUpdates(animated: animated, updates: {
-            self.pages = pages
+        collection.performBatchUpdates(animated: animated, updates: {[weak self] in
+            self?.pages = pages
             collection.reloadItems(at: indexPaths.updated)
             collection.deleteItems(at: indexPaths.removed)
             collection.insertItems(at: indexPaths.inserted)


### PR DESCRIPTION
### Description
MultipageReviewViewController: Detected memory leak (PIA-1778)
during the collection view batch update.

### How to test
Run instruments -> leaks without and with those changes

### Merging
Automatic

### Issues
https://ginis.atlassian.net/browse/PIA-1778
