### PR TITLE
Fix import sheet

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,13 +5,13 @@ PODS:
   - Gini-iOS-SDK/Core (1.4.0):
     - Bolts/Tasks (~> 1.9)
   - Gini/DocumentsAPI (1.0.1)
-  - GiniVision (5.7.2):
-    - GiniVision/Core (= 5.7.2)
-  - GiniVision/Core (5.7.2)
-  - GiniVision/Networking (5.7.2):
+  - GiniVision (5.7.3):
+    - GiniVision/Core (= 5.7.3)
+  - GiniVision/Core (5.7.3)
+  - GiniVision/Networking (5.7.3):
     - Gini/DocumentsAPI (~> 1.0.1)
     - GiniVision/Core
-  - GiniVision/Tests (5.7.2)
+  - GiniVision/Tests (5.7.3)
 
 DEPENDENCIES:
   - Gini-iOS-SDK (~> 1.4)
@@ -34,8 +34,8 @@ SPEC CHECKSUMS:
   Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
   Gini: 3c393e83afbacc0c211e4ec82233ad46ff8cf9e6
   Gini-iOS-SDK: 270169987acb2ebd83d1e11d029daa81b6f89682
-  GiniVision: 7658e0ed0d1c29ade6843bdbe7abe2c46703c0c0
+  GiniVision: 25787152d84574e3fa628ed180144b2f89407cd7
 
 PODFILE CHECKSUM: ad712b962d37e080a6b89d14b6c67309b4987f8b
 
-COCOAPODS: 1.11.0.beta.2
+COCOAPODS: 1.11.2

--- a/GiniVision.podspec
+++ b/GiniVision.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GiniVision'
-  s.version          = '5.7.2'
+  s.version          = '5.7.3'
   s.summary          = 'Computer Vision Library for scanning documents.'
 
   s.description      = <<-DESC

--- a/GiniVision/Classes/Core/GiniVisionVersion.swift
+++ b/GiniVision/Classes/Core/GiniVisionVersion.swift
@@ -1,1 +1,1 @@
-let GiniVisionVersion = "5.7.2"
+let GiniVisionVersion = "5.7.3"

--- a/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
+++ b/GiniVision/Classes/Core/Screens/Camera/CameraViewController.swift
@@ -471,10 +471,10 @@ extension CameraViewController: CameraButtonsViewControllerDelegate {
             if let tooltip = fileImportToolTipView, tooltip.isHidden == false {
                 showImportFileSheet()
             } else {
-                if ToolTipView.shouldShowFileImportToolTip {
+                if let fileImportToolTipView = self.fileImportToolTipView, ToolTipView.shouldShowFileImportToolTip {
                     shouldShowQRCodeNext = true
-                    fileImportToolTipView?.dismiss(withCompletion: nil)
-                    fileImportToolTipView = nil
+                    fileImportToolTipView.dismiss(withCompletion: nil)
+                    self.fileImportToolTipView = nil
                 } else {
                     showImportFileSheet()
                 }


### PR DESCRIPTION
### Description
fix(GiniVisionLibrary): Fix condition for showing file import sheet and tooltip for Component API.

The problem exists because showing import is coupled with Screen API and we need to refactor it in future releases.

### How to test
Start Component API after a fresh install.
