### PR TITLE
Release version 5.7.1

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,12 +4,12 @@ PODS:
     - Gini-iOS-SDK/Core (= 1.4.0)
   - Gini-iOS-SDK/Core (1.4.0):
     - Bolts/Tasks (~> 1.9)
-  - Gini/DocumentsAPI (1.0.0)
+  - Gini/DocumentsAPI (1.0.1)
   - GiniVision (5.7.0):
     - GiniVision/Core (= 5.7.0)
   - GiniVision/Core (5.7.0)
   - GiniVision/Networking (5.7.0):
-    - Gini/DocumentsAPI (~> 1.0.0)
+    - Gini/DocumentsAPI (~> 1.0.1)
     - GiniVision/Core
   - GiniVision/Tests (5.7.0)
 
@@ -22,7 +22,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Bolts
-  https://github.com/gini/gini-podspecs.git:
+  https://github.com/gini/gini-podspecs:
     - Gini
     - Gini-iOS-SDK
 
@@ -32,10 +32,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
-  Gini: 7cbfd500b84cf401d570e0fa66fca25c783b6bb3
+  Gini: 3c393e83afbacc0c211e4ec82233ad46ff8cf9e6
   Gini-iOS-SDK: 270169987acb2ebd83d1e11d029daa81b6f89682
-  GiniVision: 384659653d1e167c06ec0687181dec27190b0a34
+  GiniVision: a789858bb8dc744a1af14270c91fe60bd1e7e875
 
 PODFILE CHECKSUM: ad712b962d37e080a6b89d14b6c67309b4987f8b
 
-COCOAPODS: 1.11.0.beta.2
+COCOAPODS: 1.10.1

--- a/GiniVision.podspec
+++ b/GiniVision.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GiniVision'
-  s.version          = '5.7.0'
+  s.version          = '5.7.1'
   s.summary          = 'Computer Vision Library for scanning documents.'
 
   s.description      = <<-DESC

--- a/GiniVision.podspec
+++ b/GiniVision.podspec
@@ -29,13 +29,14 @@ The Gini Vision Library for iOS provides functionality to capture documents with
   s.subspec 'Networking' do |networking|
     networking.source_files = 'GiniVision/Classes/Networking/*.swift', 'GiniVision/Classes/Networking/Extensions/*.swift'
     networking.dependency "GiniVision/Core"
-    networking.dependency 'Gini/DocumentsAPI', '~> 1.0.0'
+    networking.dependency 'Gini/DocumentsAPI', '~> 1.0.1'
   end
 
   s.subspec 'Networking+Pinning' do |pinning|
+    pinning.ios.deployment_target = '12.0'
     pinning.source_files = 'GiniVision/Classes/Networking/Pinning/*'
     pinning.dependency "GiniVision/Networking"
-    pinning.dependency 'Gini/Pinning', '~> 1.0.0'
+    pinning.dependency 'Gini/Pinning', '~> 1.0.1'
   end
 
   s.test_spec 'Tests' do |test_spec|

--- a/GiniVision/Classes/Core/GiniVisionVersion.swift
+++ b/GiniVision/Classes/Core/GiniVisionVersion.swift
@@ -1,1 +1,1 @@
-let GiniVisionVersion = "5.7.0"
+let GiniVisionVersion = "5.7.1"


### PR DESCRIPTION
* Updates Gini API SDK to 1.0.1 and sets the minimum iOS version to 12 for the `GiniVision/Networking+Pinning` pod.